### PR TITLE
feat(mobile): diagnostics, consistent device name, app exclusions + mesh IPv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the connection changes between wifi and cellular. A new "Send diagnostics" button
   in the You screen attaches the full recent log to a report so connection problems
   can be diagnosed. All of this respects the existing crash-reporting toggle; the
-  toggle now reads "diagnostics".
+  toggle now reads "diagnostics". Diagnostic data (the log lines and recent errors)
+  can include network addresses such as relay hosts and your device's public IP, so
+  it is only sent while crash reporting is on.
 - **Device ownership in `ray status`**: peer rows that are your own paired
   devices are now tagged `(your device)`, and a paired device belonging to
   another user is labelled `(user <id>)` (or shows that user's alias when you

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Android diagnostics**: the app now captures the mesh core's recent logs and
+  reports lightweight health (networks, peers online, transport, and a WARN/ERROR
+  count) to crash reporting automatically when the tunnel goes up or down and when
+  the connection changes between wifi and cellular. A new "Send diagnostics" button
+  in the You screen attaches the full recent log to a report so connection problems
+  can be diagnosed. All of this respects the existing crash-reporting toggle; the
+  toggle now reads "diagnostics".
 - **Device ownership in `ray status`**: peer rows that are your own paired
   devices are now tagged `(your device)`, and a paired device belonging to
   another user is labelled `(user <id>)` (or shows that user's alias when you

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Consistent Android device name**: the phone now uses one device name across
+  every network instead of a different random name per network. It is seeded from
+  your device model on first run and can be changed in the You screen (the change
+  applies to all your networks and to any you join later).
+- **Android app exclusions and mesh IPv6 on the phone**: apps that break behind a
+  VPN (Android Auto, Chromecast/Google Home, RCS messaging, GoPro, Sonos) now
+  bypass the tunnel, so wireless Android Auto keeps working with Rayfish on. The
+  Android tunnel also routes mesh IPv6 (the `200::/7` range), which previously did
+  not work on mobile.
 - **Android diagnostics**: the app now captures the mesh core's recent logs and
   reports lightweight health (networks, peers online, transport, and a WARN/ERROR
   count) to crash reporting automatically when the tunnel goes up or down and when

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,6 +4737,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "uniffi",
 ]
 

--- a/android/app/src/main/java/uniffi/ray_mobile/ray_mobile.kt
+++ b/android/app/src/main/java/uniffi/ray_mobile/ray_mobile.kt
@@ -778,6 +778,10 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 
 
 
+
+
+
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -800,6 +804,8 @@ fun uniffi_ray_mobile_checksum_method_node_accept_join_request(
 fun uniffi_ray_mobile_checksum_method_node_approve_connect_request(
 ): Short
 fun uniffi_ray_mobile_checksum_method_node_create(
+): Short
+fun uniffi_ray_mobile_checksum_method_node_default_hostname(
 ): Short
 fun uniffi_ray_mobile_checksum_method_node_deny_join_request(
 ): Short
@@ -838,6 +844,8 @@ fun uniffi_ray_mobile_checksum_method_node_pair(
 fun uniffi_ray_mobile_checksum_method_node_reject_connect_request(
 ): Short
 fun uniffi_ray_mobile_checksum_method_node_reject_file_offer(
+): Short
+fun uniffi_ray_mobile_checksum_method_node_set_default_hostname(
 ): Short
 fun uniffi_ray_mobile_checksum_method_node_set_dns_upstreams(
 ): Short
@@ -920,6 +928,8 @@ fun uniffi_ray_mobile_fn_method_node_approve_connect_request(`ptr`: Pointer,`sho
 ): Unit
 fun uniffi_ray_mobile_fn_method_node_create(`ptr`: Pointer,`name`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
+fun uniffi_ray_mobile_fn_method_node_default_hostname(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_ray_mobile_fn_method_node_deny_join_request(`ptr`: Pointer,`network`: RustBuffer.ByValue,`shortId`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
 fun uniffi_ray_mobile_fn_method_node_down(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
@@ -957,6 +967,8 @@ fun uniffi_ray_mobile_fn_method_node_pair(`ptr`: Pointer,`ticket`: RustBuffer.By
 fun uniffi_ray_mobile_fn_method_node_reject_connect_request(`ptr`: Pointer,`shortId`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
 fun uniffi_ray_mobile_fn_method_node_reject_file_offer(`ptr`: Pointer,`id`: Long,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
+fun uniffi_ray_mobile_fn_method_node_set_default_hostname(`ptr`: Pointer,`name`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
 fun uniffi_ray_mobile_fn_method_node_set_dns_upstreams(`ptr`: Pointer,`servers`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
@@ -1112,6 +1124,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_ray_mobile_checksum_method_node_create() != 50208.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_ray_mobile_checksum_method_node_default_hostname() != 59357.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_ray_mobile_checksum_method_node_deny_join_request() != 27631.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1167,6 +1182,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ray_mobile_checksum_method_node_reject_file_offer() != 10539.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_ray_mobile_checksum_method_node_set_default_hostname() != 40200.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ray_mobile_checksum_method_node_set_dns_upstreams() != 50178.toShort()) {
@@ -1615,6 +1633,12 @@ public interface NodeInterface {
     fun `create`(`name`: kotlin.String?): NetworkInfo
     
     /**
+     * The device's default hostname (seeds every join, incl. pairing
+     * auto-joins). Empty when unset. Config-only; safe before `start`.
+     */
+    fun `defaultHostname`(): kotlin.String
+    
+    /**
      * Deny a pending join request on a network we coordinate.
      */
     fun `denyJoinRequest`(`network`: kotlin.String, `shortId`: kotlin.String)
@@ -1718,6 +1742,13 @@ public interface NodeInterface {
      * Decline a file offer without downloading it.
      */
     fun `rejectFileOffer`(`id`: kotlin.ULong)
+    
+    /**
+     * Set the device's default hostname. Validated with the core's hostname
+     * rules; rejected names leave the stored value untouched. Config-only;
+     * safe before `start`.
+     */
+    fun `setDefaultHostname`(`name`: kotlin.String)
     
     /**
      * Point the Magic DNS resolver at the phone's real DNS servers so
@@ -1940,6 +1971,22 @@ open class Node: Disposable, AutoCloseable, NodeInterface
     uniffiRustCallWithError(RayException) { _status ->
     UniffiLib.INSTANCE.uniffi_ray_mobile_fn_method_node_create(
         it, FfiConverterOptionalString.lower(`name`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * The device's default hostname (seeds every join, incl. pairing
+     * auto-joins). Empty when unset. Config-only; safe before `start`.
+     */override fun `defaultHostname`(): kotlin.String {
+            return FfiConverterString.lift(
+    callWithPointer {
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_ray_mobile_fn_method_node_default_hostname(
+        it, _status)
 }
     }
     )
@@ -2243,6 +2290,23 @@ open class Node: Disposable, AutoCloseable, NodeInterface
     uniffiRustCallWithError(RayException) { _status ->
     UniffiLib.INSTANCE.uniffi_ray_mobile_fn_method_node_reject_file_offer(
         it, FfiConverterULong.lower(`id`),_status)
+}
+    }
+    
+    
+
+    
+    /**
+     * Set the device's default hostname. Validated with the core's hostname
+     * rules; rejected names leave the stored value untouched. Config-only;
+     * safe before `start`.
+     */
+    @Throws(RayException::class)override fun `setDefaultHostname`(`name`: kotlin.String)
+        = 
+    callWithPointer {
+    uniffiRustCallWithError(RayException) { _status ->
+    UniffiLib.INSTANCE.uniffi_ray_mobile_fn_method_node_set_default_hostname(
+        it, FfiConverterString.lower(`name`),_status)
 }
     }
     

--- a/android/app/src/main/java/uniffi/ray_mobile/ray_mobile.kt
+++ b/android/app/src/main/java/uniffi/ray_mobile/ray_mobile.kt
@@ -774,6 +774,10 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 
 
 
+
+
+
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -811,6 +815,8 @@ fun uniffi_ray_mobile_checksum_method_node_firewall_show(
 ): Short
 fun uniffi_ray_mobile_checksum_method_node_handle_link(
 ): Short
+fun uniffi_ray_mobile_checksum_method_node_health_snapshot(
+): Short
 fun uniffi_ray_mobile_checksum_method_node_invite(
 ): Short
 fun uniffi_ray_mobile_checksum_method_node_is_paired(
@@ -824,6 +830,8 @@ fun uniffi_ray_mobile_checksum_method_node_list_connect_requests(
 fun uniffi_ray_mobile_checksum_method_node_list_file_offers(
 ): Short
 fun uniffi_ray_mobile_checksum_method_node_list_join_requests(
+): Short
+fun uniffi_ray_mobile_checksum_method_node_log_snapshot(
 ): Short
 fun uniffi_ray_mobile_checksum_method_node_pair(
 ): Short
@@ -926,6 +934,8 @@ fun uniffi_ray_mobile_fn_method_node_firewall_show(`ptr`: Pointer,uniffi_out_err
 ): RustBuffer.ByValue
 fun uniffi_ray_mobile_fn_method_node_handle_link(`ptr`: Pointer,`uri`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
+fun uniffi_ray_mobile_fn_method_node_health_snapshot(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_ray_mobile_fn_method_node_invite(`ptr`: Pointer,`network`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_ray_mobile_fn_method_node_is_paired(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
@@ -939,6 +949,8 @@ fun uniffi_ray_mobile_fn_method_node_list_connect_requests(`ptr`: Pointer,uniffi
 fun uniffi_ray_mobile_fn_method_node_list_file_offers(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_ray_mobile_fn_method_node_list_join_requests(`ptr`: Pointer,`network`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_ray_mobile_fn_method_node_log_snapshot(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_ray_mobile_fn_method_node_pair(`ptr`: Pointer,`ticket`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
@@ -1121,6 +1133,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_ray_mobile_checksum_method_node_handle_link() != 17267.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_ray_mobile_checksum_method_node_health_snapshot() != 25816.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_ray_mobile_checksum_method_node_invite() != 59156.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1140,6 +1155,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ray_mobile_checksum_method_node_list_join_requests() != 56409.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_ray_mobile_checksum_method_node_log_snapshot() != 20955.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ray_mobile_checksum_method_node_pair() != 22172.toShort()) {
@@ -1635,6 +1653,13 @@ public interface NodeInterface {
     fun `handleLink`(`uri`: kotlin.String): LinkAction
     
     /**
+     * Lightweight health vitals for auto-telemetry. Reuses `status()` for mesh
+     * state and reads the diagnostics counters. Cumulative WARN/ERROR counts
+     * (since process start); reading does not reset them.
+     */
+    fun `healthSnapshot`(): HealthSnapshot
+    
+    /**
      * Mint a single-use invite code for `network` (default 7d TTL), to share.
      */
     fun `invite`(`network`: kotlin.String): kotlin.String
@@ -1672,6 +1697,11 @@ public interface NodeInterface {
      * Join requests awaiting approval on a network we coordinate.
      */
     fun `listJoinRequests`(`network`: kotlin.String): List<PendingRequest>
+    
+    /**
+     * The full buffered core log, for the "Send diagnostics" button.
+     */
+    fun `logSnapshot`(): kotlin.String
     
     /**
      * Pair this device with a primary device using a scanned/pasted pairing
@@ -2028,6 +2058,23 @@ open class Node: Disposable, AutoCloseable, NodeInterface
 
     
     /**
+     * Lightweight health vitals for auto-telemetry. Reuses `status()` for mesh
+     * state and reads the diagnostics counters. Cumulative WARN/ERROR counts
+     * (since process start); reading does not reset them.
+     */override fun `healthSnapshot`(): HealthSnapshot {
+            return FfiConverterTypeHealthSnapshot.lift(
+    callWithPointer {
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_ray_mobile_fn_method_node_health_snapshot(
+        it, _status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
      * Mint a single-use invite code for `network` (default 7d TTL), to share.
      */
     @Throws(RayException::class)override fun `invite`(`network`: kotlin.String): kotlin.String {
@@ -2134,6 +2181,21 @@ open class Node: Disposable, AutoCloseable, NodeInterface
     uniffiRustCallWithError(RayException) { _status ->
     UniffiLib.INSTANCE.uniffi_ray_mobile_fn_method_node_list_join_requests(
         it, FfiConverterString.lower(`network`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * The full buffered core log, for the "Send diagnostics" button.
+     */override fun `logSnapshot`(): kotlin.String {
+            return FfiConverterString.lift(
+    callWithPointer {
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_ray_mobile_fn_method_node_log_snapshot(
+        it, _status)
 }
     }
     )
@@ -2511,6 +2573,74 @@ public object FfiConverterTypeFirewallStateInfo: FfiConverterRustBuffer<Firewall
 
 
 /**
+ * Lightweight health vitals for auto-telemetry. Cheap to build (reads a status
+ * snapshot + the diagnostics counters); safe to call before `start`.
+ */
+data class HealthSnapshot (
+    var `running`: kotlin.Boolean, 
+    var `networkCount`: kotlin.UInt, 
+    var `peersOnline`: kotlin.UInt, 
+    var `networks`: List<NetworkHealth>, 
+    var `meshUp`: kotlin.Boolean, 
+    var `nodeId`: kotlin.String, 
+    var `meshIpv4`: kotlin.String, 
+    var `warnCount`: kotlin.ULong, 
+    var `errorCount`: kotlin.ULong, 
+    var `recentErrors`: List<kotlin.String>
+) {
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeHealthSnapshot: FfiConverterRustBuffer<HealthSnapshot> {
+    override fun read(buf: ByteBuffer): HealthSnapshot {
+        return HealthSnapshot(
+            FfiConverterBoolean.read(buf),
+            FfiConverterUInt.read(buf),
+            FfiConverterUInt.read(buf),
+            FfiConverterSequenceTypeNetworkHealth.read(buf),
+            FfiConverterBoolean.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterULong.read(buf),
+            FfiConverterULong.read(buf),
+            FfiConverterSequenceString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: HealthSnapshot) = (
+            FfiConverterBoolean.allocationSize(value.`running`) +
+            FfiConverterUInt.allocationSize(value.`networkCount`) +
+            FfiConverterUInt.allocationSize(value.`peersOnline`) +
+            FfiConverterSequenceTypeNetworkHealth.allocationSize(value.`networks`) +
+            FfiConverterBoolean.allocationSize(value.`meshUp`) +
+            FfiConverterString.allocationSize(value.`nodeId`) +
+            FfiConverterString.allocationSize(value.`meshIpv4`) +
+            FfiConverterULong.allocationSize(value.`warnCount`) +
+            FfiConverterULong.allocationSize(value.`errorCount`) +
+            FfiConverterSequenceString.allocationSize(value.`recentErrors`)
+    )
+
+    override fun write(value: HealthSnapshot, buf: ByteBuffer) {
+            FfiConverterBoolean.write(value.`running`, buf)
+            FfiConverterUInt.write(value.`networkCount`, buf)
+            FfiConverterUInt.write(value.`peersOnline`, buf)
+            FfiConverterSequenceTypeNetworkHealth.write(value.`networks`, buf)
+            FfiConverterBoolean.write(value.`meshUp`, buf)
+            FfiConverterString.write(value.`nodeId`, buf)
+            FfiConverterString.write(value.`meshIpv4`, buf)
+            FfiConverterULong.write(value.`warnCount`, buf)
+            FfiConverterULong.write(value.`errorCount`, buf)
+            FfiConverterSequenceString.write(value.`recentErrors`, buf)
+    }
+}
+
+
+
+/**
  * One network this node belongs to, with its peers.
  */
 data class NetworkDetail (
@@ -2556,6 +2686,41 @@ public object FfiConverterTypeNetworkDetail: FfiConverterRustBuffer<NetworkDetai
             FfiConverterString.write(value.`hostname`, buf)
             FfiConverterBoolean.write(value.`isCoordinator`, buf)
             FfiConverterSequenceTypePeerInfo.write(value.`peers`, buf)
+    }
+}
+
+
+
+/**
+ * One network's liveness, for the health snapshot.
+ */
+data class NetworkHealth (
+    var `name`: kotlin.String, 
+    var `connected`: kotlin.Boolean
+) {
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeNetworkHealth: FfiConverterRustBuffer<NetworkHealth> {
+    override fun read(buf: ByteBuffer): NetworkHealth {
+        return NetworkHealth(
+            FfiConverterString.read(buf),
+            FfiConverterBoolean.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: NetworkHealth) = (
+            FfiConverterString.allocationSize(value.`name`) +
+            FfiConverterBoolean.allocationSize(value.`connected`)
+    )
+
+    override fun write(value: NetworkHealth, buf: ByteBuffer) {
+            FfiConverterString.write(value.`name`, buf)
+            FfiConverterBoolean.write(value.`connected`, buf)
     }
 }
 
@@ -3110,6 +3275,34 @@ public object FfiConverterSequenceTypeNetworkDetail: FfiConverterRustBuffer<List
         buf.putInt(value.size)
         value.iterator().forEach {
             FfiConverterTypeNetworkDetail.write(it, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterSequenceTypeNetworkHealth: FfiConverterRustBuffer<List<NetworkHealth>> {
+    override fun read(buf: ByteBuffer): List<NetworkHealth> {
+        val len = buf.getInt()
+        return List<NetworkHealth>(len) {
+            FfiConverterTypeNetworkHealth.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<NetworkHealth>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterTypeNetworkHealth.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<NetworkHealth>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterTypeNetworkHealth.write(it, buf)
         }
     }
 }

--- a/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
@@ -41,6 +41,7 @@ object NodeHolder {
     // Crash reporting is opt-out: on unless the user turns it off in You. See
     // [xyz.rayfish.android.Telemetry], which reads this to gate Sentry init.
     private const val KEY_CRASH_REPORTING = "crash_reporting"
+    private const val KEY_INSTALL_ID = "install_id"
 
     fun isEnabled(context: Context): Boolean =
         context.applicationContext
@@ -62,6 +63,17 @@ object NodeHolder {
         context.applicationContext
             .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .edit().putBoolean(KEY_CRASH_REPORTING, value).apply()
+    }
+
+    /** Stable random id for this install, minted once and persisted. Tags every
+     * diagnostics event so a device's events group together in Sentry. */
+    fun installId(context: Context): String {
+        val prefs = context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.getString(KEY_INSTALL_ID, null)?.let { return it }
+        val id = java.util.UUID.randomUUID().toString()
+        prefs.edit().putString(KEY_INSTALL_ID, id).apply()
+        return id
     }
 
     /**

--- a/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
@@ -76,6 +76,28 @@ object NodeHolder {
         return id
     }
 
+    /** Seed the device's default hostname from the Android model on first run,
+     * so pairing auto-joins all use one consistent name. Idempotent: no-op once
+     * a name is set. Runs on the caller's (IO) context; touches config only. */
+    fun seedDeviceName(context: Context) {
+        val node = get(context)
+        val current = runCatching { node.defaultHostname() }.getOrDefault("")
+        if (current.isNotBlank()) return
+        val seed = sanitizeHostname(android.os.Build.MODEL ?: "")
+        runCatching { node.setDefaultHostname(seed) }
+    }
+
+    /** Lowercase, keep [a-z0-9-], collapse/trim hyphens, cap 63, fall back to
+     * "phone". Matches the core's is_valid_hostname rules. */
+    private fun sanitizeHostname(raw: String): String {
+        var s = raw.lowercase()
+            .replace(Regex("[^a-z0-9-]"), "-")
+            .replace(Regex("-+"), "-")
+            .trim('-')
+        if (s.length > 63) s = s.substring(0, 63).trim('-')
+        return s.ifEmpty { "phone" }
+    }
+
     /**
      * Starts the node exactly once for the process, however many callers race to
      * invoke this concurrently (e.g. the initial UI launch and a cold-start deep
@@ -90,6 +112,7 @@ object NodeHolder {
                 // iroh endpoint sets up TLS, which fails without it.
                 RustlsInit.ensureInitialized(context)
                 get(context).start()
+                seedDeviceName(context)
             }
             started = true
         }

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -58,24 +58,19 @@ class RayfishVpnService : VpnService() {
 
         // Bring the control plane up before building the tunnel so status() can
         // report our real mesh IP. ensureStarted is idempotent.
-        val meshIp = try {
+        val (meshIp, meshV6) = try {
             runBlocking {
                 NodeHolder.ensureStarted(applicationContext)
-                NodeHolder.get(applicationContext).status().ipv4
+                val snapshot = NodeHolder.get(applicationContext).status()
+                snapshot.ipv4 to snapshot.ipv6
             }
         } catch (t: Throwable) {
             Log.e(TAG, "could not read mesh IP before tunnel build", t)
-            ""
+            "" to ""
         }
         // Fall back to the CGNAT base if we have no networks yet, so the tunnel
         // still establishes.
         val tunnelAddr = meshIp.ifBlank { "100.64.0.2" }
-
-        val meshV6 = try {
-            runBlocking { NodeHolder.get(applicationContext).status().ipv6 }
-        } catch (t: Throwable) {
-            ""
-        }
 
         // Point the resolver at the phone's real DNS servers before the tunnel
         // captures all DNS on 100.100.100.53. Without this, non-.ray lookups are
@@ -112,7 +107,7 @@ class RayfishVpnService : VpnService() {
         for (pkg in DISALLOWED_APPS) {
             try {
                 builder.addDisallowedApplication(pkg)
-            } catch (e: PackageManager.NameNotFoundException) {
+            } catch (_: PackageManager.NameNotFoundException) {
                 Log.i(TAG, "disallowed app not installed, skipping: $pkg")
             }
         }

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -30,6 +30,8 @@ class RayfishVpnService : VpnService() {
 
     @Volatile
     private var tunnel: ParcelFileDescriptor? = null
+    private var netCallback: android.net.ConnectivityManager.NetworkCallback? = null
+    private var heartbeat: java.util.concurrent.ScheduledExecutorService? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
@@ -115,9 +117,30 @@ class RayfishVpnService : VpnService() {
             try {
                 NodeHolder.get(applicationContext).up(pfd.detachFd())
                 Log.i(TAG, "Node.up succeeded")
+                Telemetry.sendHealth(applicationContext)
             } catch (t: Throwable) {
                 Log.e(TAG, "Node bring-up failed", t)
             }
+        }
+
+        // Re-report health when connectivity flips (e.g. cellular -> wifi), the
+        // trigger that surfaces a struggling mesh bring-up.
+        val cm = getSystemService(android.net.ConnectivityManager::class.java)
+        val cb = object : android.net.ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: android.net.Network) {
+                runCatching { Telemetry.sendHealth(applicationContext) }
+            }
+            override fun onLost(network: android.net.Network) {
+                runCatching { Telemetry.sendHealth(applicationContext) }
+            }
+        }
+        runCatching { cm?.registerDefaultNetworkCallback(cb); netCallback = cb }
+        // Slow heartbeat so a healthy device still checks in periodically.
+        heartbeat = java.util.concurrent.Executors.newSingleThreadScheduledExecutor().also { exec ->
+            exec.scheduleAtFixedRate(
+                { runCatching { Telemetry.sendHealth(applicationContext) } },
+                30, 30, java.util.concurrent.TimeUnit.MINUTES,
+            )
         }
     }
 
@@ -152,11 +175,20 @@ class RayfishVpnService : VpnService() {
         } catch (t: Throwable) {
             Log.w(TAG, "Node stop failed (may not have been up)", t)
         }
+        runCatching { Telemetry.sendHealth(applicationContext) }
         try {
             tunnel?.close()
         } catch (t: Throwable) {
             Log.w(TAG, "closing tunnel fd failed", t)
         }
+
+        netCallback?.let { cb ->
+            runCatching { getSystemService(android.net.ConnectivityManager::class.java)?.unregisterNetworkCallback(cb) }
+        }
+        netCallback = null
+        heartbeat?.shutdownNow()
+        heartbeat = null
+
         tunnel = null
     }
 

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -5,6 +5,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
@@ -70,6 +71,12 @@ class RayfishVpnService : VpnService() {
         // still establishes.
         val tunnelAddr = meshIp.ifBlank { "100.64.0.2" }
 
+        val meshV6 = try {
+            runBlocking { NodeHolder.get(applicationContext).status().ipv6 }
+        } catch (t: Throwable) {
+            ""
+        }
+
         // Point the resolver at the phone's real DNS servers before the tunnel
         // captures all DNS on 100.100.100.53. Without this, non-.ray lookups are
         // refused and public browsing breaks while the VPN is up. Read them from
@@ -93,6 +100,22 @@ class RayfishVpnService : VpnService() {
             .addDnsServer("100.100.100.53")
             .addSearchDomain("ray")
             .setMtu(1280)
+
+        // Route the mesh IPv6 range through the tunnel (mirrors the desktop
+        // 200::/7 route). Skipped if we have no v6 address to bind.
+        if (meshV6.isNotBlank()) {
+            builder.addAddress(meshV6, 128)
+            builder.addRoute("200::", 7)
+        }
+        // Keep VPN-hostile apps (Android Auto, casting, RCS, Sonos) off the
+        // tunnel. Each add is guarded: an uninstalled package must not abort setup.
+        for (pkg in DISALLOWED_APPS) {
+            try {
+                builder.addDisallowedApplication(pkg)
+            } catch (e: PackageManager.NameNotFoundException) {
+                Log.i(TAG, "disallowed app not installed, skipping: $pkg")
+            }
+        }
 
         val pfd = builder.establish()
         if (pfd == null) {
@@ -235,5 +258,16 @@ class RayfishVpnService : VpnService() {
         private const val CHANNEL_ID = "rayfish_vpn"
         private const val NOTIF_ID = 1
         const val ACTION_STOP = "xyz.rayfish.android.STOP"
+
+        // Apps that misbehave behind a VPN (casting, RCS, local-device discovery).
+        // Mirrors Tailscale's default Android exclusions. Excluded so they never
+        // see the VPN interface; our tunnel is split (mesh routes only) anyway.
+        private val DISALLOWED_APPS = listOf(
+            "com.google.android.projection.gearhead", // Android Auto
+            "com.google.android.apps.chromecast.app", // Google Home / Chromecast
+            "com.google.android.apps.messaging",      // RCS / Jibe messaging
+            "com.gopro.smarty",                       // GoPro
+            "com.sonos.acr", "com.sonos.acr2",        // Sonos
+        )
     }
 }

--- a/android/app/src/main/java/xyz/rayfish/android/Telemetry.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/Telemetry.kt
@@ -1,7 +1,11 @@
 package xyz.rayfish.android
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import io.sentry.Attachment
 import io.sentry.Sentry
+import io.sentry.SentryLevel
 import io.sentry.android.core.SentryAndroid
 
 /**
@@ -37,5 +41,69 @@ object Telemetry {
     /** Turn crash reporting off: flush and shut the client down. */
     fun disable() {
         Sentry.close()
+    }
+
+    /** wifi / cellular / ethernet / other, from the active (non-VPN) network. */
+    private fun transportType(context: Context): String {
+        val cm = context.getSystemService(ConnectivityManager::class.java) ?: return "unknown"
+        val net = cm.activeNetwork ?: return "none"
+        val caps = cm.getNetworkCapabilities(net) ?: return "unknown"
+        return when {
+            caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> "wifi"
+            caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> "cellular"
+            caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> "ethernet"
+            else -> "other"
+        }
+    }
+
+    /** Structured health event. No-op when Sentry is off. Best-effort. */
+    fun sendHealth(context: Context) {
+        if (!Sentry.isEnabled()) return
+        val h = runCatching { NodeHolder.get(context).healthSnapshot() }.getOrNull() ?: return
+        Sentry.withScope { scope ->
+            scope.level = if (h.errorCount > 0uL) SentryLevel.WARNING else SentryLevel.INFO
+            scope.setTag("install_id", NodeHolder.installId(context))
+            scope.setTag("transport", transportType(context))
+            scope.setTag("mesh_up", h.meshUp.toString())
+            scope.setContexts("rayfish", mapOf(
+                "running" to h.running,
+                "networks" to h.networkCount.toLong(),
+                "peers_online" to h.peersOnline.toLong(),
+                "node_id" to h.nodeId,
+                "mesh_ipv4" to h.meshIpv4,
+                "warn_count" to h.warnCount.toLong(),
+                "error_count" to h.errorCount.toLong(),
+                "recent_errors" to h.recentErrors,
+            ))
+            Sentry.captureMessage("rayfish health", scope.level ?: SentryLevel.INFO)
+        }
+    }
+
+    /** Full log snapshot as a Sentry attachment. Returns the event id, or null
+     * when Sentry is off / the send failed. Best-effort. */
+    fun sendDiagnostics(context: Context): String? {
+        if (!Sentry.isEnabled()) return null
+        val node = NodeHolder.get(context)
+        val logs = runCatching { node.logSnapshot() }.getOrDefault("")
+        var id: String? = null
+        Sentry.withScope { scope ->
+            scope.setTag("install_id", NodeHolder.installId(context))
+            scope.setTag("transport", transportType(context))
+            scope.addAttachment(Attachment(logs.toByteArray(), "rayfish-logs.txt", "text/plain"))
+            runCatching {
+                val h = node.healthSnapshot()
+                scope.setContexts("rayfish", mapOf(
+                    "running" to h.running,
+                    "networks" to h.networkCount.toLong(),
+                    "peers_online" to h.peersOnline.toLong(),
+                    "node_id" to h.nodeId,
+                    "mesh_ipv4" to h.meshIpv4,
+                    "warn_count" to h.warnCount.toLong(),
+                    "error_count" to h.errorCount.toLong(),
+                ))
+            }
+            id = Sentry.captureMessage("rayfish diagnostics", SentryLevel.INFO).toString()
+        }
+        return id
     }
 }

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
@@ -25,7 +25,6 @@ import xyz.rayfish.android.ui.theme.*
 fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val firstNet = status?.networks?.firstOrNull()
     var editing by remember { mutableStateOf(false) }
     var hostnameInput by remember { mutableStateOf("") }
     var deviceName by remember { mutableStateOf("") }

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
@@ -99,7 +99,7 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
         var crashReporting by remember { mutableStateOf(NodeHolder.isCrashReportingEnabled(context)) }
         ToggleCard(
             title = "Crash reporting",
-            subtitle = if (crashReporting) "on · anonymous diagnostics" else "off",
+            subtitle = if (crashReporting) "on · diagnostics" else "off",
             checked = crashReporting,
             onCheckedChange = { on ->
                 crashReporting = on
@@ -107,6 +107,16 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
                 if (on) Telemetry.enable(context) else Telemetry.disable()
             },
         )
+        if (crashReporting) {
+            PillButton("Send diagnostics", onClick = {
+                scope.launch {
+                    val id = withContext(Dispatchers.IO) {
+                        runCatching { Telemetry.sendDiagnostics(context) }.getOrNull()
+                    }
+                    onToast(if (id != null) "Diagnostics sent" else "Diagnostics unavailable")
+                }
+            }, modifier = Modifier.fillMaxWidth())
+        }
         SectionCard {
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
                 Text("About", fontFamily = Chakra, fontWeight = FontWeight.SemiBold, fontSize = 13.sp, color = Rf.Heading)

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
@@ -28,6 +28,12 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
     val firstNet = status?.networks?.firstOrNull()
     var editing by remember { mutableStateOf(false) }
     var hostnameInput by remember { mutableStateOf("") }
+    var deviceName by remember { mutableStateOf("") }
+    LaunchedEffect(Unit) {
+        deviceName = withContext(Dispatchers.IO) {
+            runCatching { NodeHolder.get(context).defaultHostname() }.getOrDefault("")
+        }
+    }
     var pairingTicket by remember { mutableStateOf<String?>(null) }
     var paired by remember { mutableStateOf(false) }
     // A device that already holds a cert cannot pair again (it must not mint new
@@ -59,10 +65,10 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
         SectionCard {
             SectionLabel("This device")
             Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
-                Text("Hostname", fontFamily = Chakra, fontWeight = FontWeight.SemiBold, fontSize = 13.sp, color = Rf.Heading)
-                if (firstNet != null) TextButton(onClick = { hostnameInput = firstNet.hostname; editing = true }) {
-                    Text(firstNet.hostname.ifEmpty { "set" } + " ✎", fontFamily = PlexMono, fontSize = 11.sp, color = Rf.Rose400)
-                } else Text("join a network first", fontFamily = PlexMono, fontSize = 10.sp, color = Rf.Faint)
+                Text("Device name", fontFamily = Chakra, fontWeight = FontWeight.SemiBold, fontSize = 13.sp, color = Rf.Heading)
+                TextButton(onClick = { hostnameInput = deviceName; editing = true }) {
+                    Text(deviceName.ifEmpty { "set" } + " ✎", fontFamily = PlexMono, fontSize = 11.sp, color = Rf.Rose400)
+                }
             }
             val nodeId = status?.nodeId?.takeIf { it.isNotEmpty() }
             val ip4 = status?.ipv4?.takeIf { it.isNotEmpty() }
@@ -125,11 +131,11 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
         }
     }
 
-    if (editing && firstNet != null) {
+    if (editing) {
         AlertDialog(
             onDismissRequest = { editing = false },
             containerColor = Rf.Sheet,
-            title = { Text("Hostname", fontFamily = Chakra, fontWeight = FontWeight.Bold, color = Rf.Heading) },
+            title = { Text("Device name", fontFamily = Chakra, fontWeight = FontWeight.Bold, color = Rf.Heading) },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     RayfishTextField(hostnameInput, { hostnameInput = it }, "lowercase, 1-63 chars")
@@ -144,10 +150,12 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
                         try {
                             withContext(Dispatchers.IO) {
                                 val node = NodeHolder.get(context)
+                                node.setDefaultHostname(h)
                                 nets.forEach { node.setHostname(it.name, h) }
                             }
-                            onToast("Hostname set"); onChanged(); editing = false
-                        } catch (t: Throwable) { onToast("Invalid hostname: ${t.message}") }
+                            deviceName = h
+                            onToast("Device name set"); onChanged(); editing = false
+                        } catch (t: Throwable) { onToast("Invalid name: ${t.message}") }
                     }
                 }) { Text("Save", color = Rf.Rose400, fontFamily = Chakra, fontWeight = FontWeight.SemiBold) }
             },

--- a/ray-mobile/Cargo.toml
+++ b/ray-mobile/Cargo.toml
@@ -31,6 +31,7 @@ anyhow = "1"
 libc = "0.2"
 thiserror = "2"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 
 # Android JNI bridges the Rust core needs at startup (see `android_jni`). Our
 # `.so` is loaded by JNA (not System.loadLibrary), so nothing registers the

--- a/ray-mobile/src/diag.rs
+++ b/ray-mobile/src/diag.rs
@@ -1,0 +1,214 @@
+//! In-memory capture of the Rust core's `tracing` output for Android
+//! diagnostics. A bounded ring buffer holds recent log lines; two atomic
+//! counters track WARN/ERROR since process start. Installed once as the process
+//! subscriber in `Node::new`; read by `Node::health_snapshot`/`log_snapshot`.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer};
+
+/// Max buffered log lines before the oldest is evicted.
+const MAX_LINES: usize = 4000;
+/// Max total buffered bytes before the oldest lines are evicted.
+const MAX_BYTES: usize = 1_000_000;
+/// Max WARN/ERROR lines kept for `recent_errors`.
+const MAX_ERROR_LINES: usize = 20;
+
+/// Bounded ring of formatted log lines plus a small tail of WARN/ERROR lines.
+pub(crate) struct Ring {
+    lines: VecDeque<String>,
+    bytes: usize,
+    errors: VecDeque<String>,
+}
+
+impl Ring {
+    fn new() -> Self {
+        Ring {
+            lines: VecDeque::new(),
+            bytes: 0,
+            errors: VecDeque::new(),
+        }
+    }
+
+    /// Append a line, evicting oldest lines past the line/byte caps. WARN/ERROR
+    /// lines are also mirrored into the bounded `errors` tail.
+    pub(crate) fn push(&mut self, line: String, level: Level) {
+        if level == Level::WARN || level == Level::ERROR {
+            self.errors.push_back(line.clone());
+            while self.errors.len() > MAX_ERROR_LINES {
+                self.errors.pop_front();
+            }
+        }
+        self.bytes += line.len();
+        self.lines.push_back(line);
+        while self.lines.len() > MAX_LINES || self.bytes > MAX_BYTES {
+            match self.lines.pop_front() {
+                Some(old) => self.bytes -= old.len(),
+                None => break,
+            }
+        }
+    }
+
+    /// All buffered lines joined newline-separated.
+    pub(crate) fn text(&self) -> String {
+        let mut out = String::with_capacity(self.bytes + self.lines.len());
+        for l in &self.lines {
+            out.push_str(l);
+            out.push('\n');
+        }
+        out
+    }
+
+    pub(crate) fn errors(&self) -> Vec<String> {
+        self.errors.iter().cloned().collect()
+    }
+}
+
+/// Process-global diagnostics state.
+struct Diag {
+    ring: Mutex<Ring>,
+    warn: AtomicU64,
+    error: AtomicU64,
+}
+
+static DIAG: OnceLock<Diag> = OnceLock::new();
+
+fn diag() -> &'static Diag {
+    DIAG.get_or_init(|| Diag {
+        ring: Mutex::new(Ring::new()),
+        warn: AtomicU64::new(0),
+        error: AtomicU64::new(0),
+    })
+}
+
+/// Formats an event's fields into a single string, prioritizing `message`.
+#[derive(Default)]
+struct LineVisitor {
+    text: String,
+}
+
+impl Visit for LineVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        use std::fmt::Write;
+        if field.name() == "message" {
+            let _ = write!(self.text, "{value:?} ");
+        } else {
+            let _ = write!(self.text, "{}={value:?} ", field.name());
+        }
+    }
+}
+
+/// The `tracing` layer that pushes each event into the ring buffer.
+struct DiagLayer;
+
+impl<S> Layer<S> for DiagLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let meta = event.metadata();
+        let level = *meta.level();
+        let mut visitor = LineVisitor::default();
+        event.record(&mut visitor);
+        let millis = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0);
+        let line = format!(
+            "{millis} {level} {}: {}",
+            meta.target(),
+            visitor.text.trim_end()
+        );
+
+        let d = diag();
+        if level == Level::WARN {
+            d.warn.fetch_add(1, Ordering::Relaxed);
+        } else if level == Level::ERROR {
+            d.error.fetch_add(1, Ordering::Relaxed);
+        }
+        // Keep the log path non-blocking: drop the line if the buffer is
+        // momentarily contended rather than stalling a logging thread.
+        if let Ok(mut ring) = d.ring.try_lock() {
+            ring.push(line, level);
+        }
+    }
+}
+
+/// Install the diagnostics layer as the process subscriber. Idempotent: a second
+/// call is a no-op (the global subscriber can only be set once).
+pub fn install() {
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info,rayfish=debug"));
+    let _ = tracing_subscriber::registry()
+        .with(DiagLayer.with_filter(filter))
+        .try_init();
+}
+
+pub fn warn_count() -> u64 {
+    diag().warn.load(Ordering::Relaxed)
+}
+
+pub fn error_count() -> u64 {
+    diag().error.load(Ordering::Relaxed)
+}
+
+pub fn recent_errors() -> Vec<String> {
+    diag().ring.lock().map(|r| r.errors()).unwrap_or_default()
+}
+
+pub fn snapshot() -> String {
+    diag().ring.lock().map(|r| r.text()).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evicts_oldest_past_line_cap() {
+        let mut ring = Ring::new();
+        for i in 0..(MAX_LINES + 5) {
+            ring.push(format!("line {i}"), Level::INFO);
+        }
+        assert_eq!(ring.lines.len(), MAX_LINES);
+        // The first five lines were evicted; the oldest kept is "line 5".
+        assert_eq!(ring.lines.front().unwrap(), "line 5");
+    }
+
+    #[test]
+    fn evicts_past_byte_cap() {
+        let mut ring = Ring::new();
+        let big = "x".repeat(100_000);
+        for _ in 0..20 {
+            ring.push(big.clone(), Level::INFO);
+        }
+        assert!(ring.bytes <= MAX_BYTES);
+    }
+
+    #[test]
+    fn tracks_recent_errors_only() {
+        let mut ring = Ring::new();
+        ring.push("info one".into(), Level::INFO);
+        ring.push("warn one".into(), Level::WARN);
+        ring.push("err one".into(), Level::ERROR);
+        assert_eq!(ring.errors(), vec!["warn one", "err one"]);
+    }
+
+    #[test]
+    fn recent_errors_bounded() {
+        let mut ring = Ring::new();
+        for i in 0..(MAX_ERROR_LINES + 5) {
+            ring.push(format!("err {i}"), Level::ERROR);
+        }
+        assert_eq!(ring.errors().len(), MAX_ERROR_LINES);
+    }
+}

--- a/ray-mobile/src/lib.rs
+++ b/ray-mobile/src/lib.rs
@@ -69,6 +69,7 @@ use rayfish::control;
 use rayfish::daemon::{DaemonState, build_headless};
 use rayfish::deeplink::{self, RayfishLink};
 use rayfish::firewall::{Action, Direction, Protocol};
+use rayfish::hostname;
 use rayfish::identity;
 use rayfish::invite;
 use rayfish::ipc::IpcMessage;
@@ -499,6 +500,30 @@ impl Node {
         }
     }
 
+    /// The device's default hostname (seeds every join, incl. pairing
+    /// auto-joins). Empty when unset. Config-only; safe before `start`.
+    pub fn default_hostname(&self) -> String {
+        config::load()
+            .ok()
+            .and_then(|c| c.default_hostname)
+            .unwrap_or_default()
+    }
+
+    /// Set the device's default hostname. Validated with the core's hostname
+    /// rules; rejected names leave the stored value untouched. Config-only;
+    /// safe before `start`.
+    pub fn set_default_hostname(&self, name: String) -> Result<(), RayError> {
+        if !hostname::is_valid_hostname(&name) {
+            return Err(RayError::BadCode(format!(
+                "invalid hostname '{name}': use 1-63 lowercase ASCII letters, digits, or hyphens (no leading/trailing hyphen)"
+            )));
+        }
+        let mut cfg = config::load().map_err(RayError::network)?;
+        cfg.default_hostname = Some(name);
+        config::save_settings(&cfg).map_err(RayError::network)?;
+        Ok(())
+    }
+
     /// Current firewall posture and rules.
     pub fn firewall_show(&self) -> Result<FirewallStateInfo, RayError> {
         let state = self.state()?;
@@ -923,7 +948,7 @@ impl Node {
             .unwrap_or_else(|| {
                 (
                     rayfish::membership::derive_ip(&endpoint_id).to_string(),
-                    String::new(),
+                    rayfish::membership::derive_ipv6(&endpoint_id).to_string(),
                 )
             });
 
@@ -998,5 +1023,30 @@ impl Node {
             return self.pair(code).map(|()| LinkAction::Paired);
         }
         self.join(code).map(LinkAction::Joined)
+    }
+}
+
+#[cfg(test)]
+mod device_name_tests {
+    use super::*;
+
+    #[test]
+    fn set_default_hostname_persists_and_rejects_invalid() {
+        // Isolated config dir; Node::new points RAYFISH_CONFIG_DIR at it.
+        let dir = std::env::temp_dir().join(format!("rayfish-dn-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let node = Node::new(dir.to_string_lossy().to_string());
+
+        node.set_default_hostname("my-phone".into()).unwrap();
+        assert_eq!(node.default_hostname(), "my-phone");
+        assert_eq!(
+            rayfish::config::load().unwrap().default_hostname.as_deref(),
+            Some("my-phone")
+        );
+
+        // Invalid name is rejected and does not overwrite the stored value.
+        assert!(node.set_default_hostname("BAD NAME".into()).is_err());
+        assert_eq!(node.default_hostname(), "my-phone");
     }
 }

--- a/ray-mobile/src/lib.rs
+++ b/ray-mobile/src/lib.rs
@@ -12,6 +12,7 @@
 //! `IpcMessage` results to the UniFFI records below.
 
 mod android_tun;
+mod diag;
 
 /// JNI bridge that hands the Android `JavaVM` + app `Context` to the two Rust
 /// dependencies that need them: `ndk-context` (so iroh-dns can read the system

--- a/ray-mobile/src/lib.rs
+++ b/ray-mobile/src/lib.rs
@@ -147,6 +147,29 @@ pub struct Status {
     pub pending_networks: Vec<String>,
 }
 
+/// One network's liveness, for the health snapshot.
+#[derive(uniffi::Record)]
+pub struct NetworkHealth {
+    pub name: String,
+    pub connected: bool,
+}
+
+/// Lightweight health vitals for auto-telemetry. Cheap to build (reads a status
+/// snapshot + the diagnostics counters); safe to call before `start`.
+#[derive(uniffi::Record)]
+pub struct HealthSnapshot {
+    pub running: bool,
+    pub network_count: u32,
+    pub peers_online: u32,
+    pub networks: Vec<NetworkHealth>,
+    pub mesh_up: bool,
+    pub node_id: String,
+    pub mesh_ipv4: String,
+    pub warn_count: u64,
+    pub error_count: u64,
+    pub recent_errors: Vec<String>,
+}
+
 /// One firewall rule as shown in the UI.
 #[derive(uniffi::Record)]
 pub struct FirewallRuleInfo {
@@ -312,6 +335,9 @@ impl Node {
     /// `RAYFISH_CONFIG_DIR`, which `config::config_dir()` honors on Android.
     #[uniffi::constructor]
     pub fn new(config_dir: String) -> Arc<Self> {
+        // Capture the core's tracing output for Android diagnostics. Idempotent;
+        // safe to call once per process (Node is a process singleton).
+        diag::install();
         // SAFETY-ish: set before any core call reads config. Single-threaded at
         // construction time.
         unsafe { std::env::set_var("RAYFISH_CONFIG_DIR", &config_dir) };
@@ -910,6 +936,39 @@ impl Node {
             networks: detail,
             pending_networks,
         }
+    }
+
+    /// Lightweight health vitals for auto-telemetry. Reuses `status()` for mesh
+    /// state and reads the diagnostics counters. Cumulative WARN/ERROR counts
+    /// (since process start); reading does not reset them.
+    pub fn health_snapshot(&self) -> HealthSnapshot {
+        let s = self.status();
+        let networks: Vec<NetworkHealth> = s
+            .networks
+            .iter()
+            .map(|n| NetworkHealth {
+                name: n.name.clone(),
+                connected: n.peers.iter().any(|p| p.online),
+            })
+            .collect();
+        let peers_online = s.peers.iter().filter(|p| p.online).count() as u32;
+        HealthSnapshot {
+            running: s.running,
+            network_count: s.networks.len() as u32,
+            peers_online,
+            networks,
+            mesh_up: peers_online > 0,
+            node_id: s.node_id.chars().take(10).collect(),
+            mesh_ipv4: s.ipv4.clone(),
+            warn_count: diag::warn_count(),
+            error_count: diag::error_count(),
+            recent_errors: diag::recent_errors(),
+        }
+    }
+
+    /// The full buffered core log, for the "Send diagnostics" button.
+    pub fn log_snapshot(&self) -> String {
+        diag::snapshot()
     }
 
     /// Follow a `rayfish://join/<code>` or `rayfish://pair/<ticket>` deep link,

--- a/src/daemon/mesh/connect.rs
+++ b/src/daemon/mesh/connect.rs
@@ -99,7 +99,17 @@ impl MeshManager {
                         room_id,
                         coordinator,
                     }) => {
-                        let _ = me.join_direct(room_id, coordinator, hostname.clone()).await;
+                        match me.join_direct(room_id, coordinator, hostname.clone()).await {
+                            IpcMessage::Joined { .. } | IpcMessage::Ok { .. } => {
+                                tracing::info!(peer = %peer.fmt_short(), "direct connect join ok");
+                            }
+                            IpcMessage::Error { message } => {
+                                tracing::warn!(peer = %peer.fmt_short(), error = %message, "direct connect join failed");
+                            }
+                            other => {
+                                tracing::warn!(peer = %peer.fmt_short(), response = ?other, "direct connect join: unexpected response");
+                            }
+                        }
                         me.connect.outgoing_connects.remove(&peer);
                         return;
                     }

--- a/src/daemon/mesh/files.rs
+++ b/src/daemon/mesh/files.rs
@@ -530,18 +530,23 @@ impl MeshManager {
                         continue;
                     }
                     let me = Arc::clone(self);
+                    let net_name = net.name.clone();
+                    let net_key = net.network_key.clone();
                     tokio::spawn(async move {
-                        let _ = me
-                            .join_network(
-                                &net.network_key,
-                                Some(&net.name),
-                                None,
-                                None,
-                                None,
-                                false,
-                                false,
-                            )
-                            .await;
+                        match me
+                            .join_network(&net_key, Some(&net_name), None, None, None, false, false)
+                            .await
+                        {
+                            IpcMessage::Joined { .. } | IpcMessage::Ok { .. } => {
+                                tracing::info!(network = %net_name, "pairing auto-join ok");
+                            }
+                            IpcMessage::Error { message } => {
+                                tracing::warn!(network = %net_name, error = %message, "pairing auto-join failed");
+                            }
+                            other => {
+                                tracing::warn!(network = %net_name, response = ?other, "pairing auto-join: unexpected response");
+                            }
+                        }
                     });
                 }
                 IpcMessage::PairingComplete {


### PR DESCRIPTION
## Summary

Android mobile improvements, in two stacked parts (this branch is ahead of `master` by both, since neither was pushed to the remote yet).

### Diagnostics (observability)
- Buffer the Rust core's `tracing` logs in a bounded in-memory ring with WARN/ERROR counters, exposed over FFI (`health_snapshot`, `log_snapshot`).
- Auto-send a structured health event to crash reporting on tunnel up/down, on a wifi/cellular change, and on a slow heartbeat; a "Send diagnostics" button ships the full recent log as an attachment.
- Stop swallowing the pairing auto-join and direct-connect errors so a failed bring-up is visible.
- All gated by the existing crash-reporting opt-out. Diagnostic logs may include network addresses (relay hosts, public IP), noted in the changelog.

### Naming + tunnel fixes
- **Consistent device name:** the phone now uses one device name across every network instead of a random name per network. Seeded from the device model on first run, editable in the You screen (persists as the core `default_hostname`, which pairing auto-joins already read).
- **App exclusions:** apps that break behind a VPN (Android Auto, Chromecast/Google Home, RCS messaging, GoPro, Sonos) now bypass the tunnel, mirroring Tailscale's default set, so wireless Android Auto keeps working.
- **Mesh IPv6 on mobile:** the Android tunnel now routes `200::/7` and binds the device's v6 address, which never worked before.

## Testing
- Rust: `cargo test -p ray-mobile` passes (incl. a new device-name validation/persistence test).
- Android: `./gradlew :app:assembleDebug` succeeds; APK builds.
- Reviewed per task plus a final whole-branch review.

## Still needs on-device verification
- `200::/7` present in the phone's route table and a `ping6` to a peer's mesh v6.
- Android Auto wireless stays connected with the tunnel on (needs a car head unit).
