### PR TITLE
fix(android): forward public DNS through DnsResolver.rawQuery (honor Private DNS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Android no longer downgrades public DNS to cleartext.** While the VPN was up,
+  non-`.ray` lookups were forwarded as plaintext UDP on port 53 to the network's
+  IPv4 resolvers, ignoring any Private DNS (DoT/DoH) the device had configured.
+  Rayfish now runs a small loopback proxy that forwards those lookups through the
+  Android platform resolver (`DnsResolver.rawQuery`), so they honor the system
+  Private DNS setting. The app is also excluded from its own tunnel so its
+  sockets use the real underlying network. Devices below Android 10 (no
+  `DnsResolver`) fall back to the previous plaintext behavior.
 - **A reconnecting peer shows the current roster within seconds, not up to a
   minute.** After a restart a node connected to its coordinator almost instantly
   but its own `ray status` could sit on a stale roster (peers missing or shown

--- a/android/app/src/main/java/uniffi/ray_mobile/ray_mobile.kt
+++ b/android/app/src/main/java/uniffi/ray_mobile/ray_mobile.kt
@@ -1202,7 +1202,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_ray_mobile_checksum_method_node_set_default_hostname() != 40200.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_ray_mobile_checksum_method_node_set_dns_upstreams() != 50178.toShort()) {
+    if (lib.uniffi_ray_mobile_checksum_method_node_set_dns_upstreams() != 41955.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ray_mobile_checksum_method_node_set_hostname() != 56819.toShort()) {
@@ -1781,12 +1781,16 @@ public interface NodeInterface {
     fun `setDefaultHostname`(`name`: kotlin.String)
     
     /**
-     * Point the Magic DNS resolver at the phone's real DNS servers so
-     * non-`.ray` queries are forwarded instead of refused. On Android there is
-     * no `resolv.conf` to capture (the desktop path), so the platform reads the
-     * underlying network's DNS servers and passes them here before the tunnel
-     * captures all DNS. Non-IPv4 entries are ignored (the resolver forwards
-     * over IPv4). Requires [`Node::start`] first.
+     * Point the Magic DNS resolver at the phone's DNS so non-`.ray` queries are
+     * forwarded instead of refused. On Android there is no `resolv.conf` to
+     * capture (the desktop path), so the platform passes upstreams here before
+     * the tunnel captures all DNS. Requires [`Node::start`] first.
+     *
+     * Each entry may be a bare IPv4 (forwarded as cleartext UDP on port 53) or
+     * an `ip:port` socket address. The platform points this at a loopback
+     * `DnsResolver.rawQuery` proxy (`127.0.0.1:<port>`) so non-`.ray` lookups
+     * honor the system Private DNS (DoT/DoH); entries that parse as neither are
+     * ignored.
      */
     fun `setDnsUpstreams`(`servers`: List<kotlin.String>)
     
@@ -2374,12 +2378,16 @@ open class Node: Disposable, AutoCloseable, NodeInterface
 
     
     /**
-     * Point the Magic DNS resolver at the phone's real DNS servers so
-     * non-`.ray` queries are forwarded instead of refused. On Android there is
-     * no `resolv.conf` to capture (the desktop path), so the platform reads the
-     * underlying network's DNS servers and passes them here before the tunnel
-     * captures all DNS. Non-IPv4 entries are ignored (the resolver forwards
-     * over IPv4). Requires [`Node::start`] first.
+     * Point the Magic DNS resolver at the phone's DNS so non-`.ray` queries are
+     * forwarded instead of refused. On Android there is no `resolv.conf` to
+     * capture (the desktop path), so the platform passes upstreams here before
+     * the tunnel captures all DNS. Requires [`Node::start`] first.
+     *
+     * Each entry may be a bare IPv4 (forwarded as cleartext UDP on port 53) or
+     * an `ip:port` socket address. The platform points this at a loopback
+     * `DnsResolver.rawQuery` proxy (`127.0.0.1:<port>`) so non-`.ray` lookups
+     * honor the system Private DNS (DoT/DoH); entries that parse as neither are
+     * ignored.
      */
     @Throws(RayException::class)override fun `setDnsUpstreams`(`servers`: List<kotlin.String>)
         = 

--- a/android/app/src/main/java/xyz/rayfish/android/DnsProxy.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/DnsProxy.kt
@@ -1,0 +1,135 @@
+package xyz.rayfish.android
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.DnsResolver
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Build
+import android.os.CancellationSignal
+import androidx.annotation.RequiresApi
+import io.sentry.android.core.SentryLogcatAdapter as Log
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.util.concurrent.Executors
+import kotlin.concurrent.thread
+
+/**
+ * A tiny loopback UDP DNS proxy that forwards each raw query through
+ * [DnsResolver.rawQuery] on the underlying (non-VPN) network. `rawQuery` goes
+ * through the platform resolver, so it honors the device's Private DNS setting
+ * (DoT/DoH) instead of downgrading to cleartext UDP on port 53.
+ *
+ * The Rust Magic DNS resolver forwards every non-`.ray` lookup here (its upstream
+ * is set to `127.0.0.1:<port>`); we hand the bytes to the system resolver and
+ * write the answer straight back to the caller. Requires API 29
+ * ([Build.VERSION_CODES.Q]); on older devices [start] returns null and the caller
+ * falls back to the plaintext upstream path.
+ */
+@RequiresApi(Build.VERSION_CODES.Q)
+class DnsProxy private constructor(
+    private val socket: DatagramSocket,
+    private val resolver: DnsResolver,
+    private val context: Context,
+) {
+    /** The loopback port the proxy is bound to; pass `127.0.0.1:<port>` to Rust. */
+    val port: Int get() = socket.localPort
+
+    @Volatile
+    private var running = true
+
+    // rawQuery callbacks land here; a single thread serializes the socket sends.
+    private val executor = Executors.newSingleThreadExecutor()
+
+    private fun loop() {
+        val buf = ByteArray(4096)
+        while (running) {
+            val request = DatagramPacket(buf, buf.size)
+            try {
+                socket.receive(request)
+            } catch (t: Throwable) {
+                if (running) Log.w(TAG, "dns proxy receive failed", t)
+                break
+            }
+            val query = request.data.copyOfRange(0, request.length)
+            val client = request.socketAddress
+            val network = underlyingNetwork()
+            try {
+                resolver.rawQuery(
+                    network,
+                    query,
+                    DnsResolver.FLAG_EMPTY,
+                    executor,
+                    CancellationSignal(),
+                    object : DnsResolver.Callback<ByteArray> {
+                        override fun onAnswer(answer: ByteArray, rcode: Int) {
+                            trySend(answer, client)
+                        }
+
+                        override fun onError(error: DnsResolver.DnsException) {
+                            // A servfail still deserves a DNS reply, but rawQuery
+                            // hands us no packet on error; drop and let the client
+                            // time out and retry. Logged sparsely to avoid spam.
+                            Log.d(TAG, "rawQuery error: ${error.message}")
+                        }
+                    },
+                )
+            } catch (t: Throwable) {
+                Log.w(TAG, "rawQuery dispatch failed", t)
+            }
+        }
+    }
+
+    private fun trySend(answer: ByteArray, client: java.net.SocketAddress) {
+        try {
+            socket.send(DatagramPacket(answer, answer.size, client))
+        } catch (t: Throwable) {
+            if (running) Log.w(TAG, "dns proxy send failed", t)
+        }
+    }
+
+    // The active underlying network, or the first non-VPN network with internet.
+    // rawQuery(network=null) would use our app's default network, which is already
+    // the underlying one once the app is excluded from its own VPN; resolving it
+    // explicitly keeps us correct regardless of exclusion ordering.
+    private fun underlyingNetwork(): Network? {
+        val cm = context.getSystemService(ConnectivityManager::class.java) ?: return null
+        for (network in cm.allNetworks) {
+            val caps = cm.getNetworkCapabilities(network) ?: continue
+            if (!caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) continue
+            if (caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) continue
+            return network
+        }
+        return null
+    }
+
+    fun stop() {
+        running = false
+        socket.close()
+        executor.shutdownNow()
+    }
+
+    companion object {
+        private const val TAG = "RayfishDnsProxy"
+
+        /**
+         * Bind the proxy to an ephemeral loopback port and start its receive loop.
+         * Returns null on API < 29 (no [DnsResolver]) or if binding fails; the
+         * caller then falls back to the plaintext upstream path.
+         */
+        fun start(context: Context): DnsProxy? {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
+            return try {
+                val socket = DatagramSocket(0, InetAddress.getByName("127.0.0.1"))
+                val proxy = DnsProxy(socket, DnsResolver.getInstance(), context.applicationContext)
+                thread(name = "rayfish-dns-proxy", isDaemon = true) { proxy.loop() }
+                Log.i(TAG, "DNS proxy listening on 127.0.0.1:${proxy.port}")
+                proxy
+            } catch (t: Throwable) {
+                Log.e(TAG, "could not start DNS proxy; falling back to plaintext DNS", t)
+                null
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -31,6 +31,9 @@ class RayfishVpnService : VpnService() {
 
     @Volatile
     private var tunnel: ParcelFileDescriptor? = null
+    // Loopback DNS proxy forwarding non-.ray lookups through DnsResolver.rawQuery
+    // (honors Private DNS / DoT). Null on API < 29 or if it failed to start.
+    private var dnsProxy: DnsProxy? = null
     // Polls for incoming own-device file offers and auto-accepts them, so files
     // shared to this device land in Downloads even with the app UI closed.
     private var autoAcceptPoller: java.util.concurrent.ScheduledExecutorService? = null
@@ -73,17 +76,29 @@ class RayfishVpnService : VpnService() {
         // still establishes.
         val tunnelAddr = meshIp.ifBlank { "100.64.0.2" }
 
-        // Point the resolver at the phone's real DNS servers before the tunnel
-        // captures all DNS on 100.100.100.53. Without this, non-.ray lookups are
-        // refused and public browsing breaks while the VPN is up. Read them from
-        // the underlying (non-VPN) network, which is still active pre-establish.
+        // Point the resolver at the phone's real DNS before the tunnel captures
+        // all DNS on 100.100.100.53. Without this, non-.ray lookups are refused
+        // and public browsing breaks while the VPN is up.
+        //
+        // Prefer a loopback DnsResolver.rawQuery proxy: it forwards through the
+        // platform resolver, so it honors the device's Private DNS (DoT/DoH)
+        // instead of downgrading to cleartext UDP:53. Only when the proxy is
+        // unavailable (API < 29 or bind failure) do we fall back to handing the
+        // underlying network's plaintext IPv4 resolvers straight to Rust.
         try {
-            val dns = systemDnsServers()
-            if (dns.isNotEmpty()) {
-                NodeHolder.get(applicationContext).setDnsUpstreams(dns)
-                Log.i(TAG, "DNS upstreams set: $dns")
+            val proxy = DnsProxy.start(applicationContext)
+            dnsProxy = proxy
+            if (proxy != null) {
+                NodeHolder.get(applicationContext).setDnsUpstreams(listOf("127.0.0.1:${proxy.port}"))
+                Log.i(TAG, "DNS upstream set to rawQuery proxy 127.0.0.1:${proxy.port}")
             } else {
-                Log.w(TAG, "no underlying IPv4 DNS servers found; only .ray will resolve")
+                val dns = systemDnsServers()
+                if (dns.isNotEmpty()) {
+                    NodeHolder.get(applicationContext).setDnsUpstreams(dns)
+                    Log.i(TAG, "DNS upstreams set (plaintext fallback): $dns")
+                } else {
+                    Log.w(TAG, "no underlying IPv4 DNS servers found; only .ray will resolve")
+                }
             }
         } catch (t: Throwable) {
             Log.e(TAG, "could not set DNS upstreams; only .ray will resolve", t)
@@ -103,6 +118,17 @@ class RayfishVpnService : VpnService() {
             builder.addAddress(meshV6, 128)
             builder.addRoute("200::", 7)
         }
+        // Exclude Rayfish itself from its own tunnel. Its sockets (the iroh mesh
+        // underlay, the DnsResolver.rawQuery proxy) then use the real underlying
+        // network directly, so DNS forwarding can't loop back through the TUN and
+        // Private DNS keeps working. Split routing already keeps mesh traffic on
+        // the tunnel via the Rust core's fd, not the app's normal sockets.
+        try {
+            builder.addDisallowedApplication(packageName)
+        } catch (_: PackageManager.NameNotFoundException) {
+            Log.w(TAG, "could not exclude self from VPN: $packageName")
+        }
+
         // Keep VPN-hostile apps (Android Auto, casting, RCS, Sonos) off the
         // tunnel. Each add is guarded: an uninstalled package must not abort setup.
         for (pkg in DISALLOWED_APPS) {
@@ -192,6 +218,9 @@ class RayfishVpnService : VpnService() {
 
         autoAcceptPoller?.shutdownNow()
         autoAcceptPoller = null
+
+        dnsProxy?.stop()
+        dnsProxy = null
 
         tunnel = null
     }

--- a/justfile
+++ b/justfile
@@ -32,12 +32,21 @@ cross:
 
 deploy ip:
     cross -q build --release --target {{target}}
+    just scp {{ip}}
+
+# Copy an already-built release binary to a host + (re)start the daemon. No build.
+# Use after `just cross` when deploying the same binary to several hosts.
+scp ip:
     rsync -az --progress target/{{target}}/release/{{binary}} {{user}}@{{ip}}:/tmp/
     ssh {{user}}@{{ip}} "getent group rayfish >/dev/null || groupadd rayfish && install -m 755 /tmp/{{binary}} /usr/local/bin/{{binary}} && (systemctl restart rayfish 2>/dev/null || {{binary}} up)"
     @echo "Deployed and installed daemon on {{ip}}"
 
 deploy-dev ip:
     cross -q build --target {{target}}
+    just scp-dev {{ip}}
+
+# Debug counterpart of `scp`: copy an already-built debug binary, no build.
+scp-dev ip:
     rsync -az --progress target/{{target}}/debug/{{binary}} {{user}}@{{ip}}:/tmp/
     ssh {{user}}@{{ip}} "getent group rayfish >/dev/null || groupadd rayfish && install -m 755 /tmp/{{binary}} /usr/local/bin/{{binary}} && (systemctl restart rayfish 2>/dev/null || {{binary}} up)"
     @echo "Deployed and installed daemon on {{ip}} (debug build)"

--- a/ray-mobile/src/lib.rs
+++ b/ray-mobile/src/lib.rs
@@ -60,7 +60,7 @@ mod android_jni {
     }
 }
 
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::{Arc, Mutex};
 
 use android_tun::{AndroidTunReader, AndroidTunWriter};
@@ -837,16 +837,27 @@ impl Node {
         }
     }
 
-    /// Point the Magic DNS resolver at the phone's real DNS servers so
-    /// non-`.ray` queries are forwarded instead of refused. On Android there is
-    /// no `resolv.conf` to capture (the desktop path), so the platform reads the
-    /// underlying network's DNS servers and passes them here before the tunnel
-    /// captures all DNS. Non-IPv4 entries are ignored (the resolver forwards
-    /// over IPv4). Requires [`Node::start`] first.
+    /// Point the Magic DNS resolver at the phone's DNS so non-`.ray` queries are
+    /// forwarded instead of refused. On Android there is no `resolv.conf` to
+    /// capture (the desktop path), so the platform passes upstreams here before
+    /// the tunnel captures all DNS. Requires [`Node::start`] first.
+    ///
+    /// Each entry may be a bare IPv4 (forwarded as cleartext UDP on port 53) or
+    /// an `ip:port` socket address. The platform points this at a loopback
+    /// `DnsResolver.rawQuery` proxy (`127.0.0.1:<port>`) so non-`.ray` lookups
+    /// honor the system Private DNS (DoT/DoH); entries that parse as neither are
+    /// ignored.
     pub fn set_dns_upstreams(&self, servers: Vec<String>) -> Result<(), RayError> {
         let state = self.state()?;
-        let parsed: Vec<Ipv4Addr> = servers.iter().filter_map(|s| s.parse().ok()).collect();
-        state.set_dns_upstreams(parsed);
+        let parsed: Vec<SocketAddr> = servers
+            .iter()
+            .filter_map(|s| {
+                s.parse::<SocketAddr>()
+                    .ok()
+                    .or_else(|| s.parse::<Ipv4Addr>().ok().map(|ip| SocketAddr::from((ip, 53u16))))
+            })
+            .collect();
+        state.set_dns_upstream_addrs(parsed);
         Ok(())
     }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -661,6 +661,14 @@ impl Daemon {
         self.dns.resolver.set_upstreams(servers);
     }
 
+    /// Point the Magic DNS resolver at explicit `ip:port` upstreams. Android uses
+    /// this to target a loopback `DnsResolver.rawQuery` proxy so non-`.ray`
+    /// lookups honor the system Private DNS (DoT/DoH) rather than being forwarded
+    /// as cleartext UDP on port 53.
+    pub fn set_dns_upstream_addrs(&self, servers: Vec<SocketAddr>) {
+        self.dns.resolver.set_upstream_addrs(servers);
+    }
+
     /// Register a [`CoordinatorAcceptState`] handler for `network` and update
     /// the network's role in `self.registry.networks` to [`NetworkRole::Coordinator`].
     ///

--- a/src/dns_resolver.rs
+++ b/src/dns_resolver.rs
@@ -2,7 +2,7 @@
 //! Answers `.ray` names from the hostname tables and forwards everything else
 //! to the captured system upstreams.
 
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -27,12 +27,20 @@ impl Resolver {
         }
     }
 
-    /// Replace the upstream set, dropping the magic IP to avoid a forwarding loop.
+    /// Replace the upstream set (bare IPv4 on port 53), dropping the magic IP to
+    /// avoid a forwarding loop. The desktop capture path uses this.
     pub fn set_upstreams(&self, servers: Vec<Ipv4Addr>) {
-        let v: Vec<SocketAddr> = servers
+        self.set_upstream_addrs(servers.into_iter().map(|ip| SocketAddr::from((ip, 53u16))));
+    }
+
+    /// Replace the upstream set with explicit socket addresses (ip:port). Lets a
+    /// caller point the resolver at a loopback proxy on a non-53 port: Android
+    /// runs a local `DnsResolver.rawQuery` proxy so non-`.ray` lookups honor the
+    /// system Private DNS (DoT/DoH) instead of being downgraded to cleartext :53.
+    pub fn set_upstream_addrs(&self, addrs: impl IntoIterator<Item = SocketAddr>) {
+        let v: Vec<SocketAddr> = addrs
             .into_iter()
-            .filter(|ip| *ip != MAGIC_DNS_V4)
-            .map(|ip| SocketAddr::from((ip, 53u16)))
+            .filter(|a| a.ip() != IpAddr::V4(MAGIC_DNS_V4))
             .collect();
         self.upstreams.store(Arc::new(v));
     }
@@ -248,6 +256,24 @@ mod tests {
         assert_eq!(
             r.upstreams(),
             vec!["1.1.1.1:53".parse::<SocketAddr>().unwrap()]
+        );
+    }
+
+    #[tokio::test]
+    async fn set_upstream_addrs_keeps_custom_port_and_drops_magic() {
+        let r = Resolver::new(
+            crate::dns::new_hostname_table(),
+            crate::dns::new_reverse_table(),
+        );
+        // A loopback rawQuery proxy on a non-53 port survives; the magic IP is
+        // still filtered regardless of the port it carries.
+        r.set_upstream_addrs([
+            "127.0.0.1:5353".parse::<SocketAddr>().unwrap(),
+            SocketAddr::from((crate::dns::MAGIC_DNS_V4, 5353)),
+        ]);
+        assert_eq!(
+            r.upstreams(),
+            vec!["127.0.0.1:5353".parse::<SocketAddr>().unwrap()]
         );
     }
 }

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -89,14 +89,16 @@ reset_state(){
   done
 }
 
-# deploy_all <root> <ip...> : cross-build + rsync + ray up on each host; abort on failure.
+# deploy_all <root> <ip...> : cross-build once + rsync + ray up on each host; abort on failure.
 deploy_all(){
   local root="$1"; shift
-  step "deploy ray to all hosts (cross build + rsync + ray up)"
+  step "deploy ray to all hosts (cross build once + rsync + ray up)"
+  echo ">> just cross"
+  if ( cd "$root" && just cross ); then pass "cross build"; else fail "cross build"; echo "aborting"; exit 1; fi
   local ip
   for ip in "$@"; do
-    echo ">> just deploy $ip"
-    if ( cd "$root" && just deploy "$ip" ); then pass "deploy $ip"; else fail "deploy $ip"; echo "aborting"; exit 1; fi
+    echo ">> just scp $ip"
+    if ( cd "$root" && just scp "$ip" ); then pass "deploy $ip"; else fail "deploy $ip"; echo "aborting"; exit 1; fi
   done
 }
 


### PR DESCRIPTION
Closes #81.

## Problem

While the VPN is up on Android, non-`.ray` lookups were handed to the underlying network's IPv4 resolvers and forwarded as **plaintext UDP on port 53** (`Resolver::forward_once`). This ignored any Private DNS (DoT/DoH) the device had configured: a user on encrypted DNS was silently downgraded to cleartext whenever Rayfish was active. IPv6-only and DoH resolvers were dropped entirely.

## Fix

Follows the approach suggested in the issue:

- **`DnsProxy.kt`** (new): a small loopback UDP DNS proxy. For each query it calls `DnsResolver.rawQuery`, pinned to the underlying non-VPN network. `rawQuery` goes through the Android platform resolver, so it honors the system Private DNS setting. The answer is written straight back to the caller.
- **`RayfishVpnService`**: starts the proxy and points the Rust Magic DNS resolver at `127.0.0.1:<proxy-port>`. Also excludes the app from its own tunnel (`addDisallowedApplication(packageName)`) so its sockets use the real underlying network and DNS can't loop back through the TUN.
- **Rust**: `Resolver` gains `set_upstream_addrs` for explicit `ip:port` upstreams; the desktop bare-IPv4/`:53` capture path is unchanged. The mobile FFI (`set_dns_upstreams`) now parses each entry as a socket address, or a bare IPv4 on port 53.

## Fallback

`DnsResolver.rawQuery` requires API 29 (Android 10). On older devices `DnsProxy.start` returns null and the service falls back to the previous plaintext-upstream behavior, so nothing regresses there.

## Testing

- `cargo check` / `clippy` / `test` green (344 lib tests pass; added a `dns_resolver` unit test for the `ip:port` / magic-IP-filter path).
- The FFI signature (`Vec<String>`) is unchanged, so the generated UniFFI Kotlin binding does not need regenerating.
- **Not device-tested.** The Android half (proxy behavior, Private DNS honored, self-exclusion) needs verification on a real device / emulator with Private DNS toggled on. Flagging since #81 mentions an Android arch rework in flight that this may want to fold into.