### PR TITLE
fix(install): vendor install.sh, fix OS detection, gate it in CI

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,86 @@
+name: Install script
+
+# The install one-liner is piped straight into a root shell, so it gets the same
+# gate as the rest of the code: a linter and a real end-to-end run. The bug in
+# #95 (a global set inside a command substitution, lost in the caller) broke
+# every platform and shipped because nothing here ran it.
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - install.sh
+      - .github/workflows/install.yml
+  pull_request:
+    paths:
+      - install.sh
+      - .github/workflows/install.yml
+
+jobs:
+  lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      # `local` is not POSIX but every shell that can be /bin/sh here implements
+      # it, so lint against dash rather than the stricter `sh` dialect.
+      - name: Shellcheck
+        run: shellcheck -s dash install.sh
+
+  # Actually install the latest release. This is the check that matters: the
+  # script's whole job is to put a working `ray` on the host.
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install into an unprivileged dir
+        run: |
+          set -eu
+          dir="$(mktemp -d)/bin"   # does not exist yet: must not demand sudo
+          INSTALL_DIR="$dir" sh ./install.sh
+          test -x "$dir/ray"
+          "$dir/ray" --version
+
+      - name: Install into the default dir (sudo path)
+        run: |
+          set -eu
+          sh ./install.sh
+          command -v ray
+          ray --version
+
+      - name: Fail loudly on a release that does not exist
+        run: |
+          set -eu
+          out="$(INSTALL_DIR="$(mktemp -d)" RAY_VERSION=v0.0.0-nope sh ./install.sh 2>&1 || true)"
+          case "$out" in
+            *"download failed"*) echo "ok: missing release rejected" ;;
+            *) echo "expected a download failure, got: $out"; exit 1 ;;
+          esac
+
+  # Non-glibc and old-glibc hosts take the musl detection path, which the
+  # runners themselves never exercise.
+  smoke-libc:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: alpine:3.20            # musl
+            deps: apk add --no-cache curl
+          - image: debian:11              # glibc 2.31, below the 2.35 build floor
+            deps: apt-get update -qq && apt-get install -y -qq curl ca-certificates
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install on ${{ matrix.image }}
+        run: |
+          docker run --rm -v "$PWD:/w" -w /w ${{ matrix.image }} sh -c '
+            set -eu
+            ${{ matrix.deps }} >/dev/null
+            dir="$(mktemp -d)/bin"
+            INSTALL_DIR="$dir" sh ./install.sh
+            test -x "$dir/ray"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **The install script now lives in the repo** as `install.sh`, so the one command
+  users are asked to pipe into a root shell can be read, reviewed, and tested like
+  the rest of the code. CI lints it and installs the latest release with it on
+  Linux (glibc and musl) and macOS on every change. rayfish.xyz serves a copy of
+  this file, and its CI fails if the two drift apart.
+
 ### Fixed
+
+- **`curl -fsSL https://rayfish.xyz/install.sh | sh` works again.** The installer
+  detected the host OS inside a command substitution, which runs in a subshell, so
+  the value was lost in the caller and the script aborted with `OS: parameter not
+  set` on every Linux and macOS host. Reported in #95, fixed by @nemanjaglumac in
+  #97.
+
+- **The installer no longer asks for `sudo` when it doesn't need it.** Pointing
+  `INSTALL_DIR` at a path that didn't exist yet (`~/.local/bin`, typically) was
+  treated as "not writable", so the install escalated and left a root-owned
+  directory in the user's home. It now tests the nearest existing parent.
+
+- **The installer refuses to install a binary it can't verify.** A missing `.sha256`
+  sidecar silently skipped checksum verification. Every release publishes one, so a
+  missing sidecar now aborts the install (`RAY_SKIP_VERIFY=1` overrides).
 
 - **`ray mdns off` (and the other config-writing commands) now take effect on
   non-Linux hosts.** `ray mdns`, `ray auto-update`, `ray config set|unset`, and

--- a/README.md
+++ b/README.md
@@ -69,12 +69,17 @@ current without rebuilding.
 
 ### 1. Install & start
 
-Build the binary, then bring the VPN up:
+Install the latest release, then bring the VPN up:
 
 ```bash
-cargo build
+curl -fsSL https://rayfish.xyz/install.sh | sh
 sudo ray up    # installs the system service if needed, then activates the VPN
 ```
+
+The installer drops the `ray` binary in `/usr/local/bin` (override with
+`INSTALL_DIR`) and verifies its checksum. It's [`install.sh`](install.sh) in
+this repo, so you can read it before you run it. To build from source instead,
+`cargo build` and see [Building](#building).
 
 Only this first `ray up` needs root. It installs a small background service (the
 daemon) that owns the network device and does the actual tunneling. From then on

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,156 @@
+#!/bin/sh
+#
+# Rayfish installer. Installs the `ray` binary from the latest GitHub release.
+#
+#   curl -fsSL https://rayfish.xyz/install.sh | sh
+#
+# Options (env vars):
+#   INSTALL_DIR   target dir (default: /usr/local/bin)
+#   RAY_VERSION   pin a release tag, e.g. v0.1.0 (default: latest)
+#
+# POSIX sh: this is piped to `sh`, which is dash on most Linux distros and does
+# not support bash-only options like `set -o pipefail`.
+set -eu
+
+REPO="rayfish/rayfish"
+BIN="ray"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+VERSION="${RAY_VERSION:-latest}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; NC='\033[0m'
+info()  { printf "${BLUE}%s${NC}\n" "$*"; }
+ok()    { printf "${GREEN}%s${NC}\n" "$*"; }
+err()   { printf "${RED}%s${NC}\n" "$*" >&2; }
+die()   { err "$*"; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+need() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
+need curl
+
+# Lowest glibc the gnu Linux binaries are built against (CI runs on
+# ubuntu-22.04 = glibc 2.35). A host below this can't run the gnu build.
+GLIBC_MIN="2.35"
+
+# Sets the global OS and echoes the base asset name (no libc suffix).
+detect_asset() {
+  local arch
+  OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+  case "$OS" in
+    linux)  OS="linux" ;;
+    darwin) OS="macos" ;;
+    *) die "unsupported OS: $OS (Windows support is planned)" ;;
+  esac
+  case "$arch" in
+    x86_64|amd64)  arch="x86_64" ;;
+    aarch64|arm64) arch="aarch64" ;;
+    *) die "unsupported architecture: $arch" ;;
+  esac
+  echo "${BIN}-${OS}-${arch}"
+}
+
+# Whether this Linux host needs the static musl binary instead of the glibc
+# one: true on musl distros (Alpine) and on glibc older than the build floor.
+# Conservative: if the libc can't be identified, trust the gnu build.
+linux_needs_musl() {
+  local have lowest
+  # Alpine and friends: ldd reports musl on stderr.
+  ldd --version 2>&1 | grep -qi musl && return 0
+  have="$(getconf GNU_LIBC_VERSION 2>/dev/null | awk '{print $2}')"
+  [ -n "$have" ] || have="$(ldd --version 2>/dev/null | head -1 | awk '{print $NF}')"
+  [ -n "$have" ] || return 1
+  lowest="$(printf '%s\n%s\n' "$have" "$GLIBC_MIN" | sort -V 2>/dev/null | head -1)"
+  [ "$have" != "$GLIBC_MIN" ] && [ "$lowest" = "$have" ] && return 0
+  return 1
+}
+
+# True if a URL resolves to an actual asset (HEAD, following redirects).
+asset_exists() { curl -fsIL "$1" >/dev/null 2>&1; }
+
+# Base URL for the chosen release (latest → the redirecting "latest" path).
+release_base() {
+  if [ "$VERSION" = "latest" ]; then
+    echo "https://github.com/${REPO}/releases/latest/download"
+  else
+    echo "https://github.com/${REPO}/releases/download/${VERSION}"
+  fi
+}
+
+verify_sha256() {
+  local file="$1" sha_file="$2" expected actual
+  expected="$(cut -d' ' -f1 < "$sha_file")"
+  [ -n "$expected" ] || { info "no checksum published; skipping verification"; return 0; }
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$file" | cut -d' ' -f1)"
+  else
+    actual="$(shasum -a 256 "$file" | cut -d' ' -f1)"
+  fi
+  [ "$actual" = "$expected" ] || die "checksum mismatch
+  expected: $expected
+  got:      $actual"
+  ok "checksum verified"
+}
+
+main() {
+  local asset base url
+  asset="$(detect_asset)"
+  base="$(release_base)"
+
+  # On Linux, switch to the static musl asset when the glibc binary won't run
+  # here (musl distro, or glibc older than the build floor) but only if a musl
+  # asset was actually published for this version: older releases are gnu-only.
+  if [ "$OS" = "linux" ] && linux_needs_musl; then
+    if asset_exists "${base}/${asset}-musl"; then
+      info "glibc is unsuitable here; using the static musl build"
+      asset="${asset}-musl"
+    else
+      info "glibc looks unsuitable but no musl build is published for ${VERSION}; trying glibc anyway"
+    fi
+  fi
+
+  url="${base}/${asset}"
+
+  info "Downloading ${asset} (${VERSION}) ..."
+  curl -fsSL "$url" -o "$TMP/$BIN" \
+    || die "download failed: no release asset at $url
+(does a published release exist yet for this platform?)"
+
+  if curl -fsSL "${url}.sha256" -o "$TMP/$BIN.sha256" 2>/dev/null; then
+    verify_sha256 "$TMP/$BIN" "$TMP/$BIN.sha256"
+  else
+    info "no .sha256 sidecar found; skipping verification"
+  fi
+
+  chmod +x "$TMP/$BIN"
+
+  # Install. Use sudo when the target dir isn't writable by the current user.
+  local sudo=""
+  if [ ! -w "$INSTALL_DIR" ] && [ "$(id -u)" != "0" ]; then
+    if command -v sudo >/dev/null 2>&1; then
+      info "Installing to ${INSTALL_DIR} (requires sudo) ..."
+      sudo=sudo
+    else
+      die "$INSTALL_DIR is not writable and sudo is unavailable. Set INSTALL_DIR to a writable path."
+    fi
+  else
+    info "Installing to ${INSTALL_DIR} ..."
+  fi
+  $sudo mkdir -p "$INSTALL_DIR"
+  $sudo install -m 0755 "$TMP/$BIN" "$INSTALL_DIR/$BIN"
+
+  ok "Installed $($INSTALL_DIR/$BIN --version 2>/dev/null || echo "$BIN") to $INSTALL_DIR/$BIN"
+
+  case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *) info "Add ${INSTALL_DIR} to your PATH:
+    export PATH=\"${INSTALL_DIR}:\$PATH\"" ;;
+  esac
+
+  echo
+  ok "Next: start the VPN service with"
+  echo "    sudo ray up"
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ need curl
 # ubuntu-22.04 = glibc 2.35). A host below this can't run the gnu build.
 GLIBC_MIN="2.35"
 
-# Sets the global OS and echoes the base asset name (no libc suffix).
+# Sets the globals OS and ASSET (base asset name, no libc suffix); call directly.
 detect_asset() {
   local arch
   OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -48,7 +48,7 @@ detect_asset() {
     aarch64|arm64) arch="aarch64" ;;
     *) die "unsupported architecture: $arch" ;;
   esac
-  echo "${BIN}-${OS}-${arch}"
+  ASSET="${BIN}-${OS}-${arch}"
 }
 
 # Whether this Linux host needs the static musl binary instead of the glibc
@@ -95,7 +95,8 @@ verify_sha256() {
 
 main() {
   local asset base url
-  asset="$(detect_asset)"
+  detect_asset
+  asset="$ASSET"
   base="$(release_base)"
 
   # On Linux, switch to the static musl asset when the glibc binary won't run

--- a/install.sh
+++ b/install.sh
@@ -5,35 +5,53 @@
 #   curl -fsSL https://rayfish.xyz/install.sh | sh
 #
 # Options (env vars):
-#   INSTALL_DIR   target dir (default: /usr/local/bin)
-#   RAY_VERSION   pin a release tag, e.g. v0.1.0 (default: latest)
+#   INSTALL_DIR      target dir (default: /usr/local/bin)
+#   RAY_VERSION      pin a release tag, e.g. v0.1.0 (default: latest)
+#   RAY_SKIP_VERIFY  set to 1 to install without checksum verification
+#
+# This file is the canonical copy. rayfish.xyz serves a byte-identical copy from
+# the public-www repo, and its CI fails if the two drift.
 #
 # POSIX sh: this is piped to `sh`, which is dash on most Linux distros and does
-# not support bash-only options like `set -o pipefail`.
+# not support bash-only options like `set -o pipefail`. `local` is not in POSIX
+# either, but every shell that can be /bin/sh here (dash, ash/busybox, bash)
+# implements it, so shellcheck is pointed at the dash dialect.
+# shellcheck shell=dash
 set -eu
 
 REPO="rayfish/rayfish"
 BIN="ray"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 VERSION="${RAY_VERSION:-latest}"
+SKIP_VERIFY="${RAY_SKIP_VERIFY:-0}"
 
-RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; NC='\033[0m'
+if [ -t 1 ]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; BLUE=''; NC=''
+fi
 info()  { printf "${BLUE}%s${NC}\n" "$*"; }
 ok()    { printf "${GREEN}%s${NC}\n" "$*"; }
 err()   { printf "${RED}%s${NC}\n" "$*" >&2; }
 die()   { err "$*"; exit 1; }
 
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
-
 need() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
 need curl
+need mktemp
+need install
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
 
 # Lowest glibc the gnu Linux binaries are built against (CI runs on
 # ubuntu-22.04 = glibc 2.35). A host below this can't run the gnu build.
 GLIBC_MIN="2.35"
 
-# Sets the globals OS and ASSET (base asset name, no libc suffix); call directly.
+# Sets the globals OS and ASSET (base asset name, no libc suffix).
+#
+# Call this directly, never as `$(detect_asset)`: a command substitution runs in
+# a subshell, so the OS it sets there would be lost in the caller and the `set
+# -u` read below would abort the script.
 detect_asset() {
   local arch
   OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -69,7 +87,7 @@ linux_needs_musl() {
 # True if a URL resolves to an actual asset (HEAD, following redirects).
 asset_exists() { curl -fsIL "$1" >/dev/null 2>&1; }
 
-# Base URL for the chosen release (latest → the redirecting "latest" path).
+# Base URL for the chosen release (latest = the redirecting "latest" path).
 release_base() {
   if [ "$VERSION" = "latest" ]; then
     echo "https://github.com/${REPO}/releases/latest/download"
@@ -78,23 +96,49 @@ release_base() {
   fi
 }
 
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  else
+    die "no sha256sum or shasum on this host, cannot verify the download.
+Install one, or set RAY_SKIP_VERIFY=1 to install unverified."
+  fi
+}
+
+# The checksum sidecar is served from the same origin as the binary, so this
+# catches corruption and truncation, not a compromised release. It is still the
+# integrity floor: never skip it silently, since every release publishes one.
 verify_sha256() {
   local file="$1" sha_file="$2" expected actual
-  expected="$(cut -d' ' -f1 < "$sha_file")"
-  [ -n "$expected" ] || { info "no checksum published; skipping verification"; return 0; }
-  if command -v sha256sum >/dev/null 2>&1; then
-    actual="$(sha256sum "$file" | cut -d' ' -f1)"
-  else
-    actual="$(shasum -a 256 "$file" | cut -d' ' -f1)"
-  fi
+  expected="$(head -n 1 "$sha_file" | cut -d' ' -f1)"
+  case "$expected" in
+    "" | *[!0-9a-fA-F]*) die "malformed checksum sidecar for $(basename "$file")" ;;
+  esac
+  actual="$(sha256_of "$file")"
   [ "$actual" = "$expected" ] || die "checksum mismatch
   expected: $expected
   got:      $actual"
   ok "checksum verified"
 }
 
+# The nearest existing directory at or above $1. A target that does not exist
+# yet is not writable, so testing $INSTALL_DIR itself would demand sudo for a
+# path the user can perfectly well create (~/.local/bin, typically) and leave a
+# root-owned directory in their home.
+existing_ancestor() {
+  local d="$1" parent
+  while [ ! -d "$d" ]; do
+    parent="$(dirname "$d")"
+    [ "$parent" != "$d" ] || break
+    d="$parent"
+  done
+  echo "$d"
+}
+
 main() {
-  local asset base url
+  local asset base url sudo=""
   detect_asset
   asset="$ASSET"
   base="$(release_base)"
@@ -120,15 +164,18 @@ main() {
 
   if curl -fsSL "${url}.sha256" -o "$TMP/$BIN.sha256" 2>/dev/null; then
     verify_sha256 "$TMP/$BIN" "$TMP/$BIN.sha256"
+  elif [ "$SKIP_VERIFY" = "1" ]; then
+    info "no .sha256 sidecar found; RAY_SKIP_VERIFY=1, installing unverified"
   else
-    info "no .sha256 sidecar found; skipping verification"
+    die "no checksum published at ${url}.sha256
+Every Rayfish release ships a .sha256 sidecar, so this should not happen.
+Refusing to install an unverified binary. Set RAY_SKIP_VERIFY=1 to override."
   fi
 
   chmod +x "$TMP/$BIN"
 
   # Install. Use sudo when the target dir isn't writable by the current user.
-  local sudo=""
-  if [ ! -w "$INSTALL_DIR" ] && [ "$(id -u)" != "0" ]; then
+  if [ ! -w "$(existing_ancestor "$INSTALL_DIR")" ] && [ "$(id -u)" != "0" ]; then
     if command -v sudo >/dev/null 2>&1; then
       info "Installing to ${INSTALL_DIR} (requires sudo) ..."
       sudo=sudo
@@ -141,7 +188,7 @@ main() {
   $sudo mkdir -p "$INSTALL_DIR"
   $sudo install -m 0755 "$TMP/$BIN" "$INSTALL_DIR/$BIN"
 
-  ok "Installed $($INSTALL_DIR/$BIN --version 2>/dev/null || echo "$BIN") to $INSTALL_DIR/$BIN"
+  ok "Installed $("$INSTALL_DIR/$BIN" --version 2>/dev/null || echo "$BIN") to $INSTALL_DIR/$BIN"
 
   case ":$PATH:" in
     *":$INSTALL_DIR:"*) ;;


### PR DESCRIPTION
Builds on #97 by @nemanjaglumac (his commits are included here, so merging this lands his fix).

## What

`curl -fsSL https://rayfish.xyz/install.sh | sh` failed on every Linux and macOS host with `OS: parameter not set`. `detect_asset` set the `OS` global inside a command substitution, which runs in a subshell, so the value was gone by the time `main` read it and `set -u` aborted. Reported in #95.

The script now lives in the repo, so it gets the same treatment as the rest of the code.

On top of the OS fix:

- **Never install an unverified binary.** A missing `.sha256` sidecar silently skipped verification. Every release publishes one, so a missing sidecar now aborts (`RAY_SKIP_VERIFY=1` overrides). A malformed sidecar is rejected too, instead of comparing against an empty string.
- **No sudo for a target that just does not exist yet.** An `INSTALL_DIR` that is not there reads as not writable, so `~/.local/bin` escalated and left a root-owned directory in the user home. It now tests the nearest existing parent.
- Clear failure when `mktemp`, `install`, or a sha256 tool is missing; color only on a terminal; quoted install path.

## CI

New `install.yml`: shellcheck, plus a real install of the latest release on Linux and macOS, and on Alpine (musl) and Debian 11 (glibc 2.31, below our 2.35 floor) for the libc-detection path. Nothing ran this script before, which is why the bug shipped.

rayfish.xyz serves a copy of this file from the public-www repo; that repo now fails its build if the two drift.

## Tested

Reproduced the failure, ran the fixed script end to end (installs `ray 0.2.0` into a fresh dir with no sudo prompt), and drove the checksum paths with a stubbed `curl`: a missing sidecar and a tampered hash both refuse to install. Shellcheck clean. No Rust touched.

Closes #95