### PR TITLE
test(e2e): drive ray apply end to end

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -8,6 +8,7 @@
 #   connect       2-peer `ray connect` direct test     (tests/e2e/connect)
 #   firewall      3-peer suggested-firewall + rule matrix (tests/e2e/firewall)
 #   closed-net    3-peer admission + lifecycle commands (tests/e2e/closed-net)
+#   apply         3-peer declarative `ray apply` deploy       (tests/e2e/apply)
 #   dns           2-peer Magic DNS resolution + resolv.conf takeover (tests/e2e/dns)
 #   bench         throughput / latency benchmark        (tests/bench)
 #
@@ -41,6 +42,9 @@ scenario_meta(){
                  LABELS=(srv-a srv-b srv-c) ;;
     closed-net)  DIR="$ROOT/tests/e2e/closed-net"
                  NAMES=(rayfish-closednet-a rayfish-closednet-b rayfish-closednet-c)
+                 LABELS=(srv-a srv-b srv-c) ;;
+    apply)       DIR="$ROOT/tests/e2e/apply"
+                 NAMES=(rayfish-apply-a rayfish-apply-b rayfish-apply-c)
                  LABELS=(srv-a srv-b srv-c) ;;
     dns)         DIR="$ROOT/tests/e2e/dns"
                  NAMES=(rayfish-dns-a rayfish-dns-b)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,6 +13,7 @@ failure). The shared SSH/deploy/reset/assert plumbing lives in
 | [`connect/`](connect) | 2 | The `ray connect` direct 2-peer friend-request flow over the public pkarr DHT — request, approve, `[direct]` network, ping + `ray send`, per-network firewall, offline negative case. |
 | [`firewall/`](firewall) | 3 | The coordinator suggested-firewall pipeline (`suggest` → `pending`/`accept`, `auto-accept`, additive whitelist vs blacklist) and the per-packet rule matrix (UDP, port ranges, same-selector replace, `--network` scoping) over a real TUN. |
 | [`closed-net/`](closed-net) | 3 | Closed-net admission + lifecycle commands: live approval (`requests`/`accept`/`deny`), co-coordinator (`admin add`) gatekeeper resilience with a reusable key, `ray hostname` + magic-DNS, `ray leave`/`nuke`, and a `ray apply` smoke. |
+| [`apply/`](apply) | 3 | Declarative `ray apply` deploy end to end: create-if-absent + membership-gap diff, `--invite-missing`, `ray identityof`, alias/group expansion (`--dry-run`), real suggestion publish + data-plane enforcement, and `--prune`. |
 
 Everything runs through one dispatcher, [`../e2e.sh`](../e2e.sh):
 
@@ -22,8 +23,8 @@ tests/e2e.sh <scenario> provision   # just spin up instances -> <dir>/.servers
 tests/e2e.sh <scenario> teardown    # destroy the instances (manual)
 ```
 
-where `<scenario>` is `device-cert`, `connect`, `firewall`, `closed-net`, or
-`bench` (run `tests/e2e.sh` with no scenario for usage). The per-scenario run steps live in `<dir>/run.sh`
+where `<scenario>` is `device-cert`, `connect`, `firewall`, `closed-net`,
+`apply`, `dns`, or `bench` (run `tests/e2e.sh` with no scenario for usage). The per-scenario run steps live in `<dir>/run.sh`
 (still runnable directly once `.servers` exists); the fleet definitions and the
 provision/teardown/assert bodies are shared in [`../lib/`](../lib).
 

--- a/tests/e2e/apply/README.md
+++ b/tests/e2e/apply/README.md
@@ -1,0 +1,29 @@
+# `apply` e2e scenario
+
+Three hosts driving `ray apply` end to end against a live daemon: coordinator +
+apply driver `srv-a`, members `srv-b` and `srv-c`, on a closed network `infra`.
+Where the `closed-net` scenario only smoke-tests `--example`/`--dry-run` (no
+mutation), this one reconciles real state: it creates the network, mints the
+gap's invites, and proves the alias/group expansion materializes into rules that
+gate real packets.
+
+## What it proves
+
+| Step | Coverage |
+|------|----------|
+| 1 | **Create + diff**: apply mints the missing closed `infra` (never joins) and reports the membership gap as `ray invite … --hostname srv-b/srv-c` lines. |
+| 2 | **`--invite-missing`**: those invites are minted; `srv-b`/`srv-c` join under their bound hostnames (`--auto-accept-firewall`). Re-apply reports the net already active. |
+| 3 | **`ray identityof`**: prints a joined host's identity (and `--json` `paired=false`); errors for a host that hasn't joined. |
+| 4 | **Aliases + groups (dry-run)**: a spec aliases `srv-b` as a user and groups it with the literal `srv-c`, referenced as a firewall peer; `--dry-run` shows the group resolving to `srv-b` + `srv-c`, with no `bob`/`team` sugar left behind. |
+| 5 | **Real apply publishes the expansion**: the coordinator materializes its own inbound `tcp:22` allow for each resolved team member. |
+| 6 | **Data plane**: the resolved allow opens `tcp:22` on `srv-a` for `srv-b` over the TUN, while an un-allowed port stays denied. |
+| 7 | **`--prune`**: an out-of-band suggestion (subject `srv-a`) is dropped because the spec doesn't name it, while the spec's own rules survive. |
+
+## Run
+
+```bash
+tests/e2e.sh apply            # provision (if needed) + deploy + drive + assert
+tests/e2e.sh apply teardown   # destroy the instances
+```
+
+See [`../README.md`](../README.md) for prerequisites and environment overrides.

--- a/tests/e2e/apply/run.sh
+++ b/tests/e2e/apply/run.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# `ray apply` declarative-deploy e2e test orchestrator.
+#
+# Topology:
+#   srv-a  coordinator + apply driver (closed network `infra`)
+#   srv-b  member (joined via an --invite-missing invite, auto-accepts firewall)
+#   srv-c  member (joined via an --invite-missing invite, auto-accepts firewall)
+#
+# Exercises the full `ray apply` surface the closed-net smoke only touches at the
+# --example/--dry-run level — here against a live daemon, end to end:
+#   - create-if-absent: apply mints a missing closed network, never joins
+#   - membership diff: the gap is reported as `ray invite … --hostname …` lines
+#   - --invite-missing: those invites are minted, and the named hosts join under
+#     their bound hostnames
+#   - `ray identityof`: prints a joined host's identity (+ negative for a stranger)
+#   - aliases/groups: a spec aliases a user and groups it with a literal hostname,
+#     then references the group as a firewall subject/peer; --dry-run shows the
+#     expansion resolving to concrete hostnames (sugar never survives)
+#   - real apply publishes the expanded suggestions, the coordinator materializes
+#     its own, and the resolved allow actually opens the port over the TUN
+#   - --prune drops an out-of-band suggestion the spec doesn't mention
+#
+# Reads tests/e2e/apply/.servers (written by provision). Does NOT modify infra.
+# Re-runnable (resets rayfish state each run unless KEEP_STATE=1).
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+SERVERS="$DIR/.servers"
+# shellcheck source=../../lib/common.sh
+source "$ROOT/tests/lib/common.sh"
+
+[[ -f "$SERVERS" ]] || { echo "No $SERVERS — run provision first"; exit 1; }
+
+A="$(server_ip "$SERVERS" srv-a || true)"
+B="$(server_ip "$SERVERS" srv-b || true)"
+C="$(server_ip "$SERVERS" srv-c || true)"
+[[ -n "$A" && -n "$B" && -n "$C" ]] || { echo "missing srv-a/b/c in $SERVERS"; exit 1; }
+
+NET=infra
+
+# sugg_tcp_allow <ip> <port> : count of installed *suggested-by-infra* inbound
+# tcp ALLOW rules for <port> on a node (from `ray firewall show --json`). Proves
+# an expanded suggestion materialized into a real rule.
+sugg_tcp_allow(){
+  on "$1" 'ray firewall show --json' 2>/dev/null | jq -r --arg p "$2" \
+    '[ .rules[]? | select((.suggested_by // "") == "infra" and .action == "allow"
+        and (.protocol | ascii_downcase) == "tcp" and .port == $p) ] | length'
+}
+
+# ---------------------------------------------------------------------------
+step "0. wait for SSH + deploy on all hosts"
+wait_all_ssh "$A" "$B" "$C"
+seed_known_hosts "$A" "$B" "$C"
+reset_state "$A" "$B" "$C"
+deploy_all "$ROOT" "$A" "$B" "$C"
+for h in "$A" "$B" "$C"; do on "$h" 'ray up' >/dev/null 2>&1 || true; done
+wait_daemons "$A" "$B" "$C"
+
+# ---------------------------------------------------------------------------
+step "1. apply creates the closed network + reports the membership gap"
+# A spec naming srv-a (subject) plus srv-b/srv-c (peers). expected hosts =
+# {srv-a, srv-b, srv-c}; only srv-a is joined, so the gap is srv-b + srv-c.
+on "$A" "printf 'networks:\n  $NET:\n    srv-a:\n      allows:\n        srv-b: \"tcp:22\"\n        srv-c: \"tcp:22\"\n' > /tmp/spec1.yaml"
+APPLY1="$(on "$A" "ray apply /tmp/spec1.yaml" 2>&1 | strip)"
+echo "$APPLY1" | sed 's/^/   a| /'
+echo "$APPLY1" | grep -qi 'creating closed network' \
+  && pass "apply created the closed network" || fail "apply did not create '$NET'"
+has_net "$A" "$NET" && pass "'$NET' now present on srv-a" || fail "'$NET' missing on srv-a after apply"
+echo "$APPLY1" | grep -qi 'Missing hosts' \
+  && pass "apply reported a membership gap" || fail "no membership gap reported"
+echo "$APPLY1" | grep -q "ray invite $NET --hostname srv-b" \
+  && pass "gap lists an invite command for srv-b" || fail "srv-b not in the gap"
+echo "$APPLY1" | grep -q "ray invite $NET --hostname srv-c" \
+  && pass "gap lists an invite command for srv-c" || fail "srv-c not in the gap"
+# apply never joins — the members must not have the network yet.
+! has_net "$B" "$NET" && ! has_net "$C" "$NET" \
+  && pass "apply did not auto-join the members" || fail "apply unexpectedly joined a member"
+
+# ---------------------------------------------------------------------------
+step "2. --invite-missing mints invites; the named hosts join"
+APPLY2="$(on "$A" "ray apply /tmp/spec1.yaml --invite-missing" 2>&1 | strip)"
+echo "$APPLY2" | sed 's/^/   a| /'
+echo "$APPLY2" | grep -qi 'already active' \
+  && pass "second apply saw the network already active" || fail "network not reported active on re-apply"
+# Each gap line ends in `→ <join-code>`; the code is a long bs58 token.
+CODE_B="$(echo "$APPLY2" | grep -- '--hostname srv-b' | grep -oE '[A-Za-z0-9]{40,}' | tail -1)"
+CODE_C="$(echo "$APPLY2" | grep -- '--hostname srv-c' | grep -oE '[A-Za-z0-9]{40,}' | tail -1)"
+[[ -n "$CODE_B" && -n "$CODE_C" ]] \
+  && pass "--invite-missing minted invites for srv-b + srv-c" \
+  || { fail "could not parse minted invite codes"; summary; }
+on "$B" "ray join $CODE_B --auto-accept-firewall" 2>&1 | strip | sed 's/^/   b| /'
+on "$C" "ray join $CODE_C --auto-accept-firewall" 2>&1 | strip | sed 's/^/   c| /'
+wait_roster "$A" srv-b srv-c
+
+# ---------------------------------------------------------------------------
+step "3. ray identityof prints a joined host's identity"
+B_IDENT="$(on "$A" "ray identityof $NET srv-b" | strip | tr -d '[:space:]')"
+[[ -n "$B_IDENT" ]] && pass "identityof srv-b printed an identity (${B_IDENT:0:16}…)" \
+  || { fail "identityof srv-b printed nothing"; summary; }
+# --json carries the same identity and paired=false (srv-b is unpaired).
+PAIRED="$(on "$A" "ray identityof $NET srv-b --json" 2>/dev/null | jq -r '.paired')"
+[[ "$PAIRED" == "false" ]] && pass "identityof --json reports paired=false" || fail "unexpected paired=$PAIRED"
+# A stranger hostname must error (an alias can only name a joined member).
+if on "$A" "ray identityof $NET ghost" >/dev/null 2>&1; then
+  fail "identityof for a non-joined host should have failed"
+else
+  pass "identityof errors for a host that has not joined"
+fi
+
+# ---------------------------------------------------------------------------
+step "4. aliases + groups expand to concrete hostnames (dry-run)"
+# bob = srv-b's user (by identity); team = bob + the literal hostname srv-c.
+# Reference `team` as a firewall peer; the expansion must resolve it to srv-b +
+# srv-c and leave no `bob`/`team` sugar behind.
+on "$A" "printf 'aliases:\n  bob: %s\ngroups:\n  team: [bob, srv-c]\nnetworks:\n  $NET:\n    \"*\":\n      allows:\n        team: \"tcp:22\"\n' '$B_IDENT' > /tmp/spec2.yaml"
+DRY="$(on "$A" "ray apply /tmp/spec2.yaml --dry-run" 2>&1 | strip)"
+echo "$DRY" | sed 's/^/   a| /'
+echo "$DRY" | grep -qi 'Spec (expanded)' \
+  && pass "dry-run echoed the expanded spec" || fail "dry-run did not expand the spec"
+echo "$DRY" | grep -q 'srv-b' && echo "$DRY" | grep -q 'srv-c' \
+  && pass "group resolved to srv-b + srv-c" || fail "group did not resolve to both hosts"
+! echo "$DRY" | grep -qiE '(^|[^a-z])(bob|team)([^a-z]|$)' \
+  && pass "no alias/group sugar survives expansion" || fail "alias/group name leaked into the expanded spec"
+
+# ---------------------------------------------------------------------------
+step "5. real apply publishes the expanded suggestions"
+APPLY5="$(on "$A" "ray apply /tmp/spec2.yaml" 2>&1 | strip)"
+echo "$APPLY5" | sed 's/^/   a| /'
+# srv-a is subject `*`, so it materializes its own inbound tcp:22 allow for each
+# resolved team member (srv-b + srv-c) — the coordinator installs its own.
+if retry_until 60 "[[ \"\$(sugg_tcp_allow '$A' 22)\" -ge 2 ]]"; then
+  pass "coordinator materialized 2 suggested tcp:22 allows (group expanded to 2 peers)"
+else
+  fail "expected ≥2 suggested tcp:22 allows on srv-a (got $(sugg_tcp_allow "$A" 22))"
+fi
+
+# ---------------------------------------------------------------------------
+step "6. the resolved allow actually opens the port over the TUN"
+A_VPN="$(peer_ip4 "$B" srv-a "$NET")"
+[[ -n "$A_VPN" ]] && pass "srv-b sees srv-a at $A_VPN" || { fail "srv-b cannot see srv-a's VPN ip"; summary; }
+start_tcp_listener "$A" 8080   # a port the spec does NOT allow (default-deny covers it)
+# tcp:22 is sshd (always listening) and is the allowed port; 8080 is denied.
+fw_allows "$B" "$A_VPN" 22 "team member reaches allowed tcp:22 on srv-a"
+fw_denies "$B" "$A_VPN" 8080 "team member blocked on un-allowed tcp:8080"
+stop_tcp_listener "$A" 8080
+
+# ---------------------------------------------------------------------------
+step "7. --prune drops an out-of-band suggestion"
+# Suggest a rule the spec doesn't mention (subject srv-a, tcp:8080).
+on "$A" "ray firewall suggest $NET --subject srv-a --allow tcp:8080" 2>&1 | strip | sed 's/^/   a| /'
+if retry_until 30 "[[ \"\$(sugg_tcp_allow '$A' 8080)\" -ge 1 ]]"; then
+  pass "out-of-band tcp:8080 suggestion installed on srv-a"
+else
+  fail "out-of-band suggestion never installed"
+fi
+# Apply spec2 (subject `*` only) with --prune: it publishes exactly the spec's
+# subjects, so the subject-srv-a 8080 suggestion is dropped, tcp:22 survives.
+on "$A" "ray apply /tmp/spec2.yaml --prune" 2>&1 | strip | sed 's/^/   a| /'
+if retry_until 60 "[[ \"\$(sugg_tcp_allow '$A' 8080)\" -eq 0 ]]"; then
+  pass "--prune dropped the out-of-band tcp:8080 suggestion"
+else
+  fail "--prune did not drop the out-of-band suggestion (got $(sugg_tcp_allow "$A" 8080))"
+fi
+[[ "$(sugg_tcp_allow "$A" 22)" -ge 2 ]] \
+  && pass "--prune kept the spec's tcp:22 suggestions" || fail "--prune wrongly dropped the spec's own rules"
+
+# ---------------------------------------------------------------------------
+summary

--- a/tests/e2e/apply/run.sh
+++ b/tests/e2e/apply/run.sh
@@ -54,7 +54,13 @@ wait_all_ssh "$A" "$B" "$C"
 seed_known_hosts "$A" "$B" "$C"
 reset_state "$A" "$B" "$C"
 deploy_all "$ROOT" "$A" "$B" "$C"
-for h in "$A" "$B" "$C"; do on "$h" 'ray up' >/dev/null 2>&1 || true; done
+# srv-a is the coordinator + apply driver and the spec names it `srv-a`. Pin its
+# default hostname so the network it *creates* (apply never joins) is owned under
+# `srv-a`, not a generated alias — otherwise srv-a is reported as a missing host
+# and peers can't resolve the `srv-a` subject. srv-b/srv-c get their names from
+# the invite binding (`--hostname srv-b|srv-c`), so only srv-a needs this.
+on "$A" 'ray up --hostname srv-a' >/dev/null 2>&1 || true
+for h in "$B" "$C"; do on "$h" 'ray up' >/dev/null 2>&1 || true; done
 wait_daemons "$A" "$B" "$C"
 
 # ---------------------------------------------------------------------------
@@ -76,6 +82,10 @@ echo "$APPLY1" | grep -q "ray invite $NET --hostname srv-c" \
 # apply never joins — the members must not have the network yet.
 ! has_net "$B" "$NET" && ! has_net "$C" "$NET" \
   && pass "apply did not auto-join the members" || fail "apply unexpectedly joined a member"
+# Consent is per-node: srv-b/srv-c auto-accept via their join flag, but srv-a (the
+# coordinator) must opt in to materialize its own suggested rules (step 5 asserts
+# the coordinator installs the rules it publishes for itself).
+on "$A" "ray firewall auto-accept $NET on" >/dev/null 2>&1 || true
 
 # ---------------------------------------------------------------------------
 step "2. --invite-missing mints invites; the named hosts join"


### PR DESCRIPTION
## What

Adds a dedicated `apply` end-to-end scenario (`tests/e2e/apply/`) that drives `ray apply` against a live 3-host daemon fleet. Today the only `apply` coverage is unit tests in `src/apply.rs` plus a `--example`/`--dry-run` smoke in the `closed-net` scenario; the alias/group expansion shipped in `d2ad28c` had no e2e coverage at all.

## Topology

- `srv-a` coordinator + apply driver (closed network `infra`)
- `srv-b` / `srv-c` members (joined via `--invite-missing` invites, auto-accept firewall)

## Steps proven

| Step | Coverage |
|------|----------|
| 1 | Create-if-absent + membership-gap diff (reports `ray invite … --hostname …` lines; never joins) |
| 2 | `--invite-missing` mints the gap's invites; the named hosts join under their bound hostnames; re-apply sees the net active |
| 3 | `ray identityof` prints a joined host's identity (+ `--json` `paired=false`); errors for a stranger |
| 4 | Aliases + groups expand to concrete hostnames on `--dry-run`, with no `bob`/`team` sugar surviving |
| 5 | A real apply publishes the expanded suggestions; the coordinator materializes its own |
| 6 | The resolved allow opens `tcp:22` on `srv-a` over the TUN while an un-allowed port stays denied |
| 7 | `--prune` drops an out-of-band suggestion the spec doesn't name, keeping the spec's own rules |

## Notes

- Wired into the dispatcher as `tests/e2e.sh apply` (`rayfish-apply-a/b/c`) and documented in the e2e READMEs.
- Test-only; no runtime change. Like the other scenarios it provisions real Scaleway instances, so it runs on demand, not in CI.