### PR TITLE
feat(freebsd): config to /usr/local/etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   still installed by our own netlink/`ifconfig` helpers. This is the groundwork for
   a later Linux GRO/GSO offload path that batches TUN writes.
 
+- **FreeBSD improvements.** The logs will be stored in /var/log and the configs
+  will be stored at /usr/local/etc.
+
 ### Added
 
 - **Static musl Linux binaries.** Every release and nightly now also ships

--- a/src/config.rs
+++ b/src/config.rs
@@ -627,11 +627,13 @@ pub fn config_dir() -> Result<PathBuf> {
     }
     #[cfg(target_os = "linux")]
     let dir = PathBuf::from("/etc/rayfish");
+    #[cfg(target_os = "freebsd")]
+    let dir = PathBuf::from("/usr/local/etc/rayfish");
     // Android without the override falls back to a fixed app-private path so the
     // library still compiles/runs standalone.
     #[cfg(target_os = "android")]
     let dir = PathBuf::from("/data/local/tmp/rayfish");
-    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd")))]
     let dir = dirs::config_dir()
         .context("could not determine config directory")?
         .join("rayfish");


### PR DESCRIPTION
This is the expected location for configs of 3rd party software on FreeBSD