### PR TITLE
fix(mesh): drop overlay IPs from iroh's direct-address candidates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,8 +2748,7 @@ dependencies = [
 [[package]]
 name = "iroh"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fca9b4b462c343ff88fc0af4096c186f939b602a0bc08723536ef2c31c93971"
+source = "git+https://github.com/rayfish/iroh?branch=direct-addr-filter#7f64ac3ea5931dd4c63ec35ba9d95588e43d0239"
 dependencies = [
  "backon",
  "blake3",
@@ -2799,8 +2798,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830a582cd54410dc1aa71d4786a82c3297d7b0165accd8b6dbbb3b240b48140d"
+source = "git+https://github.com/rayfish/iroh?branch=direct-addr-filter#7f64ac3ea5931dd4c63ec35ba9d95588e43d0239"
 dependencies = [
  "curve25519-dalek 5.0.0-rc.0",
  "data-encoding",
@@ -2858,8 +2856,7 @@ dependencies = [
 [[package]]
 name = "iroh-dns"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516e4eedc38e33ab69a6bd325520332dc3d67b25454e2d590ebb84a25240dd9a"
+source = "git+https://github.com/rayfish/iroh?branch=direct-addr-filter#7f64ac3ea5931dd4c63ec35ba9d95588e43d0239"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -2950,8 +2947,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8149bb6a57126225a07d6928846d82dcedfd24ea0f863ef7b2eb475e1d726354"
+source = "git+https://github.com/rayfish/iroh?branch=direct-addr-filter#7f64ac3ea5931dd4c63ec35ba9d95588e43d0239"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,3 +183,11 @@ core-foundation = "0.9"
 [target.'cfg(windows)'.dependencies]
 # Enables ANSI escape processing on legacy Windows consoles (no-op on modern terminals).
 enable-ansi-support = "0.3"
+
+[patch.crates-io]
+# iroh fork adding `Builder::direct_addr_filter` (upstream PR n0-computer/iroh#4397).
+# iroh-base/-dns/-relay are patched too so the fork and registry copies don't clash.
+iroh = { git = "https://github.com/rayfish/iroh", branch = "direct-addr-filter" }
+iroh-base = { git = "https://github.com/rayfish/iroh", branch = "direct-addr-filter" }
+iroh-dns = { git = "https://github.com/rayfish/iroh", branch = "direct-addr-filter" }
+iroh-relay = { git = "https://github.com/rayfish/iroh", branch = "direct-addr-filter" }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -6,13 +6,12 @@
 
 use anyhow::{Context, Result};
 use iroh::{
-    Endpoint, EndpointAddr, EndpointId, RelayMode, RelayUrl, SecretKey, TransportAddr,
-    address_lookup::{AddrFilter, PkarrPublisher, PkarrResolver},
+    Endpoint, EndpointAddr, EndpointId, RelayMode, RelayUrl, SecretKey,
+    address_lookup::{PkarrPublisher, PkarrResolver},
     endpoint::Connection,
     endpoint::presets,
     endpoint::{Builder, DirectAddrFilter, QuicTransportConfig},
 };
-use std::borrow::Cow;
 
 use crate::config::ServerOverride;
 #[cfg(feature = "tor")]
@@ -140,16 +139,11 @@ async fn bind_endpoint(
         // `noq-proto` dependency to reach the config type, deferred to a measured
         // follow-up (see iroh-audit BASELINE.md, cross-parameter sweep).
         .transport_config(quic_transport_config())
-        // Keep rayfish overlay addresses out of the transport candidates we
-        // advertise (see `overlay_stripping_filter`).
-        .addr_filter(overlay_stripping_filter())
-        // The definitive fix: drop overlay addresses from the *gathered* local
-        // interface candidates, so a mesh IP bound on the TUN is never stored,
-        // published, or offered as a holepunch / NAT-traversal candidate (and so
-        // never dialed by a peer, which would loop the underlay back through the
-        // tunnel). This covers the in-band NAT-traversal path that `addr_filter`
-        // (publish-only) cannot reach. Stays bound to `0.0.0.0`, so multi-homing /
-        // roaming is unaffected.
+        // Drop overlay addresses from the gathered direct-address candidates, so a
+        // mesh IP bound on the TUN is never stored, published, or offered as a
+        // holepunch / NAT-traversal candidate (and so never dialed by a peer, which
+        // would loop the underlay back through the tunnel). Stays bound to `0.0.0.0`,
+        // so multi-homing / roaming is unaffected.
         .direct_addr_filter(OverlayAddrFilter);
 
     // Override the N0 preset's relay / discovery defaults when configured.
@@ -181,11 +175,10 @@ async fn bind_endpoint(
 }
 
 /// A [`DirectAddrFilter`] that drops rayfish overlay addresses (`100.64.0.0/10`,
-/// `200::/7`) from iroh's gathered local-interface candidates. The mesh IP is bound
+/// `200::/7`) from iroh's gathered direct-address candidates. The mesh IP is bound
 /// on the TUN device; without this iroh would discover it, advertise it (pkarr/DNS
-/// **and** in-band NAT-traversal), and peers would dial it, looping the underlay
-/// back through the tunnel we carry. This filters the candidate set at the source,
-/// so the overlay IP is never stored, published, or holepunched.
+/// and in-band NAT-traversal), and peers would dial it, looping the underlay back
+/// through the tunnel we carry.
 #[derive(Debug)]
 struct OverlayAddrFilter;
 
@@ -193,24 +186,6 @@ impl DirectAddrFilter for OverlayAddrFilter {
     fn keeps(&self, ip: std::net::IpAddr) -> bool {
         !crate::membership::is_overlay_ip(ip)
     }
-}
-
-/// An [`AddrFilter`] that strips rayfish overlay addresses (`100.64.0.0/10`,
-/// `200::/7`) from the transport candidates iroh publishes for this node. Kept as
-/// defense in depth alongside [`OverlayAddrFilter`], which already removes overlay
-/// IPs from the gathered candidate set (so they never reach the publish path).
-/// Relay and custom (Tor) addresses pass through untouched.
-fn overlay_stripping_filter() -> AddrFilter {
-    fn is_overlay(a: &TransportAddr) -> bool {
-        matches!(a, TransportAddr::Ip(s) if crate::membership::is_overlay_ip(s.ip()))
-    }
-    AddrFilter::new(|addrs| {
-        if addrs.iter().any(is_overlay) {
-            Cow::Owned(addrs.iter().filter(|a| !is_overlay(a)).cloned().collect())
-        } else {
-            Cow::Borrowed(addrs)
-        }
-    })
 }
 
 /// Builds the [`QuicTransportConfig`] for rayfish's data-plane shape (one stream
@@ -328,31 +303,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn overlay_filter_strips_only_mesh_ips() {
-        use std::net::SocketAddr;
-        let relay = TransportAddr::Relay("https://relay.example./".parse().unwrap());
-        let underlay = TransportAddr::Ip("51.15.139.151:41383".parse::<SocketAddr>().unwrap());
-        let lan = TransportAddr::Ip("192.168.1.104:41383".parse::<SocketAddr>().unwrap());
-        let mesh_v4 = TransportAddr::Ip("100.124.253.88:41383".parse::<SocketAddr>().unwrap());
-        let mesh_v6 = TransportAddr::Ip("[200::1]:41383".parse::<SocketAddr>().unwrap());
-
-        let filter = overlay_stripping_filter();
-        let input = vec![
-            relay.clone(),
-            underlay.clone(),
-            lan.clone(),
-            mesh_v4,
-            mesh_v6,
-        ];
-        let kept = filter.apply(&input).into_owned();
-        // The overlay v4/v6 candidates are dropped; relay + real underlay stay.
-        assert_eq!(kept, vec![relay, underlay, lan]);
-
-        // A candidate set with no overlay address is returned unchanged (borrowed).
-        let clean = vec![TransportAddr::Ip(
-            "51.15.139.151:41383".parse::<SocketAddr>().unwrap(),
-        )];
-        assert!(matches!(filter.apply(&clean), Cow::Borrowed(_)));
+    fn overlay_addr_filter_keeps_only_non_overlay() {
+        use std::net::IpAddr;
+        let keeps = |s: &str| OverlayAddrFilter.keeps(s.parse::<IpAddr>().unwrap());
+        // Real underlay / LAN addresses are kept.
+        assert!(keeps("51.15.139.151"));
+        assert!(keeps("192.168.1.104"));
+        // Overlay v4 (100.64.0.0/10) and v6 (200::/7) are dropped.
+        assert!(!keeps("100.124.253.88"));
+        assert!(!keeps("200::1"));
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -10,7 +10,7 @@ use iroh::{
     address_lookup::{AddrFilter, PkarrPublisher, PkarrResolver},
     endpoint::Connection,
     endpoint::presets,
-    endpoint::{Builder, QuicTransportConfig},
+    endpoint::{Builder, DirectAddrFilter, QuicTransportConfig},
 };
 use std::borrow::Cow;
 
@@ -142,7 +142,15 @@ async fn bind_endpoint(
         .transport_config(quic_transport_config())
         // Keep rayfish overlay addresses out of the transport candidates we
         // advertise (see `overlay_stripping_filter`).
-        .addr_filter(overlay_stripping_filter());
+        .addr_filter(overlay_stripping_filter())
+        // The definitive fix: drop overlay addresses from the *gathered* local
+        // interface candidates, so a mesh IP bound on the TUN is never stored,
+        // published, or offered as a holepunch / NAT-traversal candidate (and so
+        // never dialed by a peer, which would loop the underlay back through the
+        // tunnel). This covers the in-band NAT-traversal path that `addr_filter`
+        // (publish-only) cannot reach. Stays bound to `0.0.0.0`, so multi-homing /
+        // roaming is unaffected.
+        .direct_addr_filter(OverlayAddrFilter);
 
     // Override the N0 preset's relay / discovery defaults when configured.
     if let Some(mode) = build_relay_mode(relay)? {
@@ -172,13 +180,26 @@ async fn bind_endpoint(
     builder.bind().await.context("failed to bind iroh endpoint")
 }
 
+/// A [`DirectAddrFilter`] that drops rayfish overlay addresses (`100.64.0.0/10`,
+/// `200::/7`) from iroh's gathered local-interface candidates. The mesh IP is bound
+/// on the TUN device; without this iroh would discover it, advertise it (pkarr/DNS
+/// **and** in-band NAT-traversal), and peers would dial it, looping the underlay
+/// back through the tunnel we carry. This filters the candidate set at the source,
+/// so the overlay IP is never stored, published, or holepunched.
+#[derive(Debug)]
+struct OverlayAddrFilter;
+
+impl DirectAddrFilter for OverlayAddrFilter {
+    fn keeps(&self, ip: std::net::IpAddr) -> bool {
+        !crate::membership::is_overlay_ip(ip)
+    }
+}
+
 /// An [`AddrFilter`] that strips rayfish overlay addresses (`100.64.0.0/10`,
-/// `200::/7`) from the transport candidates iroh publishes for this node. The mesh
-/// IP is bound on the TUN interface, so without this filter iroh discovers it as a
-/// local direct address and advertises it via pkarr/DNS; peers then try to reach
-/// us *through the tunnel we carry*, a self-looping path that flaps open/closed and
-/// (before the coordinator's kick-vs-leave fix) could cascade into spurious roster
-/// evictions. Relay and custom (Tor) addresses pass through untouched.
+/// `200::/7`) from the transport candidates iroh publishes for this node. Kept as
+/// defense in depth alongside [`OverlayAddrFilter`], which already removes overlay
+/// IPs from the gathered candidate set (so they never reach the publish path).
+/// Relay and custom (Tor) addresses pass through untouched.
 fn overlay_stripping_filter() -> AddrFilter {
     fn is_overlay(a: &TransportAddr) -> bool {
         matches!(a, TransportAddr::Ip(s) if crate::membership::is_overlay_ip(s.ip()))


### PR DESCRIPTION
## What this does

Keeps rayfish overlay addresses (`100.64.0.0/10`, `200::/7`) out of iroh's direct
address candidates, using iroh's new `Builder::direct_addr_filter`.

## Why

The overlay IP is bound on the TUN device, so iroh enumerated it and advertised it
as a reachable address. Peers then dialed it, routing the underlay back into the
tunnel: a self-looping path that flapped and fell back to relay latency (seen as a
same-LAN peer sitting at ~90ms instead of ~4ms). The existing `addr_filter` only
strips published addresses, not the ones used for in-band NAT-traversal, so it did
not fully stop this. The new filter drops the address from the candidate set
itself, while the endpoint stays bound to `0.0.0.0` so roaming is unaffected.

Depends on the iroh API added in n0-computer/iroh#4397; iroh is pinned to the
`rayfish/iroh#direct-addr-filter` fork until it lands upstream.

## How it was tested

```
cargo -q build
cargo -q test
cargo -q clippy
```

All pass. Live deploy to two same-LAN peers to confirm the overlay paths stop
appearing is still pending.

## Checklist

- [x] Title is a conventional commit subject.
- [x] `cargo -q build`, `cargo -q test`, and `cargo -q clippy` pass.
- [ ] Docs updated (`README.md` / `CLAUDE.md`) if behavior changed.
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` if the change is user-visible.
- [ ] Bumped the relevant ALPN version if a wire protocol changed incompatibly.
