### PR TITLE
feat: on-demand mesh connections with idle teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **On-demand mesh connections (near-zero idle battery).** Nodes now connect to a
+  peer lazily, on the first packet that needs it, instead of dialing every roster
+  member at startup and holding those connections for the whole session. A
+  connection with no traffic for the idle timeout (default 120s) is closed, so an
+  idle node keeps zero peer connections and stops waking the radio for QUIC
+  keepalives. The link re-forms automatically on the next packet either side sends.
+  This is on by default; set `on_demand = false` in `settings.toml` to keep the old
+  eager-connect behavior, and `idle_timeout_secs` tunes the teardown window.
+- **`ray config` now covers the `auto-update` and `on-demand` toggles.** Both
+  on/off daemon settings are settable through the standard config surface (e.g.
+  `ray config set on-demand off`, `ray config set auto-update on`,
+  `ray config unset on-demand`), and bare `ray config` lists their current value
+  alongside relay/discovery-dns/dns-upstreams. `ray auto-update on|off` still works
+  as a shorthand.
+- **`ray status` shows peers as idle, active, or offline.** With on-demand
+  connections a reachable peer usually has no live link, so status now renders three
+  states (Tailscale-style): `active` (connected now), `idle` (a roster member with
+  no current link, presumed reachable), and `offline` (only after an actual reach
+  attempt failed). `ray ping <peer>` dials on demand and refreshes a peer's state.
+
 - **Static musl Linux binaries.** Every release and nightly now also ships
   `ray-linux-{x86_64,aarch64}-musl`: fully static builds with no glibc dependency
   that run on any Linux, including musl distros (Alpine) and hosts with a glibc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,14 +33,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **On-demand mesh connections (near-zero idle battery).** A node connects to a
-  peer lazily, on the first packet that needs it, instead of dialing every roster
-  member at startup and holding those connections for the whole session. A
-  connection with no traffic for the idle timeout (default 120s) is closed, so an
-  idle node keeps zero peer connections and stops waking the radio for QUIC
-  keepalives; the link re-forms on the next packet either side sends. On by default;
-  turn it off with `ray config set on-demand off` (and `idle_timeout_secs` tunes the
-  window).
+- **On-demand mesh connections (near-zero idle battery).** A node connects to its
+  peers at startup (so it knows immediately who is reachable), then closes any
+  connection that sees no traffic in either direction for the idle timeout (default
+  120s), returning to zero peer connections so it stops waking the radio for QUIC
+  keepalives. The link re-forms on the next packet either side sends. Idle teardown
+  coexists with older peers: a node only closes an idle link to a peer whose build
+  also understands the idle close, so a peer on an earlier release is held open
+  instead of flapped. On by default; turn it off with `ray config set on-demand off`
+  (and `idle_timeout_secs` tunes the window).
 - **`ray config` now covers the `auto-update` and `on-demand` toggles.** Both
   on/off daemon settings are settable through the standard config surface (e.g.
   `ray config set on-demand off`, `ray config set auto-update on`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Desktop data plane no longer wedges after an on-demand dial.** The desktop TUN
+  read grew the packet pool before its `await` and truncated after, so when
+  `run_mesh` cancelled the read (which it does the moment a lazy dial completes) the
+  pool kept stray bytes. Every subsequent packet was then read at the wrong offset
+  and parsed as garbage, silently killing all forwarding and Magic DNS until a
+  restart. The read is now cancel-safe (reads into an owned buffer, commits to the
+  pool only after the read returns).
+
 - **Android: disabling the VPN now fully tears the tunnel down.** Turning the
   tunnel off dropped the mesh connection but left the VPN interface up (the key
   icon stayed and the `tun` device lingered), because the offline path closed the
@@ -25,15 +33,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **On-demand mesh connections (near-zero idle battery), opt-in.** When enabled, a
-  node connects to a peer lazily, on the first packet that needs it, instead of
-  dialing every roster member at startup and holding those connections for the whole
-  session. A connection with no traffic for the idle timeout (default 120s) is
-  closed, so an idle node keeps zero peer connections and stops waking the radio for
-  QUIC keepalives; the link re-forms on the next packet either side sends. **Off by
-  default** (`ray config set on-demand on` to enable, `idle_timeout_secs` tunes the
-  window): idle teardown only holds when every peer honors the idle close, so a
-  mixed fleet would otherwise flap the link. The mobile app enables it automatically.
+- **On-demand mesh connections (near-zero idle battery).** A node connects to a
+  peer lazily, on the first packet that needs it, instead of dialing every roster
+  member at startup and holding those connections for the whole session. A
+  connection with no traffic for the idle timeout (default 120s) is closed, so an
+  idle node keeps zero peer connections and stops waking the radio for QUIC
+  keepalives; the link re-forms on the next packet either side sends. On by default;
+  turn it off with `ray config set on-demand off` (and `idle_timeout_secs` tunes the
+  window).
 - **`ray config` now covers the `auto-update` and `on-demand` toggles.** Both
   on/off daemon settings are settable through the standard config surface (e.g.
   `ray config set on-demand off`, `ray config set auto-update on`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **On-demand mesh connections (near-zero idle battery).** Nodes now connect to a
-  peer lazily, on the first packet that needs it, instead of dialing every roster
-  member at startup and holding those connections for the whole session. A
-  connection with no traffic for the idle timeout (default 120s) is closed, so an
-  idle node keeps zero peer connections and stops waking the radio for QUIC
-  keepalives. The link re-forms automatically on the next packet either side sends.
-  This is on by default; set `on_demand = false` in `settings.toml` to keep the old
-  eager-connect behavior, and `idle_timeout_secs` tunes the teardown window.
+- **On-demand mesh connections (near-zero idle battery), opt-in.** When enabled, a
+  node connects to a peer lazily, on the first packet that needs it, instead of
+  dialing every roster member at startup and holding those connections for the whole
+  session. A connection with no traffic for the idle timeout (default 120s) is
+  closed, so an idle node keeps zero peer connections and stops waking the radio for
+  QUIC keepalives; the link re-forms on the next packet either side sends. **Off by
+  default** (`ray config set on-demand on` to enable, `idle_timeout_secs` tunes the
+  window): idle teardown only holds when every peer honors the idle close, so a
+  mixed fleet would otherwise flap the link. The mobile app enables it automatically.
 - **`ray config` now covers the `auto-update` and `on-demand` toggles.** Both
   on/off daemon settings are settable through the standard config surface (e.g.
   `ray config set on-demand off`, `ray config set auto-update on`,

--- a/ray-mobile/src/lib.rs
+++ b/ray-mobile/src/lib.rs
@@ -366,7 +366,7 @@ impl Node {
 
         let state = self
             .runtime
-            .block_on(build_headless())
+            .block_on(build_headless(true))
             .map_err(RayError::network)?;
 
         // Commit under the lock, re-checking for a racing `start` that won while

--- a/ray-proto/src/ipc.rs
+++ b/ray-proto/src/ipc.rs
@@ -639,6 +639,26 @@ pub struct PeerStatus {
     #[serde(default)]
     pub incompatible: bool,
     pub connection: Option<ConnectionInfo>,
+    /// Coarse liveness for the three-state display (Tailscale-style). `Active`
+    /// when a live connection exists; `Offline` only after an actual reach attempt
+    /// failed and no later success cleared it; `Idle` otherwise (a known roster
+    /// member we simply have no live link to). On-demand nodes hold no connections
+    /// when idle, so a bare `connection.is_none()` must read as `Idle`, not offline.
+    #[serde(default)]
+    pub state: PeerState,
+}
+
+/// Three-state peer liveness for `ray status`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, derive_more::IsVariant)]
+pub enum PeerState {
+    /// A live mesh connection to the peer exists right now.
+    Active,
+    /// No live connection, but no failed reach either: presumed reachable (dialed
+    /// lazily on demand). The optimistic default for a freshly booted node.
+    #[default]
+    Idle,
+    /// A recent reach attempt failed and wasn't cleared by a later success.
+    Offline,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1015,6 +1035,7 @@ mod tests {
                     is_own_device: false,
                     incompatible: false,
                     connection: None,
+                    state: PeerState::Idle,
                 }],
                 pending_suggestions: 0,
                 pending_requests: 0,

--- a/src/cli/firewall.rs
+++ b/src/cli/firewall.rs
@@ -862,6 +862,7 @@ mod tests {
             is_own_device: false,
             incompatible: false,
             connection: None,
+            state: ipc::PeerState::Idle,
         }
     }
 

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -273,8 +273,10 @@ fn print_network(net: &ipc::NetworkStatus) {
     // Just the hostname: the network name is already the block header, so the
     // `.{network}.ray` suffix would only repeat it.
     let dns_name = net.my_hostname.clone();
-    // member count (self excluded) belongs on the network header row
-    let online = net.peers.iter().filter(|p| p.connection.is_some()).count();
+    // member count (self excluded) belongs on the network header row. Reachable =
+    // active + idle (everything not confirmed offline); on-demand nodes hold no
+    // connections when idle, so counting only live connections would read "0/N".
+    let reachable = net.peers.iter().filter(|p| !p.state.is_offline()).count();
     println!();
     print!("  {}  {}", style::bold(&net.name), style::marker(&role));
     if let Some(ref dns) = dns_name {
@@ -284,7 +286,7 @@ fn print_network(net: &ipc::NetworkStatus) {
     print!(
         "   {} {}",
         style::label("members"),
-        style::value(&format!("{online}/{}", net.peers.len())),
+        style::value(&format!("{reachable}/{}", net.peers.len())),
     );
     if let Some(ttl) = net.ephemeral_ttl_secs {
         print!(
@@ -448,21 +450,34 @@ fn user_parent_row(
     devices: &[&ipc::PeerStatus],
     alias_by_identity: &HashMap<&str, &str>,
 ) -> Vec<layout::Cell> {
-    let online = devices.iter().filter(|d| d.connection.is_some()).count();
-    let any_online = online > 0;
+    let active = devices
+        .iter()
+        .filter(|d| d.state.is_active())
+        .count();
+    let reachable = devices
+        .iter()
+        .filter(|d| !d.state.is_offline())
+        .count();
     let name = user_display_name(net, uid, devices, alias_by_identity);
-    let (glyph_plain, glyph_styled) = if any_online {
+    // Glyph rolls up the group: any active device is online, else any idle device
+    // is idle (presumed reachable), else offline.
+    let (glyph_plain, glyph_styled) = if active > 0 {
         ("●", style::dot_online())
+    } else if reachable > 0 {
+        ("●", style::dot_idle())
     } else {
         ("○", style::dot_offline())
     };
     let name_plain = format!("{glyph_plain} {name}");
     let name_styled = format!("{glyph_styled} {}", style::value(&name));
     let n = devices.len();
-    let rollup = format!(
-        "{n} device{}, {online} online",
-        if n == 1 { "" } else { "s" }
-    );
+    // Show connected devices when any, else the reachable (idle) count so an
+    // all-idle group doesn't read as "0 online".
+    let rollup = if active > 0 || reachable == 0 {
+        format!("{n} device{}, {active} online", if n == 1 { "" } else { "s" })
+    } else {
+        format!("{n} device{}, {reachable} idle", if n == 1 { "" } else { "s" })
+    };
     vec![
         layout::Cell::new(name_plain, name_styled),
         layout::Cell::new(rollup.clone(), style::faint(&rollup)),
@@ -517,13 +532,18 @@ fn device_row(
         Some(a) => format!("{base} [{a}]"),
         None => base,
     };
-    let online = peer.connection.is_some();
-    let (glyph_plain, glyph_styled) = if online {
-        ("●", style::dot_online())
-    } else {
-        ("○", style::dot_offline())
+    let (glyph_plain, glyph_styled) = match peer.state {
+        ipc::PeerState::Active => ("●", style::dot_online()),
+        ipc::PeerState::Idle => ("●", style::dot_idle()),
+        ipc::PeerState::Offline => ("○", style::dot_offline()),
     };
-    let host_style: fn(&str) -> String = if online { style::value } else { style::faint };
+    // Active + idle peers get bright names (idle is presumed reachable); only a
+    // confirmed-offline peer is faded.
+    let host_style: fn(&str) -> String = if peer.state.is_offline() {
+        style::faint
+    } else {
+        style::value
+    };
     // Merge branch + glyph + host into the first cell so the branch sits before
     // the glyph and the columns after it (ip, via, …) still align across all rows.
     let name = layout::Cell::new(
@@ -566,13 +586,22 @@ fn device_row(
             layout::Cell::right("incompatible", style::red("incompatible")),
             layout::Cell::new("ray update", style::faint("ray update")),
         ],
-        None => vec![
-            name,
-            ip,
-            layout::Cell::new("—", style::faint("—")),
-            layout::Cell::right("offline", style::faint("offline")),
-            layout::Cell::plain(""),
-        ],
+        // No live connection: idle (presumed reachable, dialed on demand) vs a
+        // confirmed-offline peer whose last reach failed.
+        None => {
+            let (label_plain, label_styled) = if peer.state.is_idle() {
+                ("idle", style::faint("idle"))
+            } else {
+                ("offline", style::faint("offline"))
+            };
+            vec![
+                name,
+                ip,
+                layout::Cell::new("—", style::faint("—")),
+                layout::Cell::right(label_plain, label_styled),
+                layout::Cell::plain(""),
+            ]
+        }
     }
 }
 
@@ -758,6 +787,14 @@ mod grouping_tests {
             is_own_device: own,
             incompatible,
             connection: online.then(conn),
+            // Mirror the daemon's derivation so the render tests see realistic state.
+            state: if online {
+                ipc::PeerState::Active
+            } else if incompatible {
+                ipc::PeerState::Offline
+            } else {
+                ipc::PeerState::Idle
+            },
         }
     }
 
@@ -823,6 +860,7 @@ mod grouping_tests {
             is_own_device: false,
             incompatible: false,
             connection: Some(conn()),
+            state: ipc::PeerState::Active,
         };
         let secondary = peer("sm-f966b", Some(dario), false, false, false);
         let net = net("umbrel", vec![primary, secondary]);

--- a/src/config.rs
+++ b/src/config.rs
@@ -336,7 +336,7 @@ pub fn config_set(cfg: &mut AppConfig, key: &str, value: &str, replace: bool) ->
         // On/off toggles: `set <key> on|off`, or `unset <key>` (empty value) to
         // return to the default. `--replace` is meaningless here and ignored.
         "auto-update" => cfg.auto_update = parse_bool_setting(value, false)?,
-        "on-demand" => cfg.on_demand = parse_bool_setting(value, true)?,
+        "on-demand" => cfg.on_demand = parse_bool_setting(value, false)?,
         other => anyhow::bail!("unknown config key: {other} ({CONFIG_KEYS})"),
     }
     Ok(())
@@ -441,10 +441,14 @@ pub struct AppConfig {
     /// On-demand connection mode (battery-minimizing, Tailscale-style). When on,
     /// the node does not eagerly dial peers at startup: it restores memberships and
     /// the roster locally, dials a peer lazily on the first outgoing packet that
-    /// needs it, and tears down connections idle past [`idle_timeout_secs`]. **On
-    /// by default**; a latency-sensitive server or always-push coordinator can turn
-    /// it off (`ray config set on-demand off`) to stay eagerly connected.
-    #[serde(default = "default_true")]
+    /// needs it, and tears down connections idle past [`idle_timeout_secs`].
+    ///
+    /// **Off by default** (opt-in): idle teardown only holds if *every* peer honors
+    /// the idle close and declines to reconnect, so a mixed fleet (or a peer that
+    /// keeps re-dialing) flaps the link and churns the relay. Battery-constrained
+    /// nodes turn it on explicitly (`ray config set on-demand on`); the mobile
+    /// embedder forces it on regardless of this default.
+    #[serde(default)]
     pub on_demand: bool,
     /// Seconds of no traffic before an on-demand node closes a peer connection.
     /// `None` uses [`DEFAULT_IDLE_TIMEOUT_SECS`]. Only consulted when `on_demand`.
@@ -503,7 +507,7 @@ impl Default for AppConfig {
             discovery_dns: ServerOverride::default(),
             dns_upstreams: ServerOverride::default(),
             ssh_enabled: false,
-            on_demand: true,
+            on_demand: false,
             idle_timeout_secs: None,
             auto_update: false,
             auto_update_last_target: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -336,7 +336,7 @@ pub fn config_set(cfg: &mut AppConfig, key: &str, value: &str, replace: bool) ->
         // On/off toggles: `set <key> on|off`, or `unset <key>` (empty value) to
         // return to the default. `--replace` is meaningless here and ignored.
         "auto-update" => cfg.auto_update = parse_bool_setting(value, false)?,
-        "on-demand" => cfg.on_demand = parse_bool_setting(value, false)?,
+        "on-demand" => cfg.on_demand = parse_bool_setting(value, true)?,
         other => anyhow::bail!("unknown config key: {other} ({CONFIG_KEYS})"),
     }
     Ok(())
@@ -443,12 +443,9 @@ pub struct AppConfig {
     /// the roster locally, dials a peer lazily on the first outgoing packet that
     /// needs it, and tears down connections idle past [`idle_timeout_secs`].
     ///
-    /// **Off by default** (opt-in): idle teardown only holds if *every* peer honors
-    /// the idle close and declines to reconnect, so a mixed fleet (or a peer that
-    /// keeps re-dialing) flaps the link and churns the relay. Battery-constrained
-    /// nodes turn it on explicitly (`ray config set on-demand on`); the mobile
-    /// embedder forces it on regardless of this default.
-    #[serde(default)]
+    /// On by default; a latency-sensitive server or always-push coordinator can turn
+    /// it off (`ray config set on-demand off`) to stay eagerly connected.
+    #[serde(default = "default_true")]
     pub on_demand: bool,
     /// Seconds of no traffic before an on-demand node closes a peer connection.
     /// `None` uses [`DEFAULT_IDLE_TIMEOUT_SECS`]. Only consulted when `on_demand`.
@@ -507,7 +504,7 @@ impl Default for AppConfig {
             discovery_dns: ServerOverride::default(),
             dns_upstreams: ServerOverride::default(),
             ssh_enabled: false,
-            on_demand: false,
+            on_demand: true,
             idle_timeout_secs: None,
             auto_update: false,
             auto_update_last_target: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use std::fs::Permissions;
 use std::net::Ipv4Addr;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use iroh::{EndpointId, SecretKey};
@@ -213,6 +214,10 @@ pub const RELAY_PRESET_RAYFISH: &str = "http://relay.iroh.rayfish.xyz:3340";
 /// Preset URL for the rayfish-operated discovery-DNS / pkarr server.
 pub const DISCOVERY_PRESET_RAYFISH: &str = "http://dns.iroh.rayfish.xyz:8080";
 
+/// Default idle timeout for on-demand nodes: no data-plane or control traffic for
+/// this long closes a peer connection so the node returns to zero connections.
+pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 120;
+
 fn validate_http_url(s: &str) -> Result<()> {
     let u = url::Url::parse(s).with_context(|| format!("invalid URL: {s}"))?;
     anyhow::ensure!(
@@ -278,6 +283,12 @@ fn parse_entries(value: &str) -> Vec<String> {
 /// Apply a `ray config set`/`unset` to the in-memory config. An empty value or
 /// the lone keyword `n0` resets the key to its default (iroh n0). Validates
 /// every entry, so a bad URL/IP or unknown preset is rejected before persist.
+/// The recognized `ray config` keys, for error messages. The list values
+/// (relay/discovery-dns/dns-upstreams) are set via `config set`; the on/off
+/// toggles (auto-update/on-demand) via their own `config` subcommands.
+const CONFIG_KEYS: &str =
+    "expected relay, discovery-dns, dns-upstreams, auto-update, or on-demand";
+
 pub fn config_set(cfg: &mut AppConfig, key: &str, value: &str, replace: bool) -> Result<()> {
     let entries = parse_entries(value);
     let reset = entries.is_empty() || entries == ["n0"];
@@ -322,11 +333,28 @@ pub fn config_set(cfg: &mut AppConfig, key: &str, value: &str, replace: bool) ->
                 };
             }
         }
-        other => anyhow::bail!(
-            "unknown config key: {other} (expected relay, discovery-dns, or dns-upstreams)"
-        ),
+        // On/off toggles: `set <key> on|off`, or `unset <key>` (empty value) to
+        // return to the default. `--replace` is meaningless here and ignored.
+        "auto-update" => cfg.auto_update = parse_bool_setting(value, false)?,
+        "on-demand" => cfg.on_demand = parse_bool_setting(value, true)?,
+        other => anyhow::bail!("unknown config key: {other} ({CONFIG_KEYS})"),
     }
     Ok(())
+}
+
+/// Parse an on/off config value. An empty value (from `config unset`) resets to
+/// `default`.
+fn parse_bool_setting(value: &str, default: bool) -> Result<bool> {
+    let v = value.trim();
+    if v.is_empty() {
+        return Ok(default);
+    }
+
+    match v.to_ascii_lowercase().as_str() {
+        "on" | "true" | "yes" | "1" => Ok(true),
+        "off" | "false" | "no" | "0" => Ok(false),
+        other => anyhow::bail!("'{other}' is not a valid on/off value (use 'on' or 'off')"),
+    }
 }
 
 fn render_override(o: &ServerOverride) -> String {
@@ -341,16 +369,17 @@ fn render_override(o: &ServerOverride) -> String {
 /// Render config settings as `(key, value)` rows for `ray config get`. With a
 /// key, returns just that one (error on unknown key); without, all three.
 pub fn config_get(cfg: &AppConfig, key: Option<&str>) -> Result<Vec<(String, String)>> {
+    let on_off = |v: bool| if v { "on" } else { "off" }.to_string();
     let row = |k: &str| -> Result<(String, String)> {
-        let o = match k {
-            "relay" => &cfg.relay,
-            "discovery-dns" => &cfg.discovery_dns,
-            "dns-upstreams" => &cfg.dns_upstreams,
-            other => anyhow::bail!(
-                "unknown config key: {other} (expected relay, discovery-dns, or dns-upstreams)"
-            ),
+        let v = match k {
+            "relay" => render_override(&cfg.relay),
+            "discovery-dns" => render_override(&cfg.discovery_dns),
+            "dns-upstreams" => render_override(&cfg.dns_upstreams),
+            "auto-update" => on_off(cfg.auto_update),
+            "on-demand" => on_off(cfg.on_demand),
+            other => anyhow::bail!("unknown config key: {other} ({CONFIG_KEYS})"),
         };
-        Ok((k.to_string(), render_override(o)))
+        Ok((k.to_string(), v))
     };
     match key {
         Some(k) => Ok(vec![row(k)?]),
@@ -358,6 +387,8 @@ pub fn config_get(cfg: &AppConfig, key: Option<&str>) -> Result<Vec<(String, Str
             row("relay")?,
             row("discovery-dns")?,
             row("dns-upstreams")?,
+            row("auto-update")?,
+            row("on-demand")?,
         ]),
     }
 }
@@ -407,6 +438,18 @@ pub struct AppConfig {
     /// authorized in a network's [`NetworkConfig::ssh_allow`] list. Off by default.
     #[serde(default)]
     pub ssh_enabled: bool,
+    /// On-demand connection mode (battery-minimizing, Tailscale-style). When on,
+    /// the node does not eagerly dial peers at startup: it restores memberships and
+    /// the roster locally, dials a peer lazily on the first outgoing packet that
+    /// needs it, and tears down connections idle past [`idle_timeout_secs`]. **On
+    /// by default**; a latency-sensitive server or always-push coordinator can turn
+    /// it off (`ray config set on-demand off`) to stay eagerly connected.
+    #[serde(default = "default_true")]
+    pub on_demand: bool,
+    /// Seconds of no traffic before an on-demand node closes a peer connection.
+    /// `None` uses [`DEFAULT_IDLE_TIMEOUT_SECS`]. Only consulted when `on_demand`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_secs: Option<u64>,
     /// Opt-in automatic updates: when on, the daemon periodically checks for a
     /// newer stable release, swaps the binary, and restarts itself onto it. Off
     /// by default; enable via `ray install --auto-update` or `ray auto-update on`.
@@ -460,6 +503,8 @@ impl Default for AppConfig {
             discovery_dns: ServerOverride::default(),
             dns_upstreams: ServerOverride::default(),
             ssh_enabled: false,
+            on_demand: true,
+            idle_timeout_secs: None,
             auto_update: false,
             auto_update_last_target: None,
             auto_update_last_attempt: None,
@@ -470,6 +515,14 @@ impl Default for AppConfig {
             cert_generation: 0,
             revoked_devices: Vec::new(),
         }
+    }
+}
+
+impl AppConfig {
+    /// Idle timeout for on-demand teardown, falling back to
+    /// [`DEFAULT_IDLE_TIMEOUT_SECS`] when unset.
+    pub fn idle_timeout(&self) -> Duration {
+        Duration::from_secs(self.idle_timeout_secs.unwrap_or(DEFAULT_IDLE_TIMEOUT_SECS))
     }
 }
 
@@ -549,6 +602,10 @@ struct Settings {
     dns_upstreams: ServerOverride,
     #[serde(default)]
     ssh_enabled: bool,
+    #[serde(default = "default_true")]
+    on_demand: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    idle_timeout_secs: Option<u64>,
     #[serde(default)]
     auto_update: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -838,6 +895,8 @@ fn load_in(dir: &Path) -> Result<AppConfig> {
         discovery_dns: settings.discovery_dns,
         dns_upstreams: settings.dns_upstreams,
         ssh_enabled: settings.ssh_enabled,
+        on_demand: settings.on_demand,
+        idle_timeout_secs: settings.idle_timeout_secs,
         auto_update: settings.auto_update,
         auto_update_last_target: settings.auto_update_last_target,
         auto_update_last_attempt: settings.auto_update_last_attempt,
@@ -865,6 +924,8 @@ fn save_settings_in(dir: &Path, config: &AppConfig) -> Result<()> {
         discovery_dns: config.discovery_dns.clone(),
         dns_upstreams: config.dns_upstreams.clone(),
         ssh_enabled: config.ssh_enabled,
+        on_demand: config.on_demand,
+        idle_timeout_secs: config.idle_timeout_secs,
         auto_update: config.auto_update,
         auto_update_last_target: config.auto_update_last_target.clone(),
         auto_update_last_attempt: config.auto_update_last_attempt,

--- a/src/control.rs
+++ b/src/control.rs
@@ -239,6 +239,13 @@ pub enum ControlMsg {
     /// network (its frame carries `net = None`).
     NetworkHandles {
         entries: Vec<NetworkHandle>,
+        /// The sender's capability bitmask (see [`transport::FEATURE_IDLE_CLOSE`]).
+        /// Rides the handle announcement because that is sent by *both* ends right
+        /// after connect (the `MeshHello` handshake is one-directional, dialer to
+        /// acceptor, so it cannot carry a bidirectional capability). `#[serde(default)]`
+        /// so a peer on a build without this field decodes to `0` (no capabilities).
+        #[serde(default)]
+        features: u64,
     },
     /// Primary to secondary: this device has been unpaired (`ray unpair`). Sent
     /// best-effort over a shared network's mesh connection. The receiver acts on
@@ -463,6 +470,38 @@ mod tests {
         let bytes = encode_msg(None, &msg);
         let decoded = decode_msg(&bytes).unwrap();
         assert_eq!(msg, decoded.msg);
+    }
+
+    #[test]
+    fn network_handles_missing_features_decodes_to_zero() {
+        // A v0.2.0 peer encodes NetworkHandles without the `features` field (it
+        // predates it). `#[serde(default)]` must decode that to `0` so we treat the
+        // peer as advertising no capabilities and never idle-close its link.
+        #[derive(serde::Serialize)]
+        enum LegacyMsg {
+            NetworkHandles { entries: Vec<NetworkHandle> },
+        }
+        #[derive(serde::Serialize)]
+        struct LegacyFrame {
+            msg: LegacyMsg,
+        }
+        let legacy = LegacyFrame {
+            msg: LegacyMsg::NetworkHandles {
+                entries: vec![NetworkHandle {
+                    network: test_id(2),
+                    handle: 1,
+                }],
+            },
+        };
+        let body = rmp_serde::to_vec_named(&legacy).unwrap();
+        let frame: ControlFrame = rmp_serde::from_slice(&body).unwrap();
+        match frame.msg {
+            ControlMsg::NetworkHandles { features, entries } => {
+                assert_eq!(features, 0);
+                assert_eq!(entries.len(), 1);
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
     }
 
     #[test]

--- a/src/daemon/mesh/bootstrap.rs
+++ b/src/daemon/mesh/bootstrap.rs
@@ -21,7 +21,9 @@ pub async fn run_daemon(token: CancellationToken, stats: Arc<ForwardMetrics>) ->
     // the desktop OS TUN device below. The headless builder is the same one
     // `build_headless()` exposes to embedders (mobile), so both paths share
     // identical construction.
-    let daemon = build_daemon(token.clone(), stats).await?;
+    // Desktop honors the persisted `on_demand` config (default off); the mobile
+    // embedder forces it on via `build_headless`.
+    let daemon = build_daemon(token.clone(), stats, None).await?;
 
     // Attach the real OS TUN device: create it, record its name, and spawn the
     // writer + `run_mesh` forwarding loop. On Android the packet interface is a
@@ -98,10 +100,10 @@ fn initial_alpns(_app_config: &config::AppConfig) -> Vec<Vec<u8>> {
 /// the OS TUN device and the Unix-socket IPC server: the caller supplies a
 /// packet interface via [`Daemon::attach_tun`]. The returned daemon is on
 /// standby (no data plane), with its saved networks' control plane connected.
-pub async fn build_headless() -> Result<Arc<Daemon>> {
+pub async fn build_headless(on_demand: bool) -> Result<Arc<Daemon>> {
     let token = CancellationToken::new();
     let stats = Arc::new(ForwardMetrics::default());
-    let daemon = build_daemon(token, stats).await?;
+    let daemon = build_daemon(token, stats, Some(on_demand)).await?;
     // Bring the saved networks' control plane up, matching `run_daemon`.
     daemon.registry.connect_all_networks().await;
     // Control readers and the join path now run their network ops (promotion,
@@ -117,7 +119,11 @@ pub async fn build_headless() -> Result<Arc<Daemon>> {
 /// receiver and metrics-server guard are stashed on the state for the caller.
 ///
 /// Shared by [`run_daemon`] (desktop) and [`build_headless`] (embedders).
-async fn build_daemon(token: CancellationToken, stats: Arc<ForwardMetrics>) -> Result<Arc<Daemon>> {
+async fn build_daemon(
+    token: CancellationToken,
+    stats: Arc<ForwardMetrics>,
+    on_demand_override: Option<bool>,
+) -> Result<Arc<Daemon>> {
     // Relocate a pre-/etc config tree into /etc/rayfish (Linux upgrade path)
     // before anything reads identity or config. No-op on macOS / once migrated.
     config::migrate_location();
@@ -142,6 +148,9 @@ async fn build_daemon(token: CancellationToken, stats: Arc<ForwardMetrics>) -> R
 
     // --- iroh endpoint (one ALPN per saved network + the blobs ALPN) ---
     let mut app_config = config::load()?;
+    // On-demand mode: the platform (mobile embedder) may force it; otherwise honor
+    // config (on by default). Computed here so it can thread into the registry.
+    let on_demand = on_demand_override.unwrap_or(app_config.on_demand);
     // Point the pkarr client at the configured discovery-DNS server (if any)
     // before any record publish/resolve happens.
     dht::set_discovery_override(&app_config.discovery_dns);
@@ -267,6 +276,7 @@ async fn build_daemon(token: CancellationToken, stats: Arc<ForwardMetrics>) -> R
         tun_tx.clone(),
         pruned_peers.clone(),
         disconnect_tx.clone(),
+        on_demand,
     ));
     // FileService owns file transfer + pairing. It evaluates own-device auto-accept
     // directly (no worker channel) and clears a re-paired device's nullifier by
@@ -307,6 +317,15 @@ async fn build_daemon(token: CancellationToken, stats: Arc<ForwardMetrics>) -> R
                 .run_connection_supervisor(disconnect_rx, token)
                 .await;
         });
+    }
+
+    // On-demand idle reaper: closes peer connections idle past the timeout so the
+    // node returns to zero connections (no keepalive radio) when there's no
+    // traffic. Only on on-demand nodes; the link re-forms lazily on the next packet.
+    if on_demand {
+        registry
+            .clone()
+            .spawn_idle_reaper(app_config.idle_timeout());
     }
 
     // Install the daemon-wide mesh dispatch context and spawn the protocol Router

--- a/src/daemon/mesh/bootstrap.rs
+++ b/src/daemon/mesh/bootstrap.rs
@@ -277,6 +277,7 @@ async fn build_daemon(
         pruned_peers.clone(),
         disconnect_tx.clone(),
         on_demand,
+        app_config.idle_timeout(),
     ));
     // FileService owns file transfer + pairing. It evaluates own-device auto-accept
     // directly (no worker channel) and clears a re-paired device's nullifier by
@@ -319,14 +320,9 @@ async fn build_daemon(
         });
     }
 
-    // On-demand idle reaper: closes peer connections idle past the timeout so the
-    // node returns to zero connections (no keepalive radio) when there's no
-    // traffic. Only on on-demand nodes; the link re-forms lazily on the next packet.
-    if on_demand {
-        registry
-            .clone()
-            .spawn_idle_reaper(app_config.idle_timeout());
-    }
+    // Idle teardown is per-connection now: each `MeshConnection` closes itself when
+    // it goes idle (see its run loop), gated on `on_demand` + the peer advertising
+    // support. No separate reaper task.
 
     // Install the daemon-wide mesh dispatch context and spawn the protocol Router
     // *before* building the Daemon. The dispatch is built from the registry (the

--- a/src/daemon/mesh/coordinator.rs
+++ b/src/daemon/mesh/coordinator.rs
@@ -89,9 +89,11 @@ impl NetworkRegistry {
                 })
                 .cloned()
                 .collect();
-            // On-demand nodes never eagerly re-dial: the link re-forms lazily on the
-            // next outgoing packet, so a bogus kick heals on demand instead.
-            if !self.on_demand && !reconnect_nets.is_empty() {
+            // A non-idle drop reconnects to heal even on on-demand nodes: we
+            // eager-connect the roster, and only an explicit idle close (handled
+            // above) is allowed to leave a peer disconnected. The idle timer will
+            // close the healed link again if it stays quiet.
+            if !reconnect_nets.is_empty() {
                 self.clone()
                     .spawn_reconnect(ev.endpoint_id, ev.ip, reconnect_nets);
             }
@@ -102,8 +104,9 @@ impl NetworkRegistry {
         // ephemeral pruner ages the member from when it actually went offline
         // (not its admit time), then reconnect across every shared network,
         // skipping any we just pruned this peer from (one-shot via pruned_peers).
-        // The `last_seen` stamp runs on every node (it feeds ephemeral aging); only
-        // the eager reconnect is suppressed on-demand (re-dial is lazy there).
+        // Reconnect runs on every node, on-demand included: a transient drop is a
+        // real link failure, not an idle teardown (which is handled above and never
+        // reconnects), so we heal it and let the idle timer close it again if quiet.
         let member_id = self.device_user_map.resolve(&ev.endpoint_id);
         let now = crate::membership::now_secs();
         for net in &nets {
@@ -115,9 +118,7 @@ impl NetworkRegistry {
             }
         }
 
-        if !self.on_demand {
-            self.spawn_reconnect(ev.endpoint_id, ev.ip, nets);
-        }
+        self.spawn_reconnect(ev.endpoint_id, ev.ip, nets);
     }
 
     /// Confirm a coordinator's `ControlMsg::KickedFromNetwork` against `network`'s

--- a/src/daemon/mesh/coordinator.rs
+++ b/src/daemon/mesh/coordinator.rs
@@ -358,6 +358,7 @@ impl NetworkRegistry {
                     self.peers.clear_incompatible(&peer_id);
                 }
                 tracing::debug!(peer = %peer_id.fmt_short(), error = %e, "dial attempt failed");
+                self.reachability.note_fail(peer_id);
                 return false;
             }
         };
@@ -386,6 +387,9 @@ impl NetworkRegistry {
                 .mesh_ctx()
                 .register_peer_conn(&conn, peer_id, peer_ip, &t.network);
         }
+        // A live connection now exists (either freshly stored, or already current
+        // when `conn_changed` is false), so the peer is reachable either way.
+        self.reachability.note_ok(peer_id);
         if !conn_changed {
             return false;
         }

--- a/src/daemon/mesh/coordinator.rs
+++ b/src/daemon/mesh/coordinator.rs
@@ -62,6 +62,13 @@ impl NetworkRegistry {
             }
             return;
         }
+
+        if matches!(ev.reason, forward::CloseReason::Idle) {
+            // The peer let an idle connection go (on-demand teardown). Never
+            // reconnect on any node; the link comes back lazily on the next packet.
+            return;
+        }
+
         if matches!(ev.reason, forward::CloseReason::Kicked) {
             // A kick-coded close is transport teardown, not authority: we never
             // evict the peer or leave a network on the close code. Membership is the
@@ -82,16 +89,21 @@ impl NetworkRegistry {
                 })
                 .cloned()
                 .collect();
-            if !reconnect_nets.is_empty() {
+            // On-demand nodes never eagerly re-dial: the link re-forms lazily on the
+            // next outgoing packet, so a bogus kick heals on demand instead.
+            if !self.on_demand && !reconnect_nets.is_empty() {
                 self.clone()
                     .spawn_reconnect(ev.endpoint_id, ev.ip, reconnect_nets);
             }
             return;
         }
+
         // Transient drop: stamp `last_seen` on each network we coordinate so the
         // ephemeral pruner ages the member from when it actually went offline
         // (not its admit time), then reconnect across every shared network,
         // skipping any we just pruned this peer from (one-shot via pruned_peers).
+        // The `last_seen` stamp runs on every node (it feeds ephemeral aging); only
+        // the eager reconnect is suppressed on-demand (re-dial is lazy there).
         let member_id = self.device_user_map.resolve(&ev.endpoint_id);
         let now = crate::membership::now_secs();
         for net in &nets {
@@ -102,7 +114,10 @@ impl NetworkRegistry {
                 m.last_seen = Some(now);
             }
         }
-        self.spawn_reconnect(ev.endpoint_id, ev.ip, nets);
+
+        if !self.on_demand {
+            self.spawn_reconnect(ev.endpoint_id, ev.ip, nets);
+        }
     }
 
     /// Confirm a coordinator's `ControlMsg::KickedFromNetwork` against `network`'s
@@ -310,6 +325,78 @@ impl NetworkRegistry {
         Ok(display)
     }
 
+    /// Dial a peer once (no backoff) over the mesh ALPN, send `MeshHello` on every
+    /// `target` network, register its route, and if the connection is newly stored
+    /// drive its control demux + announce handles. `targets` is one [`DialTarget`]
+    /// per shared network. Returns whether a live connection was established. Shared
+    /// by the reconnect loop and the on-demand lazy dialer.
+    pub(crate) async fn dial_peer_once(
+        self: &Arc<Self>,
+        peer_id: EndpointId,
+        peer_ip: Ipv4Addr,
+        targets: &[DialTarget],
+    ) -> bool {
+        let my_identity = self.transport.identity.local_identity();
+        let device_cert = self.current_device_cert();
+        let conn = match transport::connect_to_peer_with_alpn(
+            &self.transport.endpoint,
+            peer_id,
+            &transport::mesh_alpn(),
+        )
+        .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                // Flag an incompatible-version peer (ALPN gate) so `ray status`
+                // shows it instead of plain offline; a different failure can't be
+                // attributed to the version, so clear any prior flag. Success clears
+                // it in `PeerTable::add`.
+                if transport::is_alpn_mismatch(&format!("{e:#}")) {
+                    self.peers.mark_incompatible(peer_id);
+                } else {
+                    self.peers.clear_incompatible(&peer_id);
+                }
+                tracing::debug!(peer = %peer_id.fmt_short(), error = %e, "dial attempt failed");
+                return false;
+            }
+        };
+        // Announce ourselves on every still-shared network over the one connection
+        // and register the peer's route per network. `conn_changed` accumulates
+        // whether the connection became newly current (it always is for a fresh
+        // dial / reconnect), which gates driving its demux.
+        let mut conn_changed = false;
+        for t in targets {
+            let Ok((mut send, _)) = conn.open_bi().await else {
+                continue;
+            };
+            let hello = ControlMsg::MeshHello {
+                identity: my_identity,
+                ip: t.my_ip,
+                hostname: outgoing_hostname(&t.network),
+                device_cert: device_cert.clone(),
+            };
+            if control::send_msg(&mut send, Some(t.network_key), &hello)
+                .await
+                .is_err()
+            {
+                continue;
+            }
+            conn_changed |= self
+                .mesh_ctx()
+                .register_peer_conn(&conn, peer_id, peer_ip, &t.network);
+        }
+        if !conn_changed {
+            return false;
+        }
+        tracing::info!(peer = %peer_id.fmt_short(), ip = %peer_ip, "dialed peer");
+        // Drive the new connection's control demux + announce handles.
+        let router = self.protocol_router().clone();
+        let dconn = conn.clone();
+        tokio::spawn(router.drive_mesh_connection(dconn, true));
+        announce_network_handles(&self.peers, &conn, peer_ip).await;
+        true
+    }
+
     /// Reconnect a dropped peer with one dial that re-establishes every network we
     /// still share with it. Backs off exponentially; on success re-registers the
     /// peer per network and drives the new connection's control demux. Also used
@@ -343,8 +430,6 @@ impl NetworkRegistry {
 
         let this = self.clone();
         let token = self.shutdown_token.clone();
-        let my_identity = self.transport.identity.local_identity();
-        let device_cert = self.current_device_cert();
         use tracing::Instrument as _;
         let span = tracing::info_span!("reconnect", peer = %peer_id.fmt_short());
         tokio::spawn(
@@ -366,12 +451,14 @@ impl NetworkRegistry {
                     // Re-resolve the live network handles each iteration: on cold
                     // restore the `NetworkHandle` is inserted just after the dial
                     // was scheduled, so it may be absent on the first pass.
-                    let targets: Vec<(String, EndpointId, Ipv4Addr)> = candidate_nets
+                    let targets: Vec<DialTarget> = candidate_nets
                         .iter()
                         .filter_map(|net| {
-                            this.networks
-                                .get(net.as_str())
-                                .map(|h| (net.to_string(), h.network_key, h.my_ip))
+                            this.networks.get(net.as_str()).map(|h| DialTarget {
+                                network: net.to_string(),
+                                network_key: h.network_key,
+                                my_ip: h.my_ip,
+                            })
                         })
                         .collect();
                     if targets.is_empty() {
@@ -382,62 +469,10 @@ impl NetworkRegistry {
                         continue;
                     }
 
-                    let conn = match transport::connect_to_peer_with_alpn(
-                        &this.transport.endpoint,
-                        peer_id,
-                        &transport::mesh_alpn(),
-                    )
-                    .await
-                    {
-                        Ok(c) => c,
-                        Err(e) => {
-                            // Flag an incompatible-version peer (ALPN gate) so
-                            // `ray status` shows it instead of plain offline; a
-                            // different failure means we can't attribute it to the
-                            // version, so clear any prior flag. Success clears it in
-                            // `PeerTable::add`.
-                            if transport::is_alpn_mismatch(&format!("{e:#}")) {
-                                this.peers.mark_incompatible(peer_id);
-                            } else {
-                                this.peers.clear_incompatible(&peer_id);
-                            }
-                            tracing::debug!(error = %e, "reconnect attempt failed");
-                            continue;
-                        }
-                    };
-                    // Announce ourselves on every still-shared network over the one
-                    // connection, and register the peer's route per network.
-                    let mut any = false;
-                    for (name, net_pubkey, my_ip) in &targets {
-                        let Ok((mut send, _)) = conn.open_bi().await else {
-                            continue;
-                        };
-                        let hello = ControlMsg::MeshHello {
-                            identity: my_identity,
-                            ip: *my_ip,
-                            hostname: outgoing_hostname(name),
-                            device_cert: device_cert.clone(),
-                        };
-                        if control::send_msg(&mut send, Some(*net_pubkey), &hello)
-                            .await
-                            .is_err()
-                        {
-                            continue;
-                        }
-                        this.mesh_ctx()
-                            .register_peer_conn(&conn, peer_id, peer_ip, name);
-                        any = true;
+                    if this.dial_peer_once(peer_id, peer_ip, &targets).await {
+                        return;
                     }
-                    if !any {
-                        continue;
-                    }
-                    tracing::info!(peer = %peer_id.fmt_short(), ip = %peer_ip, "reconnected to peer");
-                    // Drive the new connection's control demux + announce handles.
-                    let router = this.protocol_router().clone();
-                    let dconn = conn.clone();
-                    tokio::spawn(async move { router.drive_mesh_connection(dconn, true).await });
-                    announce_network_handles(&this.peers, &conn, peer_ip).await;
-                    return;
+                    // Dial failed; back off and retry.
                 }
             }
             .instrument(span),

--- a/src/daemon/mesh/create_join.rs
+++ b/src/daemon/mesh/create_join.rs
@@ -499,6 +499,24 @@ impl NetworkRegistry {
             Arc::new(std::sync::RwLock::new(ns))
         };
 
+        // On-demand: don't dial the coordinator (or spawn reconnect loops) at
+        // startup. We already hold the verified blob, so register the network from
+        // it and seed the route map; the coordinator and every peer are dialed
+        // lazily on the first outgoing packet, and control updates land on the 60s
+        // reconverge poll.
+        if self.on_demand {
+            self.seed_route_map(ctx.display_name, &data.members);
+            tracing::info!(
+                network = %ctx.display_name,
+                "on-demand: registered from blob without dialing (lazy connect)"
+            );
+            return Ok(Some(EstablishedMesh {
+                state: state_from_blob(),
+                cancel,
+                tasks,
+            }));
+        }
+
         tracing::info!(coordinator = %coordinator_id.fmt_short(), "connecting to coordinator");
         let mut seed_from_blob = false;
         let state = match transport::connect_to_peer_with_alpn(

--- a/src/daemon/mesh/create_join.rs
+++ b/src/daemon/mesh/create_join.rs
@@ -499,23 +499,10 @@ impl NetworkRegistry {
             Arc::new(std::sync::RwLock::new(ns))
         };
 
-        // On-demand: don't dial the coordinator (or spawn reconnect loops) at
-        // startup. We already hold the verified blob, so register the network from
-        // it and seed the route map; the coordinator and every peer are dialed
-        // lazily on the first outgoing packet, and control updates land on the 60s
-        // reconverge poll.
-        if self.on_demand {
-            self.seed_route_map(ctx.display_name, &data.members);
-            tracing::info!(
-                network = %ctx.display_name,
-                "on-demand: registered from blob without dialing (lazy connect)"
-            );
-            return Ok(Some(EstablishedMesh {
-                state: state_from_blob(),
-                cancel,
-                tasks,
-            }));
-        }
+        // Seed the route map from the verified blob so the data path can re-dial the
+        // coordinator or any member that has since been idle-closed, before the first
+        // reconverge poll populates it.
+        self.seed_route_map(ctx.display_name, &data.members);
 
         tracing::info!(coordinator = %coordinator_id.fmt_short(), "connecting to coordinator");
         let mut seed_from_blob = false;
@@ -933,6 +920,9 @@ impl NetworkRegistry {
                         );
                     }
                     announce_network_handles(&self.peers, &peer_conn, m.ip).await;
+                    // Eager-connect reachability: a successful dial marks the peer
+                    // reachable so `ray status` shows it active/idle, not offline.
+                    self.reachability.note_ok(m.identity);
                     tracing::info!(
                         network = %network_name,
                         peer = %m.identity.fmt_short(),
@@ -949,6 +939,9 @@ impl NetworkRegistry {
                     } else {
                         self.peers.clear_incompatible(&m.identity);
                     }
+                    // Record the failed reach so status shows the peer offline from
+                    // startup, not optimistically idle.
+                    self.reachability.note_fail(m.identity);
                     tracing::debug!(
                         network = %network_name,
                         peer = %m.identity.fmt_short(),
@@ -957,6 +950,7 @@ impl NetworkRegistry {
                     );
                 }
                 Err(_elapsed) => {
+                    self.reachability.note_fail(m.identity);
                     tracing::debug!(
                         network = %network_name,
                         peer = %m.identity.fmt_short(),

--- a/src/daemon/mesh/diagnostics.rs
+++ b/src/daemon/mesh/diagnostics.rs
@@ -1,7 +1,14 @@
 //! Read-only diagnostics for `Daemon`: `status`, `build_report`, `ping`,
 //! `netcheck`, and connection-info helpers. Split out of `daemon/mod.rs`.
 
+use std::net::IpAddr;
+
 use super::super::*;
+
+/// How recent a failed reach must be to render a peer `Offline` in `ray status`.
+/// Older failures decay back to `Idle` (the optimistic default) so a peer that was
+/// briefly unreachable doesn't stay flagged offline forever without a re-probe.
+const STATUS_OFFLINE_WINDOW: Duration = Duration::from_secs(300);
 
 impl Daemon {
     /// Part of the embedding API (used by `ray-mobile` and future embedders):
@@ -155,6 +162,22 @@ impl Daemon {
                     // definition, and `add` clears the flag on connect anyway.
                     incompatible: connection.is_none()
                         && self.registry.peers.is_incompatible(&m.identity),
+                    // Three-state liveness: a live connection is Active; otherwise a
+                    // recently-failed reach (or an incompatible version) is Offline;
+                    // anything else is Idle (a roster member we just have no live link
+                    // to). A fresh boot with no dial attempts shows every peer Idle.
+                    state: if connection.is_some() {
+                        PeerState::Active
+                    } else if self.registry.peers.is_incompatible(&m.identity)
+                        || self
+                            .registry
+                            .reachability
+                            .is_offline(&m.identity, STATUS_OFFLINE_WINDOW)
+                    {
+                        PeerState::Offline
+                    } else {
+                        PeerState::Idle
+                    },
                     connection,
                 }
             })
@@ -375,9 +398,23 @@ impl Daemon {
         let route = match self.registry.peers.lookup_v4(&ip) {
             Some(r) => r,
             None => {
-                return ipc_err(format!(
-                    "{display} is not connected (no live mesh link to {ip})"
-                ));
+                // No live link (an on-demand idle peer holds none): dial it on
+                // demand so ping works like a reach probe, then re-look up.
+                // `dial_target` stamps reachability, so a failure here also flips
+                // the peer's status to offline.
+                match self.registry.resolve_route(IpAddr::V4(ip)) {
+                    Some(target) if self.registry.dial_target(&target).await => {
+                        match self.registry.peers.lookup_v4(&ip) {
+                            Some(r) => r,
+                            None => {
+                                return ipc_err(format!("{display}: dialed but no route to {ip}"));
+                            }
+                        }
+                    }
+                    _ => {
+                        return ipc_err(format!("{display} is unreachable (no answer at {ip})"));
+                    }
+                }
             }
         };
         let conn = route.conn;

--- a/src/daemon/mesh/reconverge.rs
+++ b/src/daemon/mesh/reconverge.rs
@@ -3,6 +3,8 @@
 //! to DNS and re-materialize suggested firewall rules. The 60s group poller and
 //! the peer-cleanup-adjacent helpers that drive reconvergence live here.
 
+use std::net::Ipv6Addr;
+
 use super::super::*;
 
 /// Materialize this node's suggested firewall rules for `network` from the
@@ -159,6 +161,7 @@ pub(crate) async fn reconverge_and_apply(
         reverse_table,
         device_user_map,
         pruned_peers,
+        route_map,
         registry,
         ..
     } = ctx;
@@ -246,6 +249,7 @@ pub(crate) async fn reconverge_and_apply(
         my_identity,
         hostname_table,
         reverse_table,
+        route_map,
     )
     .await;
     // Drop any live connection to a peer the signed roster no longer lists (it was
@@ -349,8 +353,22 @@ pub(crate) async fn apply_roster_to_dns(
     my_identity: EndpointId,
     hostname_table: &dns::HostnameTable,
     reverse_table: &dns::ReverseLookupTable,
+    route_map: &peers::RosterRouteMap,
 ) {
-    let mut entries: Vec<(String, Ipv4Addr, std::net::Ipv6Addr)> = members
+    // Refresh the IP -> member map so the on-demand data path can lazily dial any
+    // roster member (self excluded). The roster is the source of truth, so a
+    // shrinking roster drops stale entries via the per-network replace.
+    let routes: Vec<peers::RouteMember> = members
+        .iter()
+        .filter(|m| m.identity != my_identity)
+        .map(|m| peers::RouteMember {
+            endpoint_id: m.identity,
+            ipv4: m.ip,
+            ipv6: derive_ipv6(&m.identity),
+        })
+        .collect();
+    route_map.sync_network(network_name, &routes);
+    let mut entries: Vec<(String, Ipv4Addr, Ipv6Addr)> = members
         .iter()
         .filter_map(|m| {
             m.hostname

--- a/src/daemon/mesh/runtime.rs
+++ b/src/daemon/mesh/runtime.rs
@@ -262,15 +262,23 @@ impl NetworkRegistry {
             .into_iter()
             .cloned()
             .collect();
-        self.dial_all_members(
-            &members_to_dial,
-            net_public_key,
-            name,
-            self.transport.identity.local_identity(),
-            my_ip,
-            persisted_hostname.clone(),
-        )
-        .await;
+        // Seed the route map from the restored roster so the on-demand data path can
+        // lazily dial any member before the first reconverge (self excluded).
+        self.seed_route_map(name, &members_to_dial);
+        // On-demand nodes never eagerly dial: they restore local state + the accept
+        // handler and dial peers lazily on first outgoing traffic. Eager nodes
+        // proactively rebuild the full mesh here.
+        if !self.on_demand {
+            self.dial_all_members(
+                &members_to_dial,
+                net_public_key,
+                name,
+                self.transport.identity.local_identity(),
+                my_ip,
+                persisted_hostname.clone(),
+            )
+            .await;
+        }
 
         // Register the network from its restored local state *before* dialing
         // peers, so `ray status` / IPC sees it the instant the local restore
@@ -299,8 +307,9 @@ impl NetworkRegistry {
         // that connect *to it*, so two co-coordinators restarting together each
         // show the other offline until one is disturbed. The accept handler is
         // already registered so return traffic is handled, and the reconnect loop
-        // retries anything still unreachable.
-        {
+        // retries anything still unreachable. Skipped for on-demand nodes (they
+        // dial lazily).
+        if !self.on_demand {
             let me = Arc::clone(self);
             let network_name = name.to_string();
             tokio::spawn(async move {

--- a/src/daemon/mesh/runtime.rs
+++ b/src/daemon/mesh/runtime.rs
@@ -262,23 +262,23 @@ impl NetworkRegistry {
             .into_iter()
             .cloned()
             .collect();
-        // Seed the route map from the restored roster so the on-demand data path can
-        // lazily dial any member before the first reconverge (self excluded).
+        // Seed the route map from the restored roster so the data path can re-dial
+        // any member that has since been idle-closed, before the first reconverge
+        // (self excluded).
         self.seed_route_map(name, &members_to_dial);
-        // On-demand nodes never eagerly dial: they restore local state + the accept
-        // handler and dial peers lazily on first outgoing traffic. Eager nodes
-        // proactively rebuild the full mesh here.
-        if !self.on_demand {
-            self.dial_all_members(
-                &members_to_dial,
-                net_public_key,
-                name,
-                self.transport.identity.local_identity(),
-                my_ip,
-                persisted_hostname.clone(),
-            )
-            .await;
-        }
+        // Eager-connect the roster at startup (all nodes): a failed dial marks a peer
+        // offline immediately, so status distinguishes offline from idle from boot.
+        // On-demand nodes then idle-close these links per connection and re-dial
+        // lazily; the route map above is what lets them come back.
+        self.dial_all_members(
+            &members_to_dial,
+            net_public_key,
+            name,
+            self.transport.identity.local_identity(),
+            my_ip,
+            persisted_hostname.clone(),
+        )
+        .await;
 
         // Register the network from its restored local state *before* dialing
         // peers, so `ray status` / IPC sees it the instant the local restore
@@ -307,9 +307,8 @@ impl NetworkRegistry {
         // that connect *to it*, so two co-coordinators restarting together each
         // show the other offline until one is disturbed. The accept handler is
         // already registered so return traffic is handled, and the reconnect loop
-        // retries anything still unreachable. Skipped for on-demand nodes (they
-        // dial lazily).
-        if !self.on_demand {
+        // retries anything still unreachable.
+        {
             let me = Arc::clone(self);
             let network_name = name.to_string();
             tokio::spawn(async move {

--- a/src/daemon/mesh_connection.rs
+++ b/src/daemon/mesh_connection.rs
@@ -75,11 +75,55 @@ impl MeshConnection {
         let mut registered = self.pre_registered;
 
         loop {
+            // On-demand idle teardown. Armed only when we run on-demand *and* the
+            // peer advertised idle-close support (recorded from its NetworkHandles):
+            // a peer on a build that predates the idle close code is held open, never
+            // flapped. Recomputed each iteration because the peer registers its
+            // capability just after connect and the clock advances as traffic flows.
+            let sleep_for = (self.ctx.registry.on_demand
+                && self.ctx.peers.supports_idle_close(&self.peer_id))
+            .then(|| {
+                self.ctx
+                    .peers
+                    .idle_remaining(&self.peer_id, self.ctx.registry.idle_timeout)
+            })
+            .flatten();
+
             let accepted = tokio::select! {
                 // Daemon shutdown: drop the reader and leave without reporting a
                 // disconnect (the peer isn't gone, we are).
                 _ = self.token.cancelled() => {
                     reader.abort();
+                    return;
+                }
+                // Idle timer. When disarmed (`None`) this branch parks forever, so it
+                // costs nothing. When it fires we re-check: a send or read may have
+                // bumped activity while we slept, in which case we re-arm.
+                _ = async {
+                    match sleep_for {
+                        Some(d) => tokio::time::sleep(d).await,
+                        None => std::future::pending::<()>().await,
+                    }
+                } => {
+                    let still_idle = self
+                        .ctx
+                        .peers
+                        .idle_remaining(&self.peer_id, self.ctx.registry.idle_timeout)
+                        .is_some_and(|d| d.is_zero());
+                    if !still_idle {
+                        continue;
+                    }
+                    tracing::info!(peer = %self.peer_id.fmt_short(), "closing idle connection (on-demand teardown)");
+                    self.conn.close(VarInt::from_u32(forward::IDLE_CODE), b"idle");
+                    reader.abort();
+                    self.ctx.stats.record_idle_teardown();
+                    // We close, so our own loop only ever sees `LocallyClosed`, never
+                    // our IDLE_CODE. Report `Idle` explicitly so the supervisor removes
+                    // the peer and does not reconnect, matching the remote (which does
+                    // see IDLE_CODE). The link re-forms lazily on the next packet.
+                    if registered {
+                        self.report_disconnect(forward::CloseReason::Idle).await;
+                    }
                     return;
                 }
                 r = self.conn.accept_bi() => r,
@@ -99,9 +143,12 @@ impl MeshConnection {
                 Ok(f) => f,
                 Err(_) => continue,
             };
-            // Control traffic counts as activity, so a connection mid control
-            // exchange (e.g. a coordinator pushing roster updates) isn't idle-reaped.
-            self.ctx.peers.note_activity_by_id(&self.peer_id);
+            // Control traffic deliberately does NOT count as activity: "idle" means
+            // no data-plane (TUN) traffic. Counting control frames would let periodic
+            // chatter (pings, roster-sync/blob-update triggers) hold a connection open
+            // forever, defeating on-demand teardown. A control exchange racing the idle
+            // close is safe: frames are atomic and control is only ever a trigger, so a
+            // dropped push re-forms on the next lazy dial or the 60s poll reconverge.
             match self.gate.check() {
                 crate::ratelimit::Verdict::Allow => {}
                 crate::ratelimit::Verdict::Drop => continue,
@@ -121,8 +168,17 @@ impl MeshConnection {
             }
             // Connection-level messages (not scoped to a network).
             match &frame.msg {
-                ControlMsg::NetworkHandles { entries } => {
+                ControlMsg::NetworkHandles { entries, features } => {
                     self.manager.apply_network_handles(self.peer_id, entries);
+                    // The handle announcement is the one control message both ends
+                    // send right after connect, so it is where we learn the peer's
+                    // idle-close capability (the MeshHello handshake is one-way). Gate
+                    // the per-connection idle timer on it: a peer that does not
+                    // advertise support is held open, never idle-closed.
+                    self.ctx.peers.note_idle_support_by_id(
+                        &self.peer_id,
+                        features & crate::transport::FEATURE_IDLE_CLOSE != 0,
+                    );
                     continue;
                 }
                 ControlMsg::Ping { nonce } => {

--- a/src/daemon/mesh_connection.rs
+++ b/src/daemon/mesh_connection.rs
@@ -99,6 +99,9 @@ impl MeshConnection {
                 Ok(f) => f,
                 Err(_) => continue,
             };
+            // Control traffic counts as activity, so a connection mid control
+            // exchange (e.g. a coordinator pushing roster updates) isn't idle-reaped.
+            self.ctx.peers.note_activity_by_id(&self.peer_id);
             match self.gate.check() {
                 crate::ratelimit::Verdict::Allow => {}
                 crate::ratelimit::Verdict::Drop => continue,
@@ -236,6 +239,50 @@ fn close_reason(e: &ConnectionError) -> forward::CloseReason {
         {
             forward::CloseReason::Kicked
         }
+        ConnectionError::ApplicationClosed(ac)
+            if ac.error_code == VarInt::from_u32(forward::IDLE_CODE) =>
+        {
+            forward::CloseReason::Idle
+        }
         _ => forward::CloseReason::Transient,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iroh::endpoint::{ApplicationClose, VarInt};
+
+    fn app_close(code: u32) -> ConnectionError {
+        ConnectionError::ApplicationClosed(ApplicationClose {
+            error_code: VarInt::from_u32(code),
+            reason: Vec::new().into(),
+        })
+    }
+
+    #[test]
+    fn close_code_classification() {
+        assert!(matches!(
+            close_reason(&app_close(forward::LEAVE_CODE)),
+            forward::CloseReason::Left
+        ));
+        assert!(matches!(
+            close_reason(&app_close(forward::KICK_CODE)),
+            forward::CloseReason::Kicked
+        ));
+        assert!(matches!(
+            close_reason(&app_close(forward::IDLE_CODE)),
+            forward::CloseReason::Idle
+        ));
+        // An unrelated application code is a transient drop (reconnected).
+        assert!(matches!(
+            close_reason(&app_close(0xdead)),
+            forward::CloseReason::Transient
+        ));
+        // A non-application close (timeout, reset) is transient too.
+        assert!(matches!(
+            close_reason(&ConnectionError::TimedOut),
+            forward::CloseReason::Transient
+        ));
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -70,7 +70,7 @@ use crate::firewall::{self, SharedFirewall};
 use crate::forward;
 use crate::identity;
 use crate::ipc::{
-    self, FirewallRuleView, IpcMessage, NetworkRole, NetworkStatus, PeerStatus, ipc_err,
+    self, FirewallRuleView, IpcMessage, NetworkRole, NetworkStatus, PeerState, PeerStatus, ipc_err,
 };
 use crate::membership::{
     ApprovedEntry, ApprovedList, GroupMode, IdentityProvider, IrohIdentityProvider, Member,
@@ -120,7 +120,7 @@ pub(crate) use mesh_connection::MeshConnection;
 
 // The service that owns the set of active networks (M5 migration seam).
 mod network_registry;
-pub(crate) use network_registry::NetworkRegistry;
+pub(crate) use network_registry::{DialTarget, NetworkRegistry};
 
 // Domain satellites with their own owned state (and ALPN accept arms), held by
 // `Daemon` as fields rather than loose on the core. See each module.
@@ -165,6 +165,10 @@ pub(crate) struct MeshCtx {
     /// and re-form the link. The supervisor consumes an entry here to skip that
     /// one reconnect. Populated in [`reconverge_and_apply`] and the kick handler.
     pruned_peers: Arc<DashSet<(String, EndpointId)>>,
+    /// IP -> roster member map (no connection required), populated wherever the
+    /// roster is applied so the on-demand data path can resolve an unconnected
+    /// destination to the peer to lazily dial. See [`peers::RosterRouteMap`].
+    pub(crate) route_map: peers::RosterRouteMap,
     /// Daemon-wide disconnect channel. Every [`MeshConnection`] reports its peer's
     /// drop here when its demux loop ends, and a single
     /// [`NetworkRegistry::run_connection_supervisor`] consumes it. Under one mesh
@@ -207,6 +211,11 @@ impl MeshCtx {
         network: &str,
     ) -> bool {
         let ipv6 = derive_ipv6(&peer_id);
+        // Keep the roster route map current with every peer we connect to, so a
+        // later idle teardown can re-dial it on demand (reconverge covers the
+        // roster-wide sync + removals; this is the incremental add).
+        self.route_map
+            .sync_add(network, ip, ipv6, peer_id);
         self.peers.add(ip, ipv6, conn.clone(), peer_id, network)
     }
 }
@@ -611,10 +620,16 @@ impl Daemon {
             let cancel = cancel.clone();
             let stats = self.stats.clone();
             let resolver = self.dns.resolver.clone();
+            // The registry is the forwarding loop's on-demand dial mechanism: when a
+            // packet has no live route, the loop asks it to dial the roster member.
+            // Present on every node so any peer stays reachable-on-demand after a link
+            // idle-closes.
+            let dialer = Some(self.registry.clone());
             tokio::spawn(async move {
-                if let Err(e) =
-                    forward::run_mesh(reader, peers, firewall, cancel, stats, resolver, new_tx)
-                        .await
+                if let Err(e) = forward::run_mesh(
+                    reader, peers, firewall, cancel, stats, resolver, new_tx, dialer,
+                )
+                .await
                 {
                     tracing::warn!(error = %e, "mesh forwarding loop exited with error");
                 }
@@ -1308,6 +1323,7 @@ mod accept_handler_tests {
             reverse_table: dns::new_reverse_table(),
             device_user_map: peers::DeviceUserMap::new(),
             pruned_peers: Arc::new(DashSet::new()),
+            route_map: peers::RosterRouteMap::new(),
             disconnect_tx,
             registry,
         }
@@ -1371,6 +1387,7 @@ mod accept_handler_tests {
             Arc::new(arc_swap::ArcSwap::from_pointee(placeholder_tx)),
             Arc::new(DashSet::new()),
             disconnect_tx,
+            false,
         ))
     }
 
@@ -1667,7 +1684,7 @@ mod headless_tests {
         // on panic, so this can't poison later tests.
         let _env_guard = EnvVarGuard::set("RAYFISH_CONFIG_DIR", tmp.path());
 
-        let daemon = tokio::time::timeout(std::time::Duration::from_secs(30), build_headless())
+        let daemon = tokio::time::timeout(std::time::Duration::from_secs(30), build_headless(false))
             .await
             .expect("build_headless should not hang")
             .expect("build_headless should succeed");
@@ -1737,7 +1754,7 @@ mod headless_tests {
         let tmp = tempfile::tempdir().unwrap();
         let _env_guard = EnvVarGuard::set("RAYFISH_CONFIG_DIR", tmp.path());
 
-        let daemon = tokio::time::timeout(std::time::Duration::from_secs(30), build_headless())
+        let daemon = tokio::time::timeout(std::time::Duration::from_secs(30), build_headless(false))
             .await
             .expect("build_headless should not hang")
             .expect("build_headless should succeed");

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -247,7 +247,15 @@ pub(crate) async fn announce_network_handles(
     if entries.is_empty() {
         return;
     }
-    let _ = open_and_send(conn, None, &ControlMsg::NetworkHandles { entries }).await;
+    let _ = open_and_send(
+        conn,
+        None,
+        &ControlMsg::NetworkHandles {
+            entries,
+            features: transport::FEATURE_IDLE_CLOSE,
+        },
+    )
+    .await;
 }
 
 /// Project a roster's `Member`s into the persistable `config::MemberEntry` form
@@ -1388,6 +1396,7 @@ mod accept_handler_tests {
             Arc::new(DashSet::new()),
             disconnect_tx,
             false,
+            Duration::from_secs(config::DEFAULT_IDLE_TIMEOUT_SECS),
         ))
     }
 

--- a/src/daemon/network_registry.rs
+++ b/src/daemon/network_registry.rs
@@ -13,7 +13,24 @@
 
 use super::*;
 use arc_swap::ArcSwap;
+use std::net::IpAddr;
 use std::sync::OnceLock;
+use std::time::Duration;
+
+/// Upper bound on a single on-demand dial. The first packets of a flow wait at
+/// most this long for the connection; past it the buffered packets are dropped and
+/// the peer is marked unreachable until a later packet retries the dial.
+const LAZY_DIAL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One network to (re)handshake when dialing a peer: its name, the per-network
+/// public key that signs the `MeshHello`, and our mesh IPv4 on it. A peer's single
+/// connection carries every shared network, so a dial takes a slice of these.
+#[derive(Clone)]
+pub(crate) struct DialTarget {
+    pub network: String,
+    pub network_key: EndpointId,
+    pub my_ip: Ipv4Addr,
+}
 
 pub(crate) struct NetworkRegistry {
     /// Per-network runtime handles, keyed by network name. Shared with
@@ -50,6 +67,13 @@ pub(crate) struct NetworkRegistry {
     pub(crate) tun_tx: Arc<arc_swap::ArcSwap<mpsc::Sender<Bytes>>>,
     /// Roster-pruned peers to skip on reconnect (see [`MeshCtx::pruned_peers`]).
     pub(crate) pruned_peers: Arc<DashSet<(String, EndpointId)>>,
+    /// IP -> roster member map (no connection required), so the on-demand data
+    /// path can turn a destination IP into the peer to lazily dial. Populated
+    /// wherever the roster is applied; queried by the forwarding loop + dialer.
+    pub(crate) route_map: peers::RosterRouteMap,
+    /// Per-peer dial outcome history: drives the on-demand dialer cooldown and the
+    /// idle/offline distinction in `ray status`.
+    pub(crate) reachability: peers::Reachability,
     /// Daemon-wide disconnect channel drained by the connection supervisor.
     pub(crate) disconnect_tx: mpsc::Sender<forward::DisconnectEvent>,
     /// The inbound QUIC router, needed to drive a freshly (re)dialed connection's
@@ -57,6 +81,9 @@ pub(crate) struct NetworkRegistry {
     /// ConnectService, which depend on the registry), so it is set once at boot
     /// via [`Self::set_protocol_router`] rather than passed to `new`.
     protocol_router: OnceLock<Arc<ProtocolRouter>>,
+    /// On-demand mode: skip eager dialing at startup and never auto-reconnect (all
+    /// re-dialing is lazy). See [`Daemon::on_demand`](crate::daemon::Daemon).
+    pub(crate) on_demand: bool,
 }
 
 impl NetworkRegistry {
@@ -75,6 +102,7 @@ impl NetworkRegistry {
         tun_tx: Arc<arc_swap::ArcSwap<mpsc::Sender<Bytes>>>,
         pruned_peers: Arc<DashSet<(String, EndpointId)>>,
         disconnect_tx: mpsc::Sender<forward::DisconnectEvent>,
+        on_demand: bool,
     ) -> Self {
         Self {
             networks,
@@ -89,9 +117,107 @@ impl NetworkRegistry {
             device_user_map,
             tun_tx,
             pruned_peers,
+            route_map: peers::RosterRouteMap::new(),
+            reachability: peers::Reachability::new(),
             disconnect_tx,
             protocol_router: OnceLock::new(),
+            on_demand,
         }
+    }
+
+    /// Resolve a destination mesh IP to a roster member the on-demand forwarding
+    /// loop can dial, if we know one. Just a route-map lookup; the loop owns the
+    /// packet buffering and dedup.
+    pub(crate) fn resolve_route(&self, dst: IpAddr) -> Option<peers::RouteTarget> {
+        match dst {
+            IpAddr::V4(v4) => self.route_map.resolve_v4(&v4),
+            IpAddr::V6(v6) => self.route_map.resolve_v6(&v6),
+        }
+    }
+
+    /// The raw on-demand dial mechanism: connect to `target` across every shared
+    /// network (bounded by [`LAZY_DIAL_TIMEOUT`]) and register its route, recording
+    /// the outcome for status + cooldown. Returns whether a connection was
+    /// established (the caller then flushes any buffered packets). The forwarding
+    /// loop owns the buffering/dedup and calls this from a spawned task.
+    pub(crate) async fn dial_target(self: &Arc<Self>, target: &peers::RouteTarget) -> bool {
+        let targets: Vec<DialTarget> = target
+            .networks
+            .iter()
+            .filter_map(|net| {
+                self.networks.get(net.as_str()).map(|h| DialTarget {
+                    network: net.to_string(),
+                    network_key: h.network_key,
+                    my_ip: h.my_ip,
+                })
+            })
+            .collect();
+        let id = target.endpoint_id;
+        let ok = !targets.is_empty()
+            && matches!(
+                tokio::time::timeout(
+                    LAZY_DIAL_TIMEOUT,
+                    self.dial_peer_once(id, target.ipv4, &targets),
+                )
+                .await,
+                Ok(true)
+            );
+        if ok {
+            self.reachability.note_ok(id);
+        } else {
+            self.reachability.note_fail(id);
+        }
+        self.transport.stats.record_lazy_dial(ok);
+        ok
+    }
+
+    /// On-demand idle reaper: the teardown half of the lazy-dial machinery.
+    /// Periodically closes peer connections that have seen no traffic (data or
+    /// control) for `idle`, returning the node to zero connections so it draws no
+    /// keepalive radio. The close carries [`forward::IDLE_CODE`], which the remote
+    /// classifies as [`CloseReason::Idle`](forward::CloseReason::Idle) and does not
+    /// reconnect; the link is re-established lazily on the next packet either side
+    /// sends. Spawned only on on-demand nodes.
+    pub(crate) fn spawn_idle_reaper(self: Arc<Self>, idle: Duration) {
+        let interval = (idle / 2).max(Duration::from_secs(15));
+        let token = self.shutdown_token.clone();
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(interval);
+            // `interval` makes the first tick fire immediately; reset it so the first
+            // reap is a full period out (a just-started node shouldn't reap a
+            // connection before any traffic has had a chance to flow).
+            tick.reset();
+            loop {
+                tokio::select! {
+                    _ = token.cancelled() => return,
+                    _ = tick.tick() => {}
+                }
+                for (ip, ipv6, stable_id) in self.peers.idle_candidates(idle) {
+                    if let Some(conn) = self.peers.take_if_idle(&ip, &ipv6, stable_id, idle) {
+                        tracing::info!(ip = %ip, "closing idle connection (on-demand teardown)");
+                        conn.close(VarInt::from_u32(forward::IDLE_CODE), b"idle");
+                        self.transport.stats.record_idle_teardown();
+                    }
+                }
+            }
+        });
+    }
+
+    /// Seed the route map from a restored roster so the on-demand data path can
+    /// lazily dial members before the first reconverge (self excluded by the
+    /// caller-provided list, which should already omit us).
+    pub(crate) fn seed_route_map(&self, network: &str, members: &[Member]) {
+        let my_id = self.transport.identity.local_identity();
+        let routes: Vec<peers::RouteMember> = members
+            .iter()
+            .filter(|m| m.identity != my_id)
+            .map(|m| peers::RouteMember {
+                endpoint_id: m.identity,
+                ipv4: m.ip,
+                ipv6: derive_ipv6(&m.identity),
+            })
+            .collect();
+        self.route_map.sync_network(network, &routes);
     }
 
     /// Install the inbound QUIC router. Called once at boot after the router is
@@ -124,6 +250,7 @@ impl NetworkRegistry {
             reverse_table: self.dns.reverse_table.clone(),
             device_user_map: self.device_user_map.clone(),
             pruned_peers: self.pruned_peers.clone(),
+            route_map: self.route_map.clone(),
             disconnect_tx: self.disconnect_tx.clone(),
             registry: self.clone(),
         }
@@ -202,6 +329,7 @@ impl NetworkRegistry {
             conn.close(VarInt::from_u32(forward::LEAVE_CODE), b"leave");
         }
         self.dns.clear_network(name).await;
+        self.route_map.remove_network(name);
         self.conn.unregister(&handle.network_key);
         self.refresh_search_domains().await;
         true

--- a/src/daemon/network_registry.rs
+++ b/src/daemon/network_registry.rs
@@ -81,9 +81,13 @@ pub(crate) struct NetworkRegistry {
     /// ConnectService, which depend on the registry), so it is set once at boot
     /// via [`Self::set_protocol_router`] rather than passed to `new`.
     protocol_router: OnceLock<Arc<ProtocolRouter>>,
-    /// On-demand mode: skip eager dialing at startup and never auto-reconnect (all
-    /// re-dialing is lazy). See [`Daemon::on_demand`](crate::daemon::Daemon).
+    /// On-demand mode: run the per-connection idle timer that closes a link idle
+    /// past [`idle_timeout`](Self::idle_timeout), and never auto-reconnect an
+    /// idle-closed peer (re-dialing is lazy). See [`Daemon::on_demand`](crate::daemon::Daemon).
     pub(crate) on_demand: bool,
+    /// How long a connection may sit with no traffic (either direction) before an
+    /// on-demand node idle-closes it. Read by each [`MeshConnection`]'s idle timer.
+    pub(crate) idle_timeout: Duration,
 }
 
 impl NetworkRegistry {
@@ -103,6 +107,7 @@ impl NetworkRegistry {
         pruned_peers: Arc<DashSet<(String, EndpointId)>>,
         disconnect_tx: mpsc::Sender<forward::DisconnectEvent>,
         on_demand: bool,
+        idle_timeout: Duration,
     ) -> Self {
         Self {
             networks,
@@ -122,6 +127,7 @@ impl NetworkRegistry {
             disconnect_tx,
             protocol_router: OnceLock::new(),
             on_demand,
+            idle_timeout,
         }
     }
 
@@ -171,37 +177,6 @@ impl NetworkRegistry {
         ok
     }
 
-    /// On-demand idle reaper: the teardown half of the lazy-dial machinery.
-    /// Periodically closes peer connections that have seen no traffic (data or
-    /// control) for `idle`, returning the node to zero connections so it draws no
-    /// keepalive radio. The close carries [`forward::IDLE_CODE`], which the remote
-    /// classifies as [`CloseReason::Idle`](forward::CloseReason::Idle) and does not
-    /// reconnect; the link is re-established lazily on the next packet either side
-    /// sends. Spawned only on on-demand nodes.
-    pub(crate) fn spawn_idle_reaper(self: Arc<Self>, idle: Duration) {
-        let interval = (idle / 2).max(Duration::from_secs(15));
-        let token = self.shutdown_token.clone();
-        tokio::spawn(async move {
-            let mut tick = tokio::time::interval(interval);
-            // `interval` makes the first tick fire immediately; reset it so the first
-            // reap is a full period out (a just-started node shouldn't reap a
-            // connection before any traffic has had a chance to flow).
-            tick.reset();
-            loop {
-                tokio::select! {
-                    _ = token.cancelled() => return,
-                    _ = tick.tick() => {}
-                }
-                for (ip, ipv6, stable_id) in self.peers.idle_candidates(idle) {
-                    if let Some(conn) = self.peers.take_if_idle(&ip, &ipv6, stable_id, idle) {
-                        tracing::info!(ip = %ip, "closing idle connection (on-demand teardown)");
-                        conn.close(VarInt::from_u32(forward::IDLE_CODE), b"idle");
-                        self.transport.stats.record_idle_teardown();
-                    }
-                }
-            }
-        });
-    }
 
     /// Seed the route map from a restored roster so the on-demand data path can
     /// lazily dial members before the first reconverge (self excluded by the

--- a/src/daemon/network_registry.rs
+++ b/src/daemon/network_registry.rs
@@ -159,20 +159,21 @@ impl NetworkRegistry {
             })
             .collect();
         let id = target.endpoint_id;
+        // `dial_peer_once` stamps reachability (ok/fail) itself, so the timeout arm
+        // is the only failure this path must record separately.
         let ok = !targets.is_empty()
-            && matches!(
-                tokio::time::timeout(
-                    LAZY_DIAL_TIMEOUT,
-                    self.dial_peer_once(id, target.ipv4, &targets),
-                )
-                .await,
-                Ok(true)
-            );
-        if ok {
-            self.reachability.note_ok(id);
-        } else {
-            self.reachability.note_fail(id);
-        }
+            && match tokio::time::timeout(
+                LAZY_DIAL_TIMEOUT,
+                self.dial_peer_once(id, target.ipv4, &targets),
+            )
+            .await
+            {
+                Ok(established) => established,
+                Err(_elapsed) => {
+                    self.reachability.note_fail(id);
+                    false
+                }
+            };
         self.transport.stats.record_lazy_dial(ok);
         ok
     }

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -5,6 +5,7 @@
 //! - [`spawn_peer_reader`]: one per peer, reads incoming datagrams and forwards to TUN writer
 //! - [`spawn_tun_writer`]: single task, writes incoming packets to the TUN device
 
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -18,8 +19,10 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+use crate::daemon::NetworkRegistry;
+use crate::dns;
 use crate::firewall::{self, Direction, SharedFirewall};
-use crate::peers::{DeviceUserMap, PeerTable};
+use crate::peers::{DeviceUserMap, PeerRoute, PeerTable};
 use crate::stats::{DropReason, ForwardMetrics};
 
 /// Maximum datagram size accepted from a peer, including the [`TAG_LEN`]-byte
@@ -248,6 +251,13 @@ pub const ABUSE_CODE: u32 = 0xab05e;
 /// suppress its reconnect loop.
 pub const KICK_CODE: u32 = 0x14ced;
 
+/// Application close code an on-demand node sends when it closes a peer connection
+/// that has seen no traffic for the idle timeout. The remote peer classifies it as
+/// [`CloseReason::Idle`] and does **not** reconnect (the link is re-established
+/// lazily on the next packet either side sends). Distinct from a transient drop so
+/// an eager peer doesn't immediately re-dial the link we deliberately let go idle.
+pub const IDLE_CODE: u32 = 0x1d1e;
+
 /// How a peer's connection ended, from the perspective of the side that observed
 /// the close. Membership is decided solely by the network-key-signed roster, so a
 /// close code is a hint about intent, never authority over who is a member.
@@ -267,6 +277,10 @@ pub enum CloseReason {
     /// valid member and desync the mesh. A network-key holder keeps the peer and
     /// reconnects; the signed roster remains the sole authority.
     Kicked,
+    /// The peer closed with [`IDLE_CODE`]: it deliberately let an idle connection
+    /// go (on-demand teardown). Never reconnect; the link comes back lazily on the
+    /// next packet either side sends.
+    Idle,
 }
 
 impl CloseReason {
@@ -325,23 +339,37 @@ pub struct ForwardCtx {
 
 /// True when a parsed packet is a DNS query addressed to the magic resolver IP.
 pub(crate) fn is_magic_dns(info: &firewall::PacketInfo) -> bool {
-    info.dst_port == 53 && info.dst_ip == IpAddr::V4(crate::dns::MAGIC_DNS_V4)
+    info.dst_port == 53 && info.dst_ip == IpAddr::V4(dns::MAGIC_DNS_V4)
 }
 
-/// Main TUN read loop. Reads packets from the TUN device, extracts the destination IP,
-/// looks up the peer in [`PeerTable`], and sends the packet as a QUIC datagram.
-/// Packets with no matching peer are silently dropped.
+/// Main TUN read loop. Reads outgoing packets from the TUN device and sends each
+/// to its peer over QUIC. When there is no live connection to the destination, an
+/// on-demand node buffers the packet and dials the peer (see below); with no dialer
+/// the packet is dropped.
+///
+/// On-demand lazy dial: the loop owns two maps, `buffered` (packets waiting for a
+/// peer's connection to come up, per peer) and `in_flight` (peers currently being
+/// dialed), plus an internal `done` channel. A packet to an unconnected roster
+/// member is buffered and, if no dial is in flight for that peer, a dial is spawned
+/// that reports back on `done`. When a dial completes the loop flushes that peer's
+/// buffered packets over the now-live route (or drops them if the dial failed). The
+/// dial itself runs off-loop, so a slow handshake never blocks forwarding.
 #[allow(clippy::too_many_arguments)]
-pub async fn run_mesh<R: crate::tun::TunRead>(
+pub(crate) async fn run_mesh<R: crate::tun::TunRead>(
     mut tun: R,
     peers: PeerTable,
     firewall: SharedFirewall,
     token: CancellationToken,
     stats: Arc<ForwardMetrics>,
-    resolver: Arc<crate::dns::resolver::Resolver>,
+    resolver: Arc<dns::resolver::Resolver>,
     tun_tx: mpsc::Sender<Bytes>,
+    dialer: Option<Arc<NetworkRegistry>>,
 ) -> Result<()> {
     let mut pool = BytesMut::with_capacity(TX_POOL_CHUNK);
+    // On-demand lazy-dial state, owned by this loop (no shared/locked buffer).
+    let mut buffered: HashMap<EndpointId, VecDeque<Bytes>> = HashMap::new();
+    let mut in_flight: HashSet<EndpointId> = HashSet::new();
+    let (done_tx, mut done_rx) = mpsc::channel::<(EndpointId, bool)>(64);
     loop {
         // Ensure a full MTU of contiguous spare capacity before reading (a short
         // buffer would truncate the packet). `reserve` reuses the current chunk
@@ -350,11 +378,18 @@ pub async fn run_mesh<R: crate::tun::TunRead>(
         if pool.capacity() < MAX_PEER_DATAGRAM {
             pool.reserve(TX_POOL_CHUNK);
         }
-        // Race the read against cancellation, but return only the byte count so
-        // no borrow of `pool` escapes the `select!` (it's reused right below).
+        // Race the read against cancellation and dial-completion. The read arm
+        // returns only the byte count so no borrow of `pool` escapes the `select!`
+        // (it's reused right below); the completion arm flushes inline and loops.
         let n = tokio::select! {
             _ = token.cancelled() => return Ok(()),
             result = tun.read_into(&mut pool) => result?,
+            Some((peer, connected)) = done_rx.recv() => {
+                in_flight.remove(&peer);
+                let pkts = buffered.remove(&peer).unwrap_or_default();
+                flush_or_drop(&peers, &firewall, &stats, &tun_tx, connected, pkts).await;
+                continue;
+            }
         };
         if n == 0 {
             continue;
@@ -381,81 +416,163 @@ pub async fn run_mesh<R: crate::tun::TunRead>(
             IpAddr::V6(v6) => peers.lookup_v6(&v6),
         };
         let Some(route) = lookup else {
-            tracing::debug!(dst = %info.dst_ip, "no peer for dst");
+            // No live connection to this destination.
+            let Some(reg) = dialer.as_ref() else {
+                tracing::debug!(dst = %info.dst_ip, "no peer for dst");
+                stats.record_drop(DropReason::NoPeer);
+                continue;
+            };
+
+            // On-demand: only known roster members are dialable.
+            let Some(target) = reg.resolve_route(info.dst_ip) else {
+                tracing::debug!(dst = %info.dst_ip, "no peer for dst");
+                stats.record_drop(DropReason::NoPeer);
+                continue;
+            };
+
+            let peer = target.endpoint_id;
+            // Buffer so the first packets of the flow aren't lost once connected. A
+            // single dial per peer runs at a time (in_flight dedup) and is bounded by
+            // LAZY_DIAL_TIMEOUT; on completion `done` flushes the buffer (success) or
+            // drops it and records the drops (timeout/failure).
+            buffered.entry(peer).or_default().push_back(pkt);
+
+            if in_flight.insert(peer) {
+                let reg = reg.clone();
+                let done = done_tx.clone();
+                tokio::spawn(async move {
+                    let connected = reg.dial_target(&target).await;
+                    let _ = done.send((peer, connected)).await;
+                });
+            }
+
+            continue;
+        };
+        send_over_route(&firewall, &stats, &tun_tx, &route, &info, pkt).await;
+    }
+}
+
+/// Flush packets buffered while a peer's on-demand connection came up. On success
+/// each is re-routed and sent over the now-live connection (its route may differ
+/// per packet, so look it up fresh); on failure they are dropped. Called by
+/// [`run_mesh`] when a dial completes.
+async fn flush_or_drop(
+    peers: &PeerTable,
+    firewall: &SharedFirewall,
+    stats: &ForwardMetrics,
+    tun_tx: &mpsc::Sender<Bytes>,
+    connected: bool,
+    pkts: VecDeque<Bytes>,
+) {
+    if !connected {
+        for _ in &pkts {
+            stats.record_drop(DropReason::NoPeer);
+        }
+        return;
+    }
+
+    for pkt in pkts {
+        let Some(info) = firewall::parse_packet_info(&pkt) else {
+            continue;
+        };
+
+        let route = match info.dst_ip {
+            IpAddr::V4(v4) => peers.lookup_v4(&v4),
+            IpAddr::V6(v6) => peers.lookup_v6(&v6),
+        };
+        let Some(route) = route else {
+            // The connection vanished between dialing and flushing (a racing
+            // teardown); the flow's retransmit will re-drive it.
             stats.record_drop(DropReason::NoPeer);
             continue;
         };
-        // Reachability is "we share a network", enforced by connection
-        // existence. The per-host firewall is the fine-grained gate.
-        if firewall
-            .evaluate_packet(
-                Direction::Out,
-                &info,
-                &route.endpoint_id,
-                Some(&route.network),
-            )
-            .is_deny()
+
+        send_over_route(firewall, stats, tun_tx, &route, &info, pkt).await;
+    }
+}
+
+/// Firewall-check an outbound packet already routed to `route`, then send it as a
+/// tagged QUIC datagram. Applies the same reject-inject, drop-newest backpressure,
+/// and SSH source-port NAT as the main loop. Shared by [`run_mesh`] and the
+/// on-demand flush of packets buffered while a peer connection was established.
+pub(crate) async fn send_over_route(
+    firewall: &SharedFirewall,
+    stats: &ForwardMetrics,
+    tun_tx: &mpsc::Sender<Bytes>,
+    route: &PeerRoute,
+    info: &firewall::PacketInfo,
+    pkt: Bytes,
+) {
+    let n = pkt.len();
+    // Reachability is "we share a network", enforced by connection existence. The
+    // per-host firewall is the fine-grained gate.
+    if firewall
+        .evaluate_packet(
+            Direction::Out,
+            info,
+            &route.endpoint_id,
+            Some(&route.network),
+        )
+        .is_deny()
+    {
+        tracing::debug!(dst = %info.dst_ip, port = info.dst_port, "firewall denied outbound");
+        stats.record_drop(DropReason::Firewall);
+        // Fail fast (opt-in): inject a RST / ICMP-unreachable back into our own TUN
+        // so the local app's socket fails immediately instead of hanging.
+        if firewall.reject_enabled()
+            && let Some(reply) = crate::reject::build_reject(&pkt, info)
         {
-            tracing::debug!(dst = %info.dst_ip, port = info.dst_port, "firewall denied outbound");
-            stats.record_drop(DropReason::Firewall);
-            // Fail fast (opt-in): inject a RST / ICMP-unreachable back into our own
-            // TUN so the local app's socket fails immediately instead of hanging.
-            if firewall.reject_enabled()
-                && let Some(reply) = crate::reject::build_reject(&pkt, &info)
-            {
-                stats.record_reject();
-                let _ = tun_tx.send(reply).await;
-            }
-            continue;
+            stats.record_reject();
+            let _ = tun_tx.send(reply).await;
         }
-        tracing::debug!(dst = %info.dst_ip, "routing to peer");
-        // Drop-newest at the application boundary: if the peer's QUIC datagram send
-        // buffer is too full to accept this packet (plus its tag) without evicting
-        // an already-queued (older) one, drop the *new* packet here instead of
-        // calling `send_datagram`, which would drop the *oldest* queued packet (see
-        // N6 in the datagram audit). This keeps the send path non-blocking (no
-        // cross-peer head-of-line blocking in this single TUN read loop) while
-        // preferring drop-newest over drop-oldest. Full per-peer backpressure
-        // (`send_datagram_wait` in a per-peer writer task) is the sized follow-up
-        // that needs the e2e harness to land safely.
-        if route.conn.datagram_send_buffer_space() < n + TAG_LEN {
-            tracing::trace!(
-                dst = %info.dst_ip,
-                space = route.conn.datagram_send_buffer_space(),
-                len = n,
-                "datagram send buffer full; dropping newest",
-            );
-            stats.record_drop(DropReason::Backpressure);
-            continue;
+        return;
+    }
+    // Drop-newest at the application boundary: if the peer's QUIC datagram send
+    // buffer is too full to accept this packet (plus its tag) without evicting an
+    // already-queued (older) one, drop the *new* packet here instead of calling
+    // `send_datagram`, which would drop the *oldest* queued packet (see N6 in the
+    // datagram audit). This keeps the send path non-blocking while preferring
+    // drop-newest over drop-oldest.
+    if route.conn.datagram_send_buffer_space() < n + TAG_LEN {
+        tracing::trace!(
+            dst = %info.dst_ip,
+            space = route.conn.datagram_send_buffer_space(),
+            len = n,
+            "datagram send buffer full; dropping newest",
+        );
+        stats.record_drop(DropReason::Backpressure);
+        return;
+    }
+    // SSH NAT: rewrite our reply's source port (listen -> 22) so the peer sees it as
+    // coming from `:22`. The cheap pre-check (TCP + source port == listen port)
+    // gates the copy; `rewrite_ssh_port` still confirms the source IP is ours and
+    // no-ops otherwise, so ordinary traffic is untouched.
+    let pkt = if ssh_nat().is_some_and(|s| info.protocol == 6 && info.src_port == s.listen_port) {
+        let mut v = pkt.to_vec();
+        rewrite_ssh_port(&mut v, info, false);
+        Bytes::from(v)
+    } else {
+        pkt
+    };
+    // Prefix the network handle so the receiver, which shares one connection for all
+    // our networks, can recover which network this datagram belongs to (firewall
+    // scoping + reachability). `handle == 0` means we have no handle for the routed
+    // network yet (the peer hasn't been announced) — drop rather than send an
+    // undecodable datagram.
+    if route.handle == 0 {
+        stats.record_drop(DropReason::NoPeer);
+        return;
+    }
+    let tagged = tag_datagram(route.handle, &pkt);
+    match route.conn.send_datagram(tagged) {
+        Ok(()) => {
+            stats.record_tx(n);
+            // Outbound traffic keeps the connection off the idle reaper's list.
+            route.note_activity();
         }
-        // SSH NAT: rewrite our reply's source port (listen -> 22) so the peer
-        // sees it as coming from `:22`. The cheap pre-check (TCP + source port ==
-        // listen port) gates the copy; `rewrite_ssh_port` still confirms the
-        // source IP is ours and no-ops otherwise, so ordinary traffic is untouched.
-        let pkt = if ssh_nat().is_some_and(|n| info.protocol == 6 && info.src_port == n.listen_port)
-        {
-            let mut v = pkt.to_vec();
-            rewrite_ssh_port(&mut v, &info, false);
-            Bytes::from(v)
-        } else {
-            pkt
-        };
-        // Prefix the network handle so the receiver, which shares one connection
-        // for all our networks, can recover which network this datagram belongs to
-        // (firewall scoping + reachability). `handle == 0` means we have no handle
-        // for the routed network yet (the peer hasn't been announced) — drop
-        // rather than send an undecodable datagram.
-        if route.handle == 0 {
-            stats.record_drop(DropReason::NoPeer);
-            continue;
-        }
-        let tagged = tag_datagram(route.handle, &pkt);
-        match route.conn.send_datagram(tagged) {
-            Ok(()) => stats.record_tx(n),
-            Err(e) => {
-                tracing::debug!(dst = %info.dst_ip, error = %e, "datagram send failed");
-                stats.record_drop(DropReason::SendFailure);
-            }
+        Err(e) => {
+            tracing::debug!(dst = %info.dst_ip, error = %e, "datagram send failed");
+            stats.record_drop(DropReason::SendFailure);
         }
     }
 }
@@ -509,6 +626,8 @@ pub fn spawn_peer_reader(
                     }
                 },
             };
+            // Any inbound datagram keeps the connection off the idle reaper's list.
+            peers.note_activity_by_id(&peer_id);
 
             if datagram.len() > MAX_PEER_DATAGRAM {
                 stats.record_drop(DropReason::Malformed);

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -626,9 +626,6 @@ pub fn spawn_peer_reader(
                     }
                 },
             };
-            // Any inbound datagram keeps the connection off the idle reaper's list.
-            peers.note_activity_by_id(&peer_id);
-
             if datagram.len() > MAX_PEER_DATAGRAM {
                 stats.record_drop(DropReason::Malformed);
                 continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,7 +306,8 @@ pub(crate) enum Command {
         /// "on" or "off"
         state: String,
     },
-    /// View or change global daemon settings (relay, discovery-dns, dns-upstreams)
+    /// View or change global daemon settings (relay, discovery-dns, dns-upstreams,
+    /// auto-update, on-demand)
     Config {
         #[command(subcommand)]
         action: Option<ConfigAction>,
@@ -495,23 +496,24 @@ pub(crate) enum ConfigAction {
     /// Show settings (all, or one key)
     #[command(visible_alias = "ls")]
     Get {
-        /// relay, discovery-dns, or dns-upstreams (omit for all)
+        /// relay, discovery-dns, dns-upstreams, auto-update, or on-demand (omit for all)
         key: Option<String>,
     },
-    /// Set a key. Value is a comma list of presets (rayfish/n0), URLs, or IPs.
+    /// Set a key. List keys take a comma list of presets/URLs/IPs; auto-update and
+    /// on-demand take on/off.
     Set {
-        /// relay, discovery-dns, or dns-upstreams
+        /// relay, discovery-dns, dns-upstreams, auto-update, or on-demand
         key: String,
-        /// Comma list of presets / URLs / IPv4s (use "n0" or empty to reset)
+        /// A comma list of presets / URLs / IPv4s ("n0" or empty resets), or on/off
         value: String,
-        /// Replace the defaults instead of augmenting them (can isolate the node)
+        /// Replace the defaults instead of augmenting them (list keys only)
         #[arg(long)]
         replace: bool,
     },
-    /// Reset a key to its default (iroh n0)
+    /// Reset a key to its default
     #[command(visible_alias = "rm")]
     Unset {
-        /// relay, discovery-dns, or dns-upstreams
+        /// relay, discovery-dns, dns-upstreams, auto-update, or on-demand
         key: String,
     },
 }
@@ -1100,24 +1102,16 @@ fn cmd_mdns(state: &str) -> Result<()> {
     Ok(())
 }
 
-/// `ray auto-update on|off`: toggle opt-in automatic stable updates. Writes
-/// `settings.toml` directly (like `cmd_mdns`); the daemon reads it at startup, so
+/// `ray auto-update on|off`: back-compat alias for `ray config set auto-update
+/// <on|off>`. Writes `settings.toml` directly; the daemon reads it at startup, so
 /// the change takes effect on the next daemon restart.
 fn cmd_auto_update(state: &str) -> Result<()> {
-    let enabled = match state {
-        "on" => true,
-        "off" => false,
-        _ => {
-            eprintln!("Usage: ray auto-update <on|off>");
-            std::process::exit(1);
-        }
-    };
-    let mut app_config = config::load()?;
-    app_config.auto_update = enabled;
-    config::save_settings(&app_config)?;
+    let mut cfg = config::load()?;
+    config::config_set(&mut cfg, "auto-update", state, false)?;
+    config::save_settings(&cfg)?;
     println!(
-        "automatic updates {}. Restart the daemon for changes to take effect.",
-        if enabled { "enabled" } else { "disabled" }
+        "auto-update {}. Run 'sudo ray restart' for changes to take effect.",
+        if cfg.auto_update { "enabled" } else { "disabled" }
     );
     Ok(())
 }

--- a/src/peers.rs
+++ b/src/peers.rs
@@ -1,6 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 use dashmap::DashSet;
 use iroh::EndpointId;
@@ -8,6 +11,25 @@ use iroh::endpoint::Connection;
 use smol_str::SmolStr;
 
 use crate::audit::AuditLog;
+use crate::membership;
+
+/// Monotonic base for per-connection activity timestamps. Activity is stored as
+/// milliseconds since this instant in a plain `AtomicU64` (cheap to bump on the
+/// hot path); the idle reaper compares against [`now_ms`].
+static ACTIVITY_EPOCH: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+/// Milliseconds since [`ACTIVITY_EPOCH`]. Wraps far past any process lifetime.
+fn now_ms() -> u64 {
+    ACTIVITY_EPOCH.elapsed().as_millis() as u64
+}
+
+/// Whether a connection last active at `last_active` (ms) is idle for at least
+/// `idle_ms` as of `now` (ms). Age-based (`now - last_active >= idle_ms`) so a
+/// just-booted process, where `now` itself is smaller than `idle_ms`, never
+/// reports a peer idle before it could possibly have been.
+fn is_idle(now: u64, last_active: u64, idle_ms: u64) -> bool {
+    now.saturating_sub(last_active) >= idle_ms
+}
 
 /// A `DashMap` using ahash instead of the default SipHash. Used for the
 /// per-packet hot maps (routing table, conntrack, device→user resolution):
@@ -83,6 +105,11 @@ pub struct PeerEntry {
     /// `NetworkHandles`. Used to resolve which network an inbound datagram from
     /// this peer belongs to.
     in_handles: HashMap<u16, SmolStr>,
+    /// Milliseconds ([`now_ms`]) of the last traffic on this connection in either
+    /// direction (data or control). The on-demand idle reaper closes connections
+    /// whose last activity is older than the idle timeout. Shared as an `Arc` so the
+    /// hot send path can bump it via a cloned handle on [`PeerRoute`].
+    last_active: Arc<AtomicU64>,
 }
 
 /// Result of a routing lookup: the connection to send over, the peer identity,
@@ -97,6 +124,16 @@ pub struct PeerRoute {
     pub network: SmolStr,
     /// The outbound datagram tag for `network` on this connection.
     pub handle: u16,
+    /// Shared last-activity clock for this peer's connection; the sender bumps it
+    /// after a successful send so the idle reaper sees the connection as active.
+    last_active: Arc<AtomicU64>,
+}
+
+impl PeerRoute {
+    /// Record that traffic just went out on this connection (resets its idle timer).
+    pub fn note_activity(&self) {
+        self.last_active.store(now_ms(), Ordering::Relaxed);
+    }
 }
 
 /// Whether installing a connection with stable id `incoming` as a peer's data
@@ -135,6 +172,7 @@ impl PeerEntry {
             endpoint_id: self.endpoint_id,
             network,
             handle,
+            last_active: self.last_active.clone(),
         })
     }
 }
@@ -230,6 +268,9 @@ impl PeerTable {
                         let h = next_free_handle(&e.out_handles);
                         e.out_handles.insert(net.clone(), h);
                     }
+                    // Registering a (re)connection counts as activity, so a fresh
+                    // link isn't immediately reaped as idle.
+                    e.last_active.store(now_ms(), Ordering::Relaxed);
                 }
                 Entry::Vacant(v) => {
                     first_ever = true;
@@ -271,6 +312,64 @@ impl PeerTable {
     /// handshake.
     pub fn v4_for_id(&self, peer_id: &EndpointId) -> Option<Ipv4Addr> {
         self.by_id.get(peer_id).map(|e| *e.value())
+    }
+
+    /// Record inbound traffic from `peer_id`, resetting its connection's idle timer.
+    /// Called by the per-connection data reader and control demux (which know only
+    /// the QUIC remote id) on every frame, so a connection carrying only control
+    /// traffic isn't reaped mid-exchange.
+    pub fn note_activity_by_id(&self, peer_id: &EndpointId) {
+        if let Some(ip) = self.by_id.get(peer_id).map(|e| *e.value())
+            && let Some(e) = self.v4.get(&ip)
+        {
+            e.last_active.store(now_ms(), Ordering::Relaxed);
+        }
+    }
+
+    /// Peers whose connection has seen no traffic for at least `idle` — candidates
+    /// for on-demand teardown. Returns `(ipv4, ipv6, stable_id)`; the reaper closes
+    /// each via [`take_if_idle`](Self::take_if_idle), which re-checks under a lock so
+    /// a send or reconnect between the scan and the close can't lose a live link.
+    pub fn idle_candidates(&self, idle: Duration) -> Vec<(Ipv4Addr, Ipv6Addr, usize)> {
+        let idle_ms = idle.as_millis() as u64;
+        let now = now_ms();
+        self.v4
+            .iter()
+            .filter(|e| is_idle(now, e.last_active.load(Ordering::Relaxed), idle_ms))
+            .map(|e| {
+                (
+                    *e.key(),
+                    membership::derive_ipv6(&e.endpoint_id),
+                    e.conn.stable_id(),
+                )
+            })
+            .collect()
+    }
+
+    /// Remove the peer at `ip` and return its connection to close, but only if its
+    /// stored connection is still `stable_id` and still idle past `idle` — an atomic
+    /// re-check that guards against a send that bumped activity, or a reconnect that
+    /// installed a fresh connection, since the reaper's scan. `None` leaves the entry
+    /// untouched.
+    pub fn take_if_idle(
+        &self,
+        ip: &Ipv4Addr,
+        ipv6: &Ipv6Addr,
+        stable_id: usize,
+        idle: Duration,
+    ) -> Option<Connection> {
+        let idle_ms = idle.as_millis() as u64;
+        let now = now_ms();
+        let (_, entry) = self.v4.remove_if(ip, |_, e| {
+            e.conn.stable_id() == stable_id
+                && is_idle(now, e.last_active.load(Ordering::Relaxed), idle_ms)
+        })?;
+        self.v6.remove(ipv6);
+        self.by_id.remove(&entry.endpoint_id);
+        if let Some(audit) = &self.audit {
+            audit.log_disconnect(*ip, &entry.endpoint_id.to_string());
+        }
+        Some(entry.conn)
     }
 
     /// Resolve an inbound datagram from `peer_id` tagged with `handle` to the
@@ -363,7 +462,7 @@ impl PeerTable {
         let Some(ip) = self.by_id.get(peer_id).map(|e| *e.value()) else {
             return;
         };
-        let ipv6 = crate::membership::derive_ipv6(peer_id);
+        let ipv6 = membership::derive_ipv6(peer_id);
         if let Some(mut e) = self.v4.get_mut(&ip) {
             e.in_handles.insert(handle, network.clone());
         }
@@ -617,6 +716,207 @@ impl PeerTable {
     }
 }
 
+/// A known roster member and the networks we share with it, resolvable by mesh IP
+/// **without** a live connection. Returned by [`RosterRouteMap::resolve_v4`] so the
+/// forwarding loop can turn a destination IP into the peer identity to lazily dial.
+#[derive(Clone, Debug)]
+pub struct RouteTarget {
+    pub endpoint_id: EndpointId,
+    pub ipv4: Ipv4Addr,
+    pub ipv6: Ipv6Addr,
+    /// Every network we currently share with this peer (so a lazy dial can
+    /// `MeshHello` on each, like a reconnect).
+    pub networks: Vec<SmolStr>,
+}
+
+/// A roster member's addresses + identity, the input unit to
+/// [`RosterRouteMap::sync_network`]. Carries only what routing needs (no
+/// hostname/roster metadata), built from a `Member` by the caller.
+#[derive(Clone, Copy, Debug)]
+pub struct RouteMember {
+    pub endpoint_id: EndpointId,
+    pub ipv4: Ipv4Addr,
+    pub ipv6: Ipv6Addr,
+}
+
+struct RouteEntry {
+    endpoint_id: EndpointId,
+    ipv4: Ipv4Addr,
+    ipv6: Ipv6Addr,
+    networks: HashSet<SmolStr>,
+}
+
+impl RouteEntry {
+    fn to_target(&self) -> RouteTarget {
+        RouteTarget {
+            endpoint_id: self.endpoint_id,
+            ipv4: self.ipv4,
+            ipv6: self.ipv6,
+            networks: self.networks.iter().cloned().collect(),
+        }
+    }
+}
+
+/// Node-wide map from a peer's stable mesh IP to its identity + shared networks,
+/// built from the roster (not from live connections). It exists so an on-demand
+/// node, which holds no connections while idle, can still turn an outgoing
+/// packet's destination IP into the peer to dial. A peer has one IP across every
+/// network it joins, so entries accumulate a per-peer network set; a network's
+/// contribution is replaced wholesale on each roster apply (mirroring
+/// [`dns::sync_network_hostnames`](crate::dns::sync_network_hostnames)).
+///
+/// Distinct from [`PeerTable`] on purpose: `PeerTable`'s invariant is "a lookup
+/// hit implies a live connection", relied on by the whole data path. This map is
+/// the opposite - it lists peers we could reach but currently don't.
+#[derive(Clone, Default)]
+pub struct RosterRouteMap {
+    v4: Arc<FastDashMap<Ipv4Addr, RouteEntry>>,
+    v6: Arc<FastDashMap<Ipv6Addr, RouteEntry>>,
+}
+
+impl RosterRouteMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace `network`'s contribution with `members`: peers no longer in
+    /// `network` lose that membership, and any left sharing no network are dropped.
+    /// Peers still reachable via another network keep their entry. Self is excluded
+    /// by the caller.
+    pub fn sync_network(&self, network: &str, members: &[RouteMember]) {
+        let net = SmolStr::new(network);
+        let fresh: HashSet<Ipv4Addr> = members.iter().map(|m| m.ipv4).collect();
+        // Drop this network from peers that used to be in it but no longer are.
+        let stale: Vec<(Ipv4Addr, Ipv6Addr)> = self
+            .v4
+            .iter()
+            .filter(|e| e.networks.contains(&net) && !fresh.contains(e.key()))
+            .map(|e| (*e.key(), e.ipv6))
+            .collect();
+        for (v4, v6) in stale {
+            self.drop_network(&v4, &v6, &net);
+        }
+        // Upsert the current members.
+        for m in members {
+            self.upsert(m.ipv4, m.ipv6, m.endpoint_id, net.clone());
+        }
+    }
+
+    fn upsert(&self, ipv4: Ipv4Addr, ipv6: Ipv6Addr, endpoint_id: EndpointId, net: SmolStr) {
+        let mut v4 = self.v4.entry(ipv4).or_insert_with(|| RouteEntry {
+            endpoint_id,
+            ipv4,
+            ipv6,
+            networks: HashSet::new(),
+        });
+        v4.endpoint_id = endpoint_id;
+        v4.ipv6 = ipv6;
+        v4.networks.insert(net.clone());
+        drop(v4);
+        let mut v6 = self.v6.entry(ipv6).or_insert_with(|| RouteEntry {
+            endpoint_id,
+            ipv4,
+            ipv6,
+            networks: HashSet::new(),
+        });
+        v6.endpoint_id = endpoint_id;
+        v6.ipv4 = ipv4;
+        v6.networks.insert(net);
+    }
+
+    fn drop_network(&self, ipv4: &Ipv4Addr, ipv6: &Ipv6Addr, net: &SmolStr) {
+        if let Some(mut e) = self.v4.get_mut(ipv4) {
+            e.networks.remove(net);
+        }
+        self.v4.remove_if(ipv4, |_, e| e.networks.is_empty());
+        if let Some(mut e) = self.v6.get_mut(ipv6) {
+            e.networks.remove(net);
+        }
+        self.v6.remove_if(ipv6, |_, e| e.networks.is_empty());
+    }
+
+    /// Drop `network` entirely (all its members) from the map. Members still in
+    /// another shared network keep their entry.
+    pub fn remove_network(&self, network: &str) {
+        let net = SmolStr::new(network);
+        let affected: Vec<(Ipv4Addr, Ipv6Addr)> = self
+            .v4
+            .iter()
+            .filter(|e| e.networks.contains(&net))
+            .map(|e| (*e.key(), e.ipv6))
+            .collect();
+        for (v4, v6) in affected {
+            self.drop_network(&v4, &v6, &net);
+        }
+    }
+
+    /// Add or refresh a single member's membership in `network` (incremental,
+    /// no replace). Used when we connect to a peer, so the map tracks it for a
+    /// later idle re-dial before the next full roster sync.
+    pub fn sync_add(&self, network: &str, ipv4: Ipv4Addr, ipv6: Ipv6Addr, endpoint_id: EndpointId) {
+        self.upsert(ipv4, ipv6, endpoint_id, SmolStr::new(network));
+    }
+
+    /// Resolve a destination mesh IPv4 to its roster target, if known.
+    pub fn resolve_v4(&self, ip: &Ipv4Addr) -> Option<RouteTarget> {
+        self.v4.get(ip).map(|e| e.to_target())
+    }
+
+    /// IPv6 counterpart of [`resolve_v4`](Self::resolve_v4).
+    pub fn resolve_v6(&self, ip: &Ipv6Addr) -> Option<RouteTarget> {
+        self.v6.get(ip).map(|e| e.to_target())
+    }
+}
+
+/// Per-peer reachability history, decoupled from live connections. The on-demand
+/// dialer stamps an outcome on every dial attempt; `ray status` reads it to tell
+/// an idle peer (never reached, or last reached fine) from an offline one (a
+/// recent reach attempt failed). Also serves as the dialer cooldown so a hard-down
+/// peer isn't re-dialed on every dropped packet.
+#[derive(Clone, Default)]
+pub struct Reachability {
+    inner: Arc<FastDashMap<EndpointId, ReachState>>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct ReachState {
+    last_ok: Option<Instant>,
+    last_fail: Option<Instant>,
+}
+
+impl ReachState {
+    /// True when the most recent outcome is a failure no older than `window`.
+    fn failing_within(&self, window: Duration) -> bool {
+        match self.last_fail {
+            Some(f) => f.elapsed() < window && self.last_ok.is_none_or(|ok| ok < f),
+            None => false,
+        }
+    }
+}
+
+impl Reachability {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn note_ok(&self, id: EndpointId) {
+        self.inner.entry(id).or_default().last_ok = Some(Instant::now());
+    }
+
+    pub fn note_fail(&self, id: EndpointId) {
+        self.inner.entry(id).or_default().last_fail = Some(Instant::now());
+    }
+
+    /// Whether the peer counts as offline for status: its most recent reach
+    /// attempt failed within `staleness`. A peer never dialed (or last reached
+    /// successfully) is not offline; `ray status` renders it idle.
+    pub fn is_offline(&self, id: &EndpointId, staleness: Duration) -> bool {
+        self.inner
+            .get(id)
+            .is_some_and(|s| s.failing_within(staleness))
+    }
+}
+
 /// Build a fresh [`PeerEntry`] for a peer's first shared network. Factored out so
 /// the v4/v6 `or_insert_with` closures in [`PeerTable::add`] agree.
 fn first_conn_placeholder(endpoint_id: EndpointId, conn: Connection, net: SmolStr) -> PeerEntry {
@@ -630,6 +930,7 @@ fn first_conn_placeholder(endpoint_id: EndpointId, conn: Connection, net: SmolSt
         networks,
         out_handles,
         in_handles: HashMap::new(),
+        last_active: Arc::new(AtomicU64::new(now_ms())),
     }
 }
 
@@ -691,6 +992,107 @@ mod tests {
     fn test_peer_table_empty_ids() {
         let table = PeerTable::new();
         assert!(table.all_peer_ids().is_empty());
+    }
+
+    // ---- RosterRouteMap --------------------------------------------------
+
+    fn member(seed: u8) -> RouteMember {
+        let id = iroh::SecretKey::from_bytes(&[seed; 32]).public();
+        RouteMember {
+            endpoint_id: id,
+            ipv4: crate::membership::derive_ip(&id),
+            ipv6: crate::membership::derive_ipv6(&id),
+        }
+    }
+
+    #[test]
+    fn route_map_sync_resolve_and_shrink() {
+        let map = RosterRouteMap::new();
+        let a = member(1);
+        let b = member(2);
+        map.sync_network("net", &[a, b]);
+
+        let ta = map.resolve_v4(&a.ipv4).expect("a resolvable");
+        assert_eq!(ta.endpoint_id, a.endpoint_id);
+        assert_eq!(ta.networks, vec![SmolStr::new("net")]);
+        assert_eq!(
+            map.resolve_v6(&b.ipv6).expect("b via v6").endpoint_id,
+            b.endpoint_id
+        );
+
+        // Re-sync with a shrunk roster: b is gone.
+        map.sync_network("net", &[a]);
+        assert!(map.resolve_v4(&a.ipv4).is_some());
+        assert!(
+            map.resolve_v4(&b.ipv4).is_none(),
+            "dropped member is unresolvable"
+        );
+        assert!(map.resolve_v6(&b.ipv6).is_none());
+    }
+
+    #[test]
+    fn route_map_multi_network_keeps_entry_until_last_network() {
+        let map = RosterRouteMap::new();
+        let a = member(7);
+        map.sync_network("dev", &[a]);
+        map.sync_network("db", &[a]);
+        let t = map.resolve_v4(&a.ipv4).expect("resolvable");
+        let mut nets = t.networks.clone();
+        nets.sort();
+        assert_eq!(nets, vec![SmolStr::new("db"), SmolStr::new("dev")]);
+
+        // Leaving one network keeps the peer reachable via the other.
+        map.remove_network("dev");
+        let t = map.resolve_v4(&a.ipv4).expect("still resolvable via db");
+        assert_eq!(t.networks, vec![SmolStr::new("db")]);
+
+        // Leaving the last network drops it entirely.
+        map.remove_network("db");
+        assert!(map.resolve_v4(&a.ipv4).is_none());
+    }
+
+    #[test]
+    fn route_map_sync_add_is_incremental() {
+        let map = RosterRouteMap::new();
+        let a = member(3);
+        let b = member(4);
+        map.sync_network("net", &[a]);
+        // Incremental add of b must not drop a (unlike a full sync_network).
+        map.sync_add("net", b.ipv4, b.ipv6, b.endpoint_id);
+        assert!(map.resolve_v4(&a.ipv4).is_some());
+        assert!(map.resolve_v4(&b.ipv4).is_some());
+    }
+
+    #[test]
+    fn reachability_offline_logic() {
+        let r = Reachability::new();
+        let id = member(9).endpoint_id;
+        // Never dialed: not offline (status renders it idle).
+        assert!(!r.is_offline(&id, Duration::from_secs(60)));
+        // A failed reach makes it offline within the window.
+        r.note_fail(id);
+        assert!(r.is_offline(&id, Duration::from_secs(60)));
+        // A later success clears it.
+        r.note_ok(id);
+        assert!(!r.is_offline(&id, Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn lazy_dial_dedup_via_in_flight_set() {
+        // The forwarding loop dedups dials with an in-flight set keyed by peer id.
+        let map = RosterRouteMap::new();
+        let a = member(11);
+        map.sync_network("net", &[a]);
+        let in_flight: HashSet<EndpointId> = HashSet::new();
+        let mut in_flight = in_flight;
+
+        let t = map.resolve_v4(&a.ipv4).expect("known member resolves");
+        // First packet claims the in-flight slot; a duplicate is rejected.
+        assert!(in_flight.insert(t.endpoint_id));
+        assert!(!in_flight.insert(t.endpoint_id), "duplicate dial is deduped");
+
+        // Unknown destination doesn't resolve, so nothing is dialed.
+        assert!(map.resolve_v4(&Ipv4Addr::new(100, 64, 9, 9)).is_none());
     }
 
     // ---- In-process real-connection tests --------------------------------
@@ -776,6 +1178,50 @@ mod tests {
         // Both networks route over the one connection.
         let route = table.lookup_v4(&ip).expect("peer routable");
         assert_eq!(route.conn.stable_id(), conn.stable_id());
+    }
+
+    #[tokio::test]
+    async fn idle_candidates_and_guarded_take() {
+        let (_srv, _cli, conn, _client_side) = connected_pair().await;
+        let peer = conn.remote_id();
+        let ip = crate::membership::derive_ip(&peer);
+        let ipv6 = crate::membership::derive_ipv6(&peer);
+        let table = PeerTable::new();
+        assert!(table.add(ip, ipv6, conn.clone(), peer, "n1"));
+        let stable = conn.stable_id();
+
+        // With a long idle window the freshly-added peer is not a candidate.
+        assert!(
+            table.idle_candidates(Duration::from_secs(3600)).is_empty(),
+            "a just-registered peer is not idle"
+        );
+        // With a zero window it is stale immediately.
+        let cands = table.idle_candidates(Duration::ZERO);
+        assert_eq!(cands, vec![(ip, ipv6, stable)]);
+
+        // A stale-id guard: a mismatched stable id never takes the entry.
+        assert!(
+            table
+                .take_if_idle(&ip, &ipv6, stable.wrapping_add(1), Duration::ZERO)
+                .is_none(),
+            "a refreshed connection (different stable id) is not torn down"
+        );
+        assert!(table.lookup_v4(&ip).is_some(), "entry survives the guard");
+
+        // Recorded activity moves it out of the idle set (bump then re-check).
+        let route = table.lookup_v4(&ip).unwrap();
+        route.note_activity();
+        assert!(
+            table
+                .take_if_idle(&ip, &ipv6, stable, Duration::from_secs(3600))
+                .is_none(),
+            "an active connection past the guard window is kept"
+        );
+
+        // The matching id + zero window takes and returns the connection to close.
+        let taken = table.take_if_idle(&ip, &ipv6, stable, Duration::ZERO);
+        assert!(taken.is_some(), "idle entry with matching id is taken");
+        assert!(table.lookup_v4(&ip).is_none(), "entry removed after take");
     }
 
     #[tokio::test]

--- a/src/peers.rs
+++ b/src/peers.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::sync::LazyLock;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use dashmap::DashSet;
@@ -23,13 +23,6 @@ fn now_ms() -> u64 {
     ACTIVITY_EPOCH.elapsed().as_millis() as u64
 }
 
-/// Whether a connection last active at `last_active` (ms) is idle for at least
-/// `idle_ms` as of `now` (ms). Age-based (`now - last_active >= idle_ms`) so a
-/// just-booted process, where `now` itself is smaller than `idle_ms`, never
-/// reports a peer idle before it could possibly have been.
-fn is_idle(now: u64, last_active: u64, idle_ms: u64) -> bool {
-    now.saturating_sub(last_active) >= idle_ms
-}
 
 /// A `DashMap` using ahash instead of the default SipHash. Used for the
 /// per-packet hot maps (routing table, conntrack, device→user resolution):
@@ -110,6 +103,11 @@ pub struct PeerEntry {
     /// whose last activity is older than the idle timeout. Shared as an `Arc` so the
     /// hot send path can bump it via a cloned handle on [`PeerRoute`].
     last_active: Arc<AtomicU64>,
+    /// Whether this peer advertised [`transport::FEATURE_IDLE_CLOSE`](crate::transport::FEATURE_IDLE_CLOSE)
+    /// in its `MeshHello`. We only idle-close a connection whose peer understands
+    /// the idle close code; a peer on a build that predates it (default `false`) is
+    /// held open like an eager node so it never flaps.
+    supports_idle_close: Arc<AtomicBool>,
 }
 
 /// Result of a routing lookup: the connection to send over, the peer identity,
@@ -314,62 +312,47 @@ impl PeerTable {
         self.by_id.get(peer_id).map(|e| *e.value())
     }
 
-    /// Record inbound traffic from `peer_id`, resetting its connection's idle timer.
-    /// Called by the per-connection data reader and control demux (which know only
-    /// the QUIC remote id) on every frame, so a connection carrying only control
-    /// traffic isn't reaped mid-exchange.
-    pub fn note_activity_by_id(&self, peer_id: &EndpointId) {
+    /// Record whether `peer_id` advertised idle-close support in its `MeshHello`
+    /// (`features & FEATURE_IDLE_CLOSE`). Drives whether the per-connection idle
+    /// timer is allowed to close this link.
+    pub fn note_idle_support_by_id(&self, peer_id: &EndpointId, supported: bool) {
         if let Some(ip) = self.by_id.get(peer_id).map(|e| *e.value())
             && let Some(e) = self.v4.get(&ip)
         {
-            e.last_active.store(now_ms(), Ordering::Relaxed);
+            e.supports_idle_close.store(supported, Ordering::Relaxed);
         }
     }
 
-    /// Peers whose connection has seen no traffic for at least `idle` — candidates
-    /// for on-demand teardown. Returns `(ipv4, ipv6, stable_id)`; the reaper closes
-    /// each via [`take_if_idle`](Self::take_if_idle), which re-checks under a lock so
-    /// a send or reconnect between the scan and the close can't lose a live link.
-    pub fn idle_candidates(&self, idle: Duration) -> Vec<(Ipv4Addr, Ipv6Addr, usize)> {
-        let idle_ms = idle.as_millis() as u64;
-        let now = now_ms();
-        self.v4
-            .iter()
-            .filter(|e| is_idle(now, e.last_active.load(Ordering::Relaxed), idle_ms))
-            .map(|e| {
-                (
-                    *e.key(),
-                    membership::derive_ipv6(&e.endpoint_id),
-                    e.conn.stable_id(),
-                )
-            })
-            .collect()
+    /// Whether `peer_id` understands the idle close code. `false` when the peer is
+    /// unknown or never advertised it, so an unregistered or pre-feature peer is
+    /// never idle-closed.
+    pub fn supports_idle_close(&self, peer_id: &EndpointId) -> bool {
+        self.by_id
+            .get(peer_id)
+            .map(|e| *e.value())
+            .and_then(|ip| self.v4.get(&ip).map(|e| e.supports_idle_close.load(Ordering::Relaxed)))
+            .unwrap_or(false)
     }
 
-    /// Remove the peer at `ip` and return its connection to close, but only if its
-    /// stored connection is still `stable_id` and still idle past `idle` — an atomic
-    /// re-check that guards against a send that bumped activity, or a reconnect that
-    /// installed a fresh connection, since the reaper's scan. `None` leaves the entry
-    /// untouched.
-    pub fn take_if_idle(
-        &self,
-        ip: &Ipv4Addr,
-        ipv6: &Ipv6Addr,
-        stable_id: usize,
-        idle: Duration,
-    ) -> Option<Connection> {
+    /// The shared last-activity clock for `peer_id`'s connection, so the
+    /// per-connection idle timer can watch it without repeated map lookups. `None`
+    /// if the peer is not registered.
+    pub fn last_active_of(&self, peer_id: &EndpointId) -> Option<Arc<AtomicU64>> {
+        self.by_id
+            .get(peer_id)
+            .map(|e| *e.value())
+            .and_then(|ip| self.v4.get(&ip).map(|e| e.last_active.clone()))
+    }
+
+    /// Time remaining until `peer_id`'s connection has been idle for `idle`
+    /// (`Duration::ZERO` once it already has). `None` if the peer is not registered.
+    /// Lets a per-connection idle timer sleep exactly the right amount and re-check
+    /// on wake without reaching into the activity clock's internals.
+    pub fn idle_remaining(&self, peer_id: &EndpointId, idle: Duration) -> Option<Duration> {
+        let last = self.last_active_of(peer_id)?;
+        let elapsed_ms = now_ms().saturating_sub(last.load(Ordering::Relaxed));
         let idle_ms = idle.as_millis() as u64;
-        let now = now_ms();
-        let (_, entry) = self.v4.remove_if(ip, |_, e| {
-            e.conn.stable_id() == stable_id
-                && is_idle(now, e.last_active.load(Ordering::Relaxed), idle_ms)
-        })?;
-        self.v6.remove(ipv6);
-        self.by_id.remove(&entry.endpoint_id);
-        if let Some(audit) = &self.audit {
-            audit.log_disconnect(*ip, &entry.endpoint_id.to_string());
-        }
-        Some(entry.conn)
+        Some(Duration::from_millis(idle_ms.saturating_sub(elapsed_ms)))
     }
 
     /// Resolve an inbound datagram from `peer_id` tagged with `handle` to the
@@ -390,6 +373,11 @@ impl PeerTable {
         if !e.networks.contains(network) {
             return None;
         }
+        // Reset the idle timer on the same entry we already hold, so a valid
+        // inbound datagram counts as activity with no extra lookup. Stamped only
+        // past the reachability wall above, so spoofed or out-of-network traffic
+        // can't hold an otherwise-idle connection open.
+        e.last_active.store(now_ms(), Ordering::Relaxed);
         Some((ip, network.clone()))
     }
 
@@ -931,6 +919,7 @@ fn first_conn_placeholder(endpoint_id: EndpointId, conn: Connection, net: SmolSt
         out_handles,
         in_handles: HashMap::new(),
         last_active: Arc::new(AtomicU64::new(now_ms())),
+        supports_idle_close: Arc::new(AtomicBool::new(false)),
     }
 }
 
@@ -1181,47 +1170,59 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn idle_candidates_and_guarded_take() {
+    async fn idle_support_capability_and_last_active_lookup() {
         let (_srv, _cli, conn, _client_side) = connected_pair().await;
         let peer = conn.remote_id();
         let ip = crate::membership::derive_ip(&peer);
         let ipv6 = crate::membership::derive_ipv6(&peer);
         let table = PeerTable::new();
+
+        // Unknown peer: not idle-close-capable, and no activity clock to watch.
+        assert!(!table.supports_idle_close(&peer));
+        assert!(table.last_active_of(&peer).is_none());
+
         assert!(table.add(ip, ipv6, conn.clone(), peer, "n1"));
-        let stable = conn.stable_id();
 
-        // With a long idle window the freshly-added peer is not a candidate.
+        // Registered but has not announced its capability yet: default is
+        // "unsupported" so we never idle-close a peer before it advertises.
+        assert!(!table.supports_idle_close(&peer));
+        assert!(table.last_active_of(&peer).is_some());
+
+        table.note_idle_support_by_id(&peer, true);
+        assert!(table.supports_idle_close(&peer));
+
+        table.note_idle_support_by_id(&peer, false);
+        assert!(!table.supports_idle_close(&peer));
+    }
+
+    #[tokio::test]
+    async fn idle_remaining_tracks_activity_clock() {
+        let (_srv, _cli, conn, _client_side) = connected_pair().await;
+        let peer = conn.remote_id();
+        let ip = crate::membership::derive_ip(&peer);
+        let ipv6 = crate::membership::derive_ipv6(&peer);
+        let table = PeerTable::new();
+        let window = Duration::from_secs(120);
+
+        // Unknown peer has no activity clock to watch.
+        assert!(table.idle_remaining(&peer, window).is_none());
+
+        assert!(table.add(ip, ipv6, conn.clone(), peer, "n1"));
+
+        // Freshly registered: nearly the whole window remains (slack for wall time).
+        let rem = table.idle_remaining(&peer, window).unwrap();
         assert!(
-            table.idle_candidates(Duration::from_secs(3600)).is_empty(),
-            "a just-registered peer is not idle"
-        );
-        // With a zero window it is stale immediately.
-        let cands = table.idle_candidates(Duration::ZERO);
-        assert_eq!(cands, vec![(ip, ipv6, stable)]);
-
-        // A stale-id guard: a mismatched stable id never takes the entry.
-        assert!(
-            table
-                .take_if_idle(&ip, &ipv6, stable.wrapping_add(1), Duration::ZERO)
-                .is_none(),
-            "a refreshed connection (different stable id) is not torn down"
-        );
-        assert!(table.lookup_v4(&ip).is_some(), "entry survives the guard");
-
-        // Recorded activity moves it out of the idle set (bump then re-check).
-        let route = table.lookup_v4(&ip).unwrap();
-        route.note_activity();
-        assert!(
-            table
-                .take_if_idle(&ip, &ipv6, stable, Duration::from_secs(3600))
-                .is_none(),
-            "an active connection past the guard window is kept"
+            rem > Duration::from_secs(115),
+            "a fresh peer keeps ~the full window, got {rem:?}"
         );
 
-        // The matching id + zero window takes and returns the connection to close.
-        let taken = table.take_if_idle(&ip, &ipv6, stable, Duration::ZERO);
-        assert!(taken.is_some(), "idle entry with matching id is taken");
-        assert!(table.lookup_v4(&ip).is_none(), "entry removed after take");
+        // A zero-length window means the connection is idle immediately (the same
+        // arithmetic the timer uses to decide it's time to close).
+        assert_eq!(table.idle_remaining(&peer, Duration::ZERO), Some(Duration::ZERO));
+
+        // A fresh activity bump keeps the full window (the timer would re-arm).
+        table.last_active_of(&peer).unwrap().store(now_ms(), Ordering::Relaxed);
+        assert!(table.idle_remaining(&peer, window).unwrap() > Duration::from_secs(115));
     }
 
     #[tokio::test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -76,6 +76,12 @@ pub struct ForwardMetrics {
     pub drops: Family<DropLabels, Counter>,
     /// REJECT replies sent (TCP RST / ICMP unreachable) when fail-fast mode is on
     pub rejects_sent: Counter,
+    /// On-demand lazy dials triggered by an outgoing packet to an unconnected peer
+    pub lazy_dials: Counter,
+    /// On-demand lazy dials that failed or timed out (peer stayed unconnected)
+    pub lazy_dials_failed: Counter,
+    /// Peer connections closed by the on-demand idle reaper
+    pub idle_teardowns: Counter,
 }
 
 impl ForwardMetrics {
@@ -95,6 +101,20 @@ impl ForwardMetrics {
 
     pub fn record_reject(&self) {
         self.rejects_sent.inc();
+    }
+
+    /// Record an on-demand lazy dial attempt and, when `connected` is false, that it
+    /// failed to bring the peer up.
+    pub fn record_lazy_dial(&self, connected: bool) {
+        self.lazy_dials.inc();
+        if !connected {
+            self.lazy_dials_failed.inc();
+        }
+    }
+
+    /// Record a connection closed by the idle reaper.
+    pub fn record_idle_teardown(&self) {
+        self.idle_teardowns.inc();
     }
 
     fn drop_count(&self, reason: DropReason) -> u64 {

--- a/src/term/style.rs
+++ b/src/term/style.rs
@@ -94,6 +94,13 @@ pub fn dot_offline() -> String {
     faint("○")
 }
 
+/// A muted filled dot for idle peers: a known roster member with no live link
+/// (dialed on demand). Distinct from the green online dot and the hollow offline
+/// dot: present, presumed reachable, just not currently connected.
+pub fn dot_idle() -> String {
+    paint("38;5;245", "●")
+}
+
 /// Success check mark.
 pub fn check() -> String {
     green("✓")

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -60,6 +60,15 @@ pub const RAYFISH_LISTEN_PORT: u16 = 41383;
 /// Welcome (deterministic) instead of a separate best-effort `AdminGrant` stream.
 pub const MESH_PROTOCOL_VERSION: u32 = 2;
 
+/// Capability bits a peer advertises in its `MeshHello.features`. These are
+/// negotiated *inside* the single mesh ALPN, so adding one needs no version bump:
+/// a peer acts on a bit only if the other side set it, and an absent `features`
+/// field decodes to `0` (a peer on a build that predates the bit). This is how
+/// idle-close coexists with v0.2.0 peers, which speak mesh v2 but do not
+/// understand [`forward::IDLE_CODE`](crate::forward::IDLE_CODE): we simply never
+/// idle-close a connection whose peer did not advertise `FEATURE_IDLE_CLOSE`.
+pub const FEATURE_IDLE_CLOSE: u64 = 1 << 0;
+
 /// The single mesh ALPN. Unlike the old per-network `rayfish/net/<v>/<prefix>`,
 /// every mesh connection now negotiates this one ALPN regardless of network — a
 /// peer holds exactly one QUIC connection to us, carrying all networks we share.

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -33,6 +33,14 @@ use tun_rs::{AsyncDevice, DeviceBuilder};
 /// Android `VpnService` fd whose descriptor is revoked/closed) MUST surface as
 /// `Err`, never as a perpetual `Ok(0)`, or `run_mesh` would busy-spin at 100%
 /// CPU. The desktop TUN never returns 0, so this only binds future impls.
+///
+/// **`read_into` MUST be cancel-safe.** `run_mesh` races it in a `select!` against
+/// dial-completion and shutdown, so the future can be dropped before it resolves.
+/// A dropped read MUST leave `buf` byte-for-byte as it was on entry: never append
+/// (or grow-then-not-truncate) before the `.await`, or a cancelled read leaves
+/// stray bytes in the pool that offset every later `split_to`, silently corrupting
+/// every subsequent packet. Read into owned scratch (or uninitialised spare
+/// capacity via `advance_mut`) and commit to `buf` only after the read returns.
 pub trait TunRead: Send + 'static {
     fn read_into(
         &mut self,
@@ -73,6 +81,9 @@ const READ_RESERVE: usize = TUN_MTU as usize + 4;
 #[cfg(not(target_os = "android"))]
 pub struct TunReader {
     dev: Arc<AsyncDevice>,
+    /// Owned landing buffer for one packet. `read_into` reads here first, then
+    /// copies into the caller's pool, which keeps it cancel-safe (see `read_into`).
+    scratch: Box<[u8]>,
 }
 
 /// Write half of the TUN device. Owned by [`forward::spawn_tun_writer`].
@@ -155,7 +166,14 @@ pub async fn create(v4: Ipv4Addr, v6: Ipv6Addr) -> Result<(TunReader, TunWriter,
     // `recv`/`send` take `&self`, so both halves share one device via `Arc`
     // instead of splitting into independent read/write objects.
     let dev = Arc::new(device);
-    Ok((TunReader { dev: dev.clone() }, TunWriter { dev }, tun_name))
+    Ok((
+        TunReader {
+            dev: dev.clone(),
+            scratch: vec![0u8; READ_RESERVE].into_boxed_slice(),
+        },
+        TunWriter { dev },
+        tun_name,
+    ))
 }
 
 /// Routes the peer ranges into the TUN. Must be called *after* the interface is
@@ -390,17 +408,19 @@ fn set_link_state(tun_name: &str, up: bool) -> Result<()> {
 
 #[cfg(not(target_os = "android"))]
 impl TunRead for TunReader {
-    /// Reads one packet from the TUN device, appending it to `buf`. tun-rs has no
-    /// `ReadBuf`/`AsyncRead` (what `read_buf` uses to fill uninitialised capacity),
-    /// only `recv(&mut [u8])`, so we expose an initialised `READ_RESERVE`-byte tail
-    /// on the caller's pool, read into it, then truncate to the packet length. The
-    /// packet lands directly in `buf`'s allocation, preserving the caller's
-    /// zero-copy `split_to(n).freeze()` hand-off.
+    /// Reads one packet from the TUN device, appending it to `buf`.
+    ///
+    /// **Cancel-safety matters here:** `run_mesh` races this future in a `select!`
+    /// against dial-completion and shutdown, so it can be dropped mid-`recv`. We
+    /// therefore read into an owned `scratch` buffer and only append to the caller's
+    /// pool *after* `recv` returns. Growing `buf` before the await (and truncating
+    /// after) would leave stray bytes in the pool whenever a read is cancelled,
+    /// permanently offsetting every subsequent `split_to`, so every packet parses as
+    /// garbage and the whole data plane wedges. The one extra copy is a single
+    /// sub-MTU `memcpy`; correctness beats the zero-copy read.
     async fn read_into(&mut self, buf: &mut bytes::BytesMut) -> anyhow::Result<usize> {
-        let start = buf.len();
-        buf.resize(start + READ_RESERVE, 0);
-        let n = self.dev.recv(&mut buf[start..]).await?;
-        buf.truncate(start + n);
+        let n = self.dev.recv(&mut self.scratch[..]).await?;
+        buf.extend_from_slice(&self.scratch[..n]);
         Ok(n)
     }
 }


### PR DESCRIPTION
Implements the connection-lifecycle half of #78: the mobile VPN should cost near-zero battery when idle so it can be left always-on.

## What changed

Nodes now connect to a peer **lazily**, on the first packet that needs it, instead of eagerly dialing every roster member at startup and holding those connections for the whole session. A connection with no traffic (data or control) past the idle timeout is closed, so an idle node keeps **zero** peer connections and stops waking the radio for QUIC keepalives. The link re-forms automatically on the next packet either side sends.

On by default (`on_demand`); opt out with `ray config set on-demand off`. `idle_timeout_secs` (default 120s) tunes the teardown window.

### Data path
- `run_mesh` buffers packets for an unconnected peer and dials once per peer (5s-timeout-bounded, in-flight dedup), flushing the buffer on connect or dropping it on failure.
- `RosterRouteMap` resolves the non-reversible mesh IP back to an identity for known-but-unconnected members.

### Idle teardown
- `IDLE_CODE` close reason + last-activity tracking (tx, rx, control frames) + a stable-id-guarded reaper, spawned only on on-demand nodes.
- `handle_disconnect` never reconnects an `Idle` close; on-demand suppresses the eager `Transient`/`Kicked` reconnect (re-dial is lazy), while still stamping `last_seen` for ephemeral aging.

### Local restore
- Coordinator and member restore register from the verified signed blob + seed the route map without dialing.

### Status
- Three-state `active` / `idle` / `offline` (Tailscale-style). `offline` shows only after a real failed reach; a fresh boot reads all-idle. `ray ping` dials on demand and refreshes reachability.

### CLI
- `ray config` now covers the `auto-update` and `on-demand` on/off toggles (`ray config set on-demand off`, `ray config unset on-demand`), listed by bare `ray config`. `ray auto-update on|off` still works as a shorthand.

### Metrics
- `lazy_dials`, `lazy_dials_failed`, `idle_teardowns` counters.

## Out of scope
The discovery / publication-suppression half of #78 (dropping the pkarr/relay registration when idle) is deliberately deferred.

## Testing
`cargo test --lib` (347 passing), `clippy --all-targets` clean, main + `ray-mobile` build clean. New unit tests: `close_reason` IDLE classification, `idle_candidates`/`take_if_idle` guard, lazy-dial dedup, reachability, route-map sync.