### PR TITLE
fix(join): keep member network alive when coordinator offline at restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Member network vanished when the coordinator was offline at startup**: a
+  member (non-coordinator) whose daemon restarted while its coordinator was
+  unreachable would silently drop the network from its running state. `ray
+  status` showed "no active networks" and the node rejected inbound mesh
+  connections, and it stayed that way until it happened to restart again while
+  the coordinator was online (its config was never lost). Restore now registers
+  the network immediately from the verified group blob it already holds, whether
+  or not the coordinator answers, and hands off to the reconnect loop to dial the
+  coordinator back with backoff. The network stays visible in `ray status`
+  (peers show offline) and reconnects on its own when the coordinator returns. As
+  a side effect, a network no longer takes ~30s to appear in `ray status` after a
+  member restart.
 - **Mesh SSH host-key mismatch**: enabling `ray firewall ssh on` no longer makes
   `ssh <host>.ray` fail with a "REMOTE HOST IDENTIFICATION HAS CHANGED" warning.
   The embedded SSH server now presents the machine's existing OpenSSH ed25519

--- a/src/daemon/handlers/create_join.rs
+++ b/src/daemon/handlers/create_join.rs
@@ -584,13 +584,14 @@ impl DaemonState {
                         .map(|m| m.identity)
                 })
                 .context("no coordinator found in network record")?;
-            tracing::info!(coordinator = %coordinator_id.fmt_short(), "connecting to coordinator");
-            let conn = transport::connect_to_peer_with_alpn(&self.endpoint, coordinator_id, &alpn)
-                .await
-                .map_err(|e| {
-                    anyhow::anyhow!("coordinator offline; cannot join this network right now: {e}")
-                })?;
 
+            // The reconnect loop is spawned unconditionally and up front. A
+            // member already holds the verified blob, so being *in* the network
+            // does not depend on the coordinator answering right now: if it is
+            // offline at restore we still register the network from the blob and
+            // let this loop dial it back when it returns. Without this a member
+            // that reboots while its coordinator is down silently drops the
+            // network from its running state until a lucky restart.
             let cancel = self.shutdown_token.child_token();
             let (disconnect_tx, disconnect_rx) = mpsc::channel::<forward::DisconnectEvent>(64);
             let tasks = vec![spawn_reconnect_loop(
@@ -606,39 +607,113 @@ impl DaemonState {
                 self.device_cert.clone(),
             )];
 
-            let state = match join_mesh_shared(
-                conn,
-                &self.endpoint,
-                display_name,
-                &alpn,
-                self.mesh_ctx(),
-                JoinParams {
-                    my_hostname: Some(my_hostname.clone()),
-                    net_pubkey,
-                    device_cert: self.device_cert.clone(),
-                    invite_secret: invite,
+            // Fallback state built straight from the verified blob so
+            // registration never blocks on (or dies with) the coordinator
+            // handshake.
+            let state_from_blob = || {
+                let mut ns = NetworkState {
+                    members: MemberList::from_members(data.members.clone()),
+                    approved: ApprovedList::from_entries(data.approved.clone()),
+                    snapshot: None,
+                    network_secret_key: None,
+                    network_public_key: net_pubkey,
+                    network_name: Some(display_name.to_string()),
+                    mode: GroupMode::Restricted,
                     suggested_firewall: data.suggested_firewall.clone(),
                     reusable_keys: data.reusable_keys.clone(),
-                    auto_accept_firewall,
-                    initial: false,
-                },
-                disconnect_tx.clone(),
-                cancel.clone(),
-                self.promote_tx.clone(),
-                invite_lock.clone(),
-                self.protocol_router.pending_pongs.clone(),
+                    pending_suggestions: Vec::new(),
+                    pending: HashMap::new(),
+                };
+                ns.refresh_snapshot();
+                Arc::new(std::sync::RwLock::new(ns))
+            };
+
+            tracing::info!(coordinator = %coordinator_id.fmt_short(), "connecting to coordinator");
+            let mut seed_from_blob = false;
+            let state = match transport::connect_to_peer_with_alpn(
+                &self.endpoint,
+                coordinator_id,
+                &alpn,
             )
-            .await?
+            .await
             {
-                JoinResult::Joined(state) => state,
-                JoinResult::Pending => {
-                    // Closed network: we've been queued for live approval. Stop the
-                    // just-spawned reconnect loop (nothing is connected yet) and let
-                    // the caller retry on a backoff until `ray accept` lets us in.
-                    cancel.cancel();
-                    return Ok(TryJoin::Pending);
+                Ok(conn) => match join_mesh_shared(
+                    conn,
+                    &self.endpoint,
+                    display_name,
+                    &alpn,
+                    self.mesh_ctx(),
+                    JoinParams {
+                        my_hostname: Some(my_hostname.clone()),
+                        net_pubkey,
+                        device_cert: self.device_cert.clone(),
+                        invite_secret: invite,
+                        suggested_firewall: data.suggested_firewall.clone(),
+                        reusable_keys: data.reusable_keys.clone(),
+                        auto_accept_firewall,
+                        initial: false,
+                    },
+                    disconnect_tx.clone(),
+                    cancel.clone(),
+                    self.promote_tx.clone(),
+                    invite_lock.clone(),
+                    self.protocol_router.pending_pongs.clone(),
+                )
+                .await
+                {
+                    Ok(JoinResult::Joined(state)) => state,
+                    Ok(JoinResult::Pending) => {
+                        // Closed network: we've been queued for live approval.
+                        // Stop the just-spawned reconnect loop (nothing is
+                        // connected yet) and let the caller retry on a backoff
+                        // until `ray accept` lets us in.
+                        cancel.cancel();
+                        for t in tasks {
+                            t.abort();
+                        }
+                        return Ok(TryJoin::Pending);
+                    }
+                    Err(e) => {
+                        // Dialed the coordinator but the handshake failed. We
+                        // still hold the verified blob, so register from it and
+                        // let the reconnect loop recover rather than dropping the
+                        // network entirely.
+                        tracing::warn!(coordinator = %coordinator_id.fmt_short(), error = %e, "coordinator handshake failed on restore; registering from blob, reconnect loop will retry");
+                        seed_from_blob = true;
+                        state_from_blob()
+                    }
+                },
+                Err(e) => {
+                    // Coordinator offline at restore: register from the blob so
+                    // the network stays live; the reconnect loop dials it back
+                    // once it returns.
+                    tracing::warn!(coordinator = %coordinator_id.fmt_short(), error = %e, "coordinator offline on restore; registering from blob, reconnect loop will retry");
+                    seed_from_blob = true;
+                    state_from_blob()
                 }
             };
+
+            // The reconnect loop is edge-triggered on disconnect events, so a
+            // cold registration (no live connection yet) needs a synthetic kick
+            // per member to start the backoff-retry dial. Only fires when we
+            // registered from the blob without a live handshake.
+            if seed_from_blob {
+                let me = self.identity.local_identity();
+                for m in &data.members {
+                    if m.identity == me {
+                        continue;
+                    }
+                    let _ = disconnect_tx
+                        .send(forward::DisconnectEvent {
+                            endpoint_id: m.identity,
+                            ip: m.ip,
+                            ipv6: derive_ipv6(&m.identity),
+                            network: display_name.to_string(),
+                            intentional: false,
+                        })
+                        .await;
+                }
+            }
             (state, cancel, disconnect_tx, tasks)
         };
         let state = state;

--- a/src/daemon/handlers/create_join.rs
+++ b/src/daemon/handlers/create_join.rs
@@ -2,6 +2,7 @@
 //! handshake (`join_network*`, dial/fetch/restore-roster helpers). Split out of `daemon/mod.rs`.
 
 use super::super::*;
+use std::sync::RwLock;
 
 impl DaemonState {
     /// Refresh the network's blob snapshot, store its bytes in the local blob
@@ -235,7 +236,7 @@ impl DaemonState {
         })?;
 
         let cancel = self.shutdown_token.child_token();
-        let state = Arc::new(std::sync::RwLock::new(net_state));
+        let state = Arc::new(RwLock::new(net_state));
         let invite_lock = Arc::new(tokio::sync::Mutex::new(()));
         let dht_notify = Arc::new(tokio::sync::Notify::new());
         let (tasks, disconnect_tx) =
@@ -625,7 +626,7 @@ impl DaemonState {
                     pending: HashMap::new(),
                 };
                 ns.refresh_snapshot();
-                Arc::new(std::sync::RwLock::new(ns))
+                Arc::new(RwLock::new(ns))
             };
 
             tracing::info!(coordinator = %coordinator_id.fmt_short(), "connecting to coordinator");
@@ -1021,7 +1022,7 @@ impl DaemonState {
                 pending: HashMap::new(),
             };
             ns.refresh_snapshot();
-            let live_state = Arc::new(std::sync::RwLock::new(ns));
+            let live_state = Arc::new(RwLock::new(ns));
 
             let handle = NetworkHandle {
                 name: network_name.to_string(),

--- a/src/daemon/handlers/runtime.rs
+++ b/src/daemon/handlers/runtime.rs
@@ -2,6 +2,7 @@
 //! connect-all, activate/deactivate (data plane), teardown, leave. Split out of `daemon/mod.rs`.
 
 use super::super::*;
+use std::sync::RwLock;
 
 /// The membership a coordinator restores at startup, sourced from the signed
 /// `GroupBlob` (authoritative) or the stale config roster as a fallback.
@@ -189,7 +190,7 @@ impl DaemonState {
         })?;
 
         let cancel = self.shutdown_token.child_token();
-        let state = Arc::new(std::sync::RwLock::new(net_state));
+        let state = Arc::new(RwLock::new(net_state));
         let invite_lock = Arc::new(tokio::sync::Mutex::new(()));
         let dht_notify = Arc::new(tokio::sync::Notify::new());
         let (tasks, disconnect_tx) =

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -40,6 +40,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
@@ -1150,7 +1151,7 @@ struct GroupSnapshot {
 
 /// A per-network state cell shared (read-mostly) across the accept handlers,
 /// publisher, poller, and cleanup tasks for that network.
-pub(crate) type SharedNetworkState = Arc<std::sync::RwLock<NetworkState>>;
+pub(crate) type SharedNetworkState = Arc<RwLock<NetworkState>>;
 
 pub(crate) struct NetworkState {
     members: MemberList,
@@ -2458,7 +2459,7 @@ fn apply_suggested_firewall(
     firewall: &SharedFirewall,
     my_identity: EndpointId,
     network_name: &str,
-    state: &std::sync::RwLock<NetworkState>,
+    state: &RwLock<NetworkState>,
 ) {
     let (suggestions, members): (SuggestedFirewall, Vec<Member>) = {
         let s = state.read().unwrap();
@@ -3775,7 +3776,7 @@ async fn join_mesh_shared(
         if let Some(snap) = &ns.snapshot {
             let _ = blob_store.blobs().add_slice(&snap.msgpack_bytes).await;
         }
-        Arc::new(std::sync::RwLock::new(ns))
+        Arc::new(RwLock::new(ns))
     };
 
     // Materialize this node's suggested rules from the blob we just joined with.
@@ -4248,7 +4249,7 @@ mod accept_handler_tests {
     fn make_network_state() -> SharedNetworkState {
         let net_secret = iroh::SecretKey::from_bytes(&[1u8; 32]);
         let net_pub = net_secret.public();
-        Arc::new(std::sync::RwLock::new(NetworkState {
+        Arc::new(RwLock::new(NetworkState {
             members: MemberList::new(),
             approved: ApprovedList::new(),
             snapshot: None,

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -12,7 +12,7 @@
 #   dns           2-peer Magic DNS resolution + resolv.conf takeover (tests/e2e/dns)
 #   ssh           2-peer mesh SSH (`ray firewall ssh`) allow/deny matrix (tests/e2e/ssh)
 #   reliability   4-peer full-mesh packet-loss test (ping + iperf3 UDP) (tests/e2e/reliability)
-#   restore-offline 2-peer member-restore-with-coordinator-offline test (tests/e2e/restore-offline)
+#   restore-offline 3-peer member-restore-with-coordinator-offline test (tests/e2e/restore-offline)
 #   bench         throughput / latency benchmark        (tests/bench)
 #
 # Actions:
@@ -59,8 +59,8 @@ scenario_meta(){
                  NAMES=(rayfish-reli-a rayfish-reli-b rayfish-reli-c rayfish-reli-d)
                  LABELS=(srv-a srv-b srv-c srv-d) ;;
     restore-offline) DIR="$ROOT/tests/e2e/restore-offline"
-                 NAMES=(rayfish-restore-a rayfish-restore-b)
-                 LABELS=(srv-a srv-b) ;;
+                 NAMES=(rayfish-restore-a rayfish-restore-b rayfish-restore-c)
+                 LABELS=(srv-a srv-b srv-c) ;;
     bench)       DIR="$ROOT/tests/bench"
                  NAMES=(rayfish-bench-a rayfish-bench-b)
                  LABELS=(srv-a srv-b) ;;

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -12,6 +12,7 @@
 #   dns           2-peer Magic DNS resolution + resolv.conf takeover (tests/e2e/dns)
 #   ssh           2-peer mesh SSH (`ray firewall ssh`) allow/deny matrix (tests/e2e/ssh)
 #   reliability   4-peer full-mesh packet-loss test (ping + iperf3 UDP) (tests/e2e/reliability)
+#   restore-offline 2-peer member-restore-with-coordinator-offline test (tests/e2e/restore-offline)
 #   bench         throughput / latency benchmark        (tests/bench)
 #
 # Actions:
@@ -57,6 +58,9 @@ scenario_meta(){
     reliability) DIR="$ROOT/tests/e2e/reliability"
                  NAMES=(rayfish-reli-a rayfish-reli-b rayfish-reli-c rayfish-reli-d)
                  LABELS=(srv-a srv-b srv-c srv-d) ;;
+    restore-offline) DIR="$ROOT/tests/e2e/restore-offline"
+                 NAMES=(rayfish-restore-a rayfish-restore-b)
+                 LABELS=(srv-a srv-b) ;;
     bench)       DIR="$ROOT/tests/bench"
                  NAMES=(rayfish-bench-a rayfish-bench-b)
                  LABELS=(srv-a srv-b) ;;

--- a/tests/e2e/restore-offline/README.md
+++ b/tests/e2e/restore-offline/README.md
@@ -1,0 +1,53 @@
+# member-restore-with-coordinator-offline e2e
+
+End-to-end regression test for the bug where a member whose daemon restarts while
+its coordinator is offline silently drops the network from its running state.
+Runs over two real Scaleway hosts; shared plumbing lives in `tests/lib/`.
+
+Background: PR #60 / issue #59.
+
+## Topology
+
+```
+srv-a  coordinator of a closed network `priv`
+srv-b  member (admitted with an invite)
+```
+
+## The bug this guards against
+
+A member (non-coordinator) already holds the verified group blob, so being *in* a
+network must not depend on the coordinator being reachable at restore time. Before
+the fix, member restore dialed the coordinator first and, on failure, aborted
+before registering the network: no ALPN handler, absent from `ray status`, inbound
+mesh connections rejected with `no handler for ALPN` then `closed by peer: 0`.
+Startup restore runs once with no retry, so the network stayed gone until the node
+happened to restart again while the coordinator was reachable (its config was
+never lost). One member was observed stuck for ~13 hours.
+
+## What it proves
+
+1. `srv-a` creates a closed network; `srv-b` joins with an invite and they mesh.
+2. `srv-a`'s daemon is stopped entirely (`systemctl stop`, not `ray down` standby),
+   so the coordinator endpoint is genuinely unreachable; `srv-b` sees it go offline.
+3. `srv-b`'s daemon is restarted while the coordinator is offline (the exact
+   failure path).
+4. **The fix:** `srv-b` still has `priv` after the restart and still lists the
+   coordinator as an (offline) peer. Pre-fix, this step fails with "no active
+   networks".
+5. **Recovery:** the coordinator is brought back and `srv-b` reconnects on its own
+   (the reconnect loop seeded at restore keeps dialing with backoff), with no
+   manual step on the member.
+
+Running this scenario against a pre-fix binary fails at step 4; against the fixed
+binary it passes end to end.
+
+## Usage
+
+```bash
+# Requires: scw (authenticated), jq, just, cross + docker, an SSH key.
+tests/e2e.sh restore-offline             # provision (if needed), cross-build, deploy, drive, assert
+tests/e2e.sh restore-offline provision   # create the two Scaleway instances only
+tests/e2e.sh restore-offline teardown    # destroy them
+```
+
+Re-runnable: each run resets rayfish state on both hosts unless `KEEP_STATE=1`.

--- a/tests/e2e/restore-offline/README.md
+++ b/tests/e2e/restore-offline/README.md
@@ -10,8 +10,13 @@ Background: PR #60 / issue #59.
 
 ```
 srv-a  coordinator of a closed network `priv`
-srv-b  member (admitted with an invite)
+srv-b  member (admitted with an invite)   <- restarted mid-test
+srv-c  member (admitted with an invite)   <- stays up, the peer srv-b must find
 ```
+
+The third host is what makes the core claim testable: with the coordinator
+stopped, the restarted member has to re-mesh with the *other* member on its own,
+proving the fix connects to any available peer rather than just the coordinator.
 
 ## The bug this guards against
 
@@ -26,17 +31,20 @@ never lost). One member was observed stuck for ~13 hours.
 
 ## What it proves
 
-1. `srv-a` creates a closed network; `srv-b` joins with an invite and they mesh.
+1. `srv-a` creates a closed network; `srv-b` and `srv-c` join with invites and
+   the three full-mesh.
 2. `srv-a`'s daemon is stopped entirely (`systemctl stop`, not `ray down` standby),
-   so the coordinator endpoint is genuinely unreachable; `srv-b` sees it go offline.
+   so the coordinator endpoint is genuinely unreachable; `srv-b` and `srv-c` see it
+   go offline but stay linked to each other.
 3. `srv-b`'s daemon is restarted while the coordinator is offline (the exact
    failure path).
-4. **The fix:** `srv-b` still has `priv` after the restart and still lists the
-   coordinator as an (offline) peer. Pre-fix, this step fails with "no active
-   networks".
-5. **Recovery:** the coordinator is brought back and `srv-b` reconnects on its own
-   (the reconnect loop seeded at restore keeps dialing with backoff), with no
-   manual step on the member.
+4. **The fix:** `srv-b` still has `priv` after the restart, **reconnects to
+   `srv-c` while the coordinator is still down** (connect to any available peer,
+   not just the coordinator), and lists the coordinator as an offline peer.
+   Pre-fix, this step fails with "no active networks".
+5. **Recovery:** the coordinator is brought back and the full mesh reconverges on
+   its own (the reconnect loop seeded at restore keeps dialing with backoff), with
+   no manual step on the members.
 
 Running this scenario against a pre-fix binary fails at step 4; against the fixed
 binary it passes end to end.

--- a/tests/e2e/restore-offline/run.sh
+++ b/tests/e2e/restore-offline/run.sh
@@ -3,7 +3,8 @@
 #
 # Topology:
 #   srv-a  coordinator of a closed network `priv`
-#   srv-b  member (admitted with an invite)
+#   srv-b  member (admitted with an invite)  <- restarted mid-test
+#   srv-c  member (admitted with an invite)  <- stays up, the peer srv-b must find
 #
 # Regression guard for the bug where a member whose daemon restarts while its
 # coordinator is offline silently drops the network from its running state
@@ -12,14 +13,19 @@
 # coordinator is reachable again. See PR #60 / issue #59.
 #
 # The member already holds the verified group blob, so being in the network must
-# not depend on the coordinator answering at restore time. This test:
-#   1. brings up a-coordinator + b-member and confirms they mesh,
-#   2. stops the coordinator daemon entirely (not `ray down` standby — the
-#      coordinator's endpoint must be genuinely unreachable),
-#   3. restarts the member daemon (the restore-with-coordinator-offline path),
-#   4. asserts the member STILL has the network + still lists the coordinator as
-#      a (now offline) peer  <- this is the whole fix; pre-fix it fails here,
-#   5. brings the coordinator back and asserts the member reconnects on its own.
+# not depend on the coordinator answering at restore time, and the member must
+# connect to *any* available peer, not just the coordinator. The third host is
+# what makes that second claim testable: with the coordinator stopped, the
+# restarted member has to re-mesh with the other member on its own.
+#
+# Flow:
+#   1. a-coordinator + b-member + c-member come up and full-mesh,
+#   2. the coordinator daemon is stopped entirely (not `ray down` standby, so its
+#      endpoint is genuinely unreachable); b and c stay linked to each other,
+#   3. srv-b's daemon is restarted (the restore-with-coordinator-offline path),
+#   4. asserts srv-b still has the network AND reconnects to srv-c while the
+#      coordinator is still down  <- the whole fix; pre-fix it fails here,
+#   5. brings the coordinator back and asserts the full mesh reconverges.
 #
 # Reads tests/e2e/restore-offline/.servers (written by provision). Does NOT
 # modify infra. Re-runnable (resets rayfish state each run unless KEEP_STATE=1).
@@ -35,43 +41,53 @@ source "$ROOT/tests/lib/common.sh"
 
 A="$(server_ip "$SERVERS" srv-a || true)"
 B="$(server_ip "$SERVERS" srv-b || true)"
-[[ -n "$A" && -n "$B" ]] || { echo "missing srv-a/srv-b in $SERVERS"; exit 1; }
+C="$(server_ip "$SERVERS" srv-c || true)"
+[[ -n "$A" && -n "$B" && -n "$C" ]] || { echo "missing srv-a/srv-b/srv-c in $SERVERS"; exit 1; }
 
 NET=priv
 
 # ---------------------------------------------------------------------------
-step "0. wait for SSH + deploy on both hosts"
-wait_all_ssh "$A" "$B"
-seed_known_hosts "$A" "$B"
-reset_state "$A" "$B"
-deploy_all "$ROOT" "$A" "$B"
-for h in "$A" "$B"; do on "$h" 'ray up' >/dev/null 2>&1 || true; done
-wait_daemons "$A" "$B"
+step "0. wait for SSH + deploy on all hosts"
+wait_all_ssh "$A" "$B" "$C"
+seed_known_hosts "$A" "$B" "$C"
+reset_state "$A" "$B" "$C"
+deploy_all "$ROOT" "$A" "$B" "$C"
+for h in "$A" "$B" "$C"; do on "$h" 'ray up' >/dev/null 2>&1 || true; done
+wait_daemons "$A" "$B" "$C"
 
 # ---------------------------------------------------------------------------
-step "1. srv-a creates a closed network and srv-b joins with an invite"
+step "1. srv-a creates a closed network; srv-b and srv-c join with invites"
 CREATE="$(on "$A" "ray create --name $NET --hostname srv-a" | strip)"
 echo "$CREATE" | sed 's/^/   a| /'
 has_net "$A" "$NET" && pass "network '$NET' created on srv-a" || { fail "create failed"; summary; }
 
-INVITE="$(mint_invite "$A" "$NET" srv-b)"
-[[ -n "$INVITE" ]] && pass "srv-a minted an invite (${INVITE:0:12}…)" || { fail "invite mint failed"; summary; }
+INV_B="$(mint_invite "$A" "$NET" srv-b)"
+INV_C="$(mint_invite "$A" "$NET" srv-c)"
+[[ -n "$INV_B" && -n "$INV_C" ]] && pass "srv-a minted invites for srv-b and srv-c" \
+  || { fail "invite mint failed"; summary; }
 
-on "$B" "ray join $INVITE --hostname srv-b" 2>&1 | strip | sed 's/^/   b| /'
-wait_roster "$A" srv-b        # coordinator sees the member online
-wait_roster "$B" srv-a        # member sees the coordinator online
-has_net "$B" "$NET" && pass "srv-b joined '$NET'" || { fail "srv-b did not join"; summary; }
+on "$B" "ray join $INV_B --hostname srv-b" 2>&1 | strip | sed 's/^/   b| /'
+on "$C" "ray join $INV_C --hostname srv-c" 2>&1 | strip | sed 's/^/   c| /'
+
+# Full mesh: every node sees the other two online.
+wait_roster "$A" srv-b srv-c
+wait_roster "$B" srv-a srv-c
+wait_roster "$C" srv-a srv-b
 
 # ---------------------------------------------------------------------------
 step "2. take the coordinator fully offline (systemctl stop, not 'ray down')"
 # `ray down` is standby: the daemon stays connected to peers, so it would still
 # answer the member's restore dial. We need the endpoint genuinely gone.
 on "$A" 'systemctl stop rayfish' >/dev/null 2>&1 || true
-if retry_until 45 "[[ \"\$(peer_online '$B' srv-a '$NET')\" == 0 ]]"; then
-  pass "srv-b sees the coordinator go offline"
+if retry_until 45 "[[ \"\$(peer_online '$B' srv-a '$NET')\" == 0 && \"\$(peer_online '$C' srv-a '$NET')\" == 0 ]]"; then
+  pass "srv-b and srv-c both see the coordinator go offline"
 else
-  fail "coordinator still shows online to srv-b after stop"
+  fail "coordinator still shows online after stop"
 fi
+# The two members keep their direct link to each other with the coordinator gone.
+[[ "$(peer_online "$B" srv-c "$NET")" == 1 ]] \
+  && pass "srv-b <-> srv-c stay linked without the coordinator" \
+  || fail "srv-b lost its link to srv-c when the coordinator went down"
 
 # ---------------------------------------------------------------------------
 step "3. restart the member daemon while the coordinator is offline"
@@ -87,35 +103,45 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-step "4. THE FIX: the network survives a restart with the coordinator offline"
-# Give restore a moment; the network should register from the cached blob
-# without the coordinator. Pre-fix this stays "no active networks" forever.
+step "4. THE FIX: network survives + member re-meshes with the OTHER member"
+# 4a. The network registers from the cached blob without the coordinator.
+#     Pre-fix this stays "no active networks" forever.
 if retry_until 60 "has_net '$B' '$NET'"; then
   pass "srv-b still has network '$NET' after restarting with coordinator offline"
 else
-  fail "REGRESSION: srv-b dropped '$NET' (no active networks) — restore gated on coordinator"
+  fail "REGRESSION: srv-b dropped '$NET' (no active networks) — restore gated on coordinator"; summary
 fi
-# The coordinator must still appear in the member's roster (offline is fine): the
-# network was registered from the blob, which lists it.
-if retry_until 30 "[[ -n \"\$(peer_ip4 '$B' srv-a '$NET')\" ]]"; then
-  pass "srv-b's roster still lists the coordinator (offline peer)"
+# 4b. The heart of the fix: connect to any available peer, not just the
+#     coordinator. srv-b must reconnect to srv-c while srv-a is still down.
+if retry_until 90 "[[ \"\$(peer_online '$B' srv-c '$NET')\" == 1 ]]"; then
+  pass "srv-b reconnected to srv-c with the coordinator still offline"
 else
-  fail "srv-b's roster is missing the coordinator after blob restore"
+  fail "srv-b did not re-mesh with srv-c — restore did not connect to available peers"
 fi
-# And it must genuinely be offline right now (no live link to a stopped node).
+# 4c. srv-c sees srv-b back too (the link is bidirectional and real).
+if retry_until 60 "[[ \"\$(peer_online '$C' srv-b '$NET')\" == 1 ]]"; then
+  pass "srv-c sees srv-b reconnected"
+else
+  fail "srv-c does not see srv-b after its restart"
+fi
+# 4d. The coordinator is still listed as a peer, and correctly offline.
+[[ -n "$(peer_ip4 "$B" srv-a "$NET")" ]] \
+  && pass "srv-b's roster still lists the coordinator (offline peer)" \
+  || fail "srv-b's roster is missing the coordinator after blob restore"
 [[ "$(peer_online "$B" srv-a "$NET")" == 0 ]] \
   && pass "coordinator correctly shows offline (no phantom connection)" \
   || fail "coordinator shows online while its daemon is stopped"
 
 # ---------------------------------------------------------------------------
-step "5. RECOVERY: bring the coordinator back, member reconnects on its own"
+step "5. RECOVERY: bring the coordinator back, full mesh reconverges"
 on "$A" 'systemctl start rayfish' >/dev/null 2>&1 || true
 sleep 5
 on "$A" 'ray up' >/dev/null 2>&1 || true
 wait_daemons "$A"
-# The reconnect loop (seeded at restore) keeps dialing with backoff, so the link
-# forms without any manual step on the member.
-wait_roster "$B" srv-a        # member reconnects to the coordinator
-wait_roster "$A" srv-b        # coordinator sees the member again
+# The reconnect loop (seeded at restore) keeps dialing with backoff, so links
+# form without any manual step on the members.
+wait_roster "$B" srv-a srv-c
+wait_roster "$C" srv-a srv-b
+wait_roster "$A" srv-b srv-c
 
 summary

--- a/tests/e2e/restore-offline/run.sh
+++ b/tests/e2e/restore-offline/run.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Member-restore-with-coordinator-offline e2e test orchestrator.
+#
+# Topology:
+#   srv-a  coordinator of a closed network `priv`
+#   srv-b  member (admitted with an invite)
+#
+# Regression guard for the bug where a member whose daemon restarts while its
+# coordinator is offline silently drops the network from its running state
+# (`ray status` -> "no active networks", inbound mesh rejected with "no handler
+# for ALPN"), and stays that way until it happens to restart while the
+# coordinator is reachable again. See PR #60 / issue #59.
+#
+# The member already holds the verified group blob, so being in the network must
+# not depend on the coordinator answering at restore time. This test:
+#   1. brings up a-coordinator + b-member and confirms they mesh,
+#   2. stops the coordinator daemon entirely (not `ray down` standby — the
+#      coordinator's endpoint must be genuinely unreachable),
+#   3. restarts the member daemon (the restore-with-coordinator-offline path),
+#   4. asserts the member STILL has the network + still lists the coordinator as
+#      a (now offline) peer  <- this is the whole fix; pre-fix it fails here,
+#   5. brings the coordinator back and asserts the member reconnects on its own.
+#
+# Reads tests/e2e/restore-offline/.servers (written by provision). Does NOT
+# modify infra. Re-runnable (resets rayfish state each run unless KEEP_STATE=1).
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+SERVERS="$DIR/.servers"
+# shellcheck source=../../lib/common.sh
+source "$ROOT/tests/lib/common.sh"
+
+[[ -f "$SERVERS" ]] || { echo "No $SERVERS — run '$ROOT/tests/e2e.sh restore-offline provision' first"; exit 1; }
+
+A="$(server_ip "$SERVERS" srv-a || true)"
+B="$(server_ip "$SERVERS" srv-b || true)"
+[[ -n "$A" && -n "$B" ]] || { echo "missing srv-a/srv-b in $SERVERS"; exit 1; }
+
+NET=priv
+
+# ---------------------------------------------------------------------------
+step "0. wait for SSH + deploy on both hosts"
+wait_all_ssh "$A" "$B"
+seed_known_hosts "$A" "$B"
+reset_state "$A" "$B"
+deploy_all "$ROOT" "$A" "$B"
+for h in "$A" "$B"; do on "$h" 'ray up' >/dev/null 2>&1 || true; done
+wait_daemons "$A" "$B"
+
+# ---------------------------------------------------------------------------
+step "1. srv-a creates a closed network and srv-b joins with an invite"
+CREATE="$(on "$A" "ray create --name $NET --hostname srv-a" | strip)"
+echo "$CREATE" | sed 's/^/   a| /'
+has_net "$A" "$NET" && pass "network '$NET' created on srv-a" || { fail "create failed"; summary; }
+
+INVITE="$(mint_invite "$A" "$NET" srv-b)"
+[[ -n "$INVITE" ]] && pass "srv-a minted an invite (${INVITE:0:12}…)" || { fail "invite mint failed"; summary; }
+
+on "$B" "ray join $INVITE --hostname srv-b" 2>&1 | strip | sed 's/^/   b| /'
+wait_roster "$A" srv-b        # coordinator sees the member online
+wait_roster "$B" srv-a        # member sees the coordinator online
+has_net "$B" "$NET" && pass "srv-b joined '$NET'" || { fail "srv-b did not join"; summary; }
+
+# ---------------------------------------------------------------------------
+step "2. take the coordinator fully offline (systemctl stop, not 'ray down')"
+# `ray down` is standby: the daemon stays connected to peers, so it would still
+# answer the member's restore dial. We need the endpoint genuinely gone.
+on "$A" 'systemctl stop rayfish' >/dev/null 2>&1 || true
+if retry_until 45 "[[ \"\$(peer_online '$B' srv-a '$NET')\" == 0 ]]"; then
+  pass "srv-b sees the coordinator go offline"
+else
+  fail "coordinator still shows online to srv-b after stop"
+fi
+
+# ---------------------------------------------------------------------------
+step "3. restart the member daemon while the coordinator is offline"
+# This is the exact failure path: startup restore dials the coordinator, which
+# is unreachable. Pre-fix, restore aborted and the network was never registered.
+on "$B" 'systemctl restart rayfish' >/dev/null 2>&1 || true
+sleep 5
+on "$B" 'ray up' >/dev/null 2>&1 || true
+if retry_until 30 "on '$B' 'ray status' >/dev/null 2>&1"; then
+  pass "srv-b daemon responds after restart"
+else
+  fail "srv-b daemon not responding after restart"; summary
+fi
+
+# ---------------------------------------------------------------------------
+step "4. THE FIX: the network survives a restart with the coordinator offline"
+# Give restore a moment; the network should register from the cached blob
+# without the coordinator. Pre-fix this stays "no active networks" forever.
+if retry_until 60 "has_net '$B' '$NET'"; then
+  pass "srv-b still has network '$NET' after restarting with coordinator offline"
+else
+  fail "REGRESSION: srv-b dropped '$NET' (no active networks) — restore gated on coordinator"
+fi
+# The coordinator must still appear in the member's roster (offline is fine): the
+# network was registered from the blob, which lists it.
+if retry_until 30 "[[ -n \"\$(peer_ip4 '$B' srv-a '$NET')\" ]]"; then
+  pass "srv-b's roster still lists the coordinator (offline peer)"
+else
+  fail "srv-b's roster is missing the coordinator after blob restore"
+fi
+# And it must genuinely be offline right now (no live link to a stopped node).
+[[ "$(peer_online "$B" srv-a "$NET")" == 0 ]] \
+  && pass "coordinator correctly shows offline (no phantom connection)" \
+  || fail "coordinator shows online while its daemon is stopped"
+
+# ---------------------------------------------------------------------------
+step "5. RECOVERY: bring the coordinator back, member reconnects on its own"
+on "$A" 'systemctl start rayfish' >/dev/null 2>&1 || true
+sleep 5
+on "$A" 'ray up' >/dev/null 2>&1 || true
+wait_daemons "$A"
+# The reconnect loop (seeded at restore) keeps dialing with backoff, so the link
+# forms without any manual step on the member.
+wait_roster "$B" srv-a        # member reconnects to the coordinator
+wait_roster "$A" srv-b        # coordinator sees the member again
+
+summary


### PR DESCRIPTION
## Problem

A member (non-coordinator) whose daemon restarts while its coordinator is offline permanently drops the network from its running state. On startup, member restore tries to connect to the coordinator, times out after ~30s, and returns an error before the network is registered: no ALPN handler, absent from `ray status`, inbound mesh connections rejected with `no handler for ALPN` then `closed by peer: 0`. Startup restore runs once with no retry, so the network stays gone until the node happens to restart again while the coordinator is online. A member was observed stuck like this for ~13 hours (its config was never lost).

## Fix

The member already holds the verified group blob (roster, keys, firewall), which is enough to be in the network. The restore path (`join_network_inner`, member/reconnect branch) no longer treats the coordinator connection as a hard prerequisite:

- Happy path (coordinator reachable): unchanged, full `join_mesh_shared` handshake.
- Failed dial or handshake: build the network state from the verified blob and register it, then seed the reconnect loop with every roster member so the node connects to any available peer (not just the coordinator) and links the coordinator back when it returns.

The reconnect loop is edge-triggered on disconnect events, so a cold registration is kicked with one synthetic disconnect per member to start the backoff-retry dial.

Side effect: a network no longer takes ~30s to appear in `ray status` after a member restart against a reachable coordinator.

## Scope

This is the targeted fix for the outage. The broader design (make restore fully coordinator-agnostic: coordinator needed only to join, then connect to any cached roster member or pkarr seed peer, and lift the live-sync control listener out of `join_mesh_shared` so it survives reconnects) is tracked in #59.

## Test plan

- `cargo check`, `cargo clippy` clean.
- `cargo test`: 301 tests pass.
- Not yet verified end to end on hardware (reboot a member with the coordinator down, confirm the network still registers and auto-reconnects when the coordinator returns).

Refs #59