### PR TITLE
fix(clippy): iterate map values directly

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -117,7 +117,7 @@ fn normalize_nil(v: &mut config::Value) {
             v.kind = ValueKind::Table(config::Map::new());
         }
         ValueKind::Table(t) => {
-            for (_k, child) in t.iter_mut() {
+            for child in t.values_mut() {
                 normalize_nil(child);
             }
         }

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -108,7 +108,7 @@ pub async fn sync_network_hostnames(
     let mut t = table.write().await;
     // Drop reverse entries for the network's previous set before rebuilding.
     if let Some(old) = t.get(network) {
-        for (_, (v4, v6)) in old.iter() {
+        for (v4, v6) in old.values() {
             reverse.remove(&IpAddr::V4(*v4));
             reverse.remove(&IpAddr::V6(*v6));
         }


### PR DESCRIPTION
Master has been red on clippy since #92 (`-D warnings` turns `clippy::iter_kv_map` into an error):

- `src/apply.rs:120`
- `src/dns/mod.rs:111`

Both loops destructured a key they never used. Switched to `values()` / `values_mut()`. No behavior change.

`cargo clippy --all-targets -- -D warnings` is clean and `cargo test` passes (373 tests).