### PR TITLE
feat(android): stay online with the VPN off, and honest transfer notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **Android: keep sending and receiving files with the VPN off.** A new "Keep files
-  working when the VPN is off" toggle in You (default off) keeps Rayfish's control
-  plane connected when the tunnel comes down, so files still arrive and still send,
-  and the phone stays visible in the mesh. Android only allows one VPN at a time, so
-  this is what lets you run another VPN (Tailscale, say) and keep using Rayfish for
-  files. It applies whether you turn the VPN off in the app or another VPN app takes
-  the slot.
+- **Android: disabling Rayfish no longer takes the phone offline.** Turning the VPN
+  off (in the app, or because another VPN app took the slot) now drops the tunnel
+  and releases the VPN slot but keeps Rayfish's control plane connected, so files
+  still arrive and still send and the phone stays visible in the mesh. Android only
+  allows one VPN at a time, so this is what lets you run another VPN (Tailscale,
+  say) alongside Rayfish. A new "Go fully offline when disabled" toggle in You
+  (default off) is there for anyone who wants the old behavior back.
 - **Android: accurate notifications for sent and received files.** Sending a file
   now shows a progress bar and only reports "Sent" once the recipient has actually
   pulled the bytes, not just once the offer went out (a manual accept on the other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   this is what lets you run another VPN (Tailscale, say) and keep using Rayfish for
   files. It applies whether you turn the VPN off in the app or another VPN app takes
   the slot.
+- **Android: accurate notifications for sent and received files.** Sending a file
+  now shows a progress bar and only reports "Sent" once the recipient has actually
+  pulled the bytes, not just once the offer went out (a manual accept on the other
+  end can take a while, or never happen). Receiving a file, including an
+  auto-accepted one from your own paired device, now posts its own progress and
+  "Saved" notification instead of landing in Downloads silently. Both keep working
+  in the background, including with the VPN off.
 - **The install script now lives in the repo** as `install.sh`, so the one command
   users are asked to pipe into a root shell can be read, reviewed, and tested like
   the rest of the code. CI lints it and installs the latest release with it on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Android: keep sending and receiving files with the VPN off.** A new "Keep files
+  working when the VPN is off" toggle in You (default off) keeps Rayfish's control
+  plane connected when the tunnel comes down, so files still arrive and still send,
+  and the phone stays visible in the mesh. Android only allows one VPN at a time, so
+  this is what lets you run another VPN (Tailscale, say) and keep using Rayfish for
+  files. It applies whether you turn the VPN off in the app or another VPN app takes
+  the slot.
 - **The install script now lives in the repo** as `install.sh`, so the one command
   users are asked to pipe into a root shell can be read, reviewed, and tested like
   the rest of the code. CI lints it and installs the latest release with it on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   auto-accepted one from your own paired device, now posts its own progress and
   "Saved" notification instead of landing in Downloads silently. Both keep working
   in the background, including with the VPN off.
+- **Android: a one-tap "Disable" on the VPN notification.** While the VPN is on, its
+  persistent notification now carries a Disable action, so you can drop the tunnel
+  and free the VPN slot from the notification shade (as Tailscale does) without
+  opening the app. Under the default above, the control plane stays up, so files
+  keep working after you disable.
 - **The install script now lives in the repo** as `install.sh`, so the one command
   users are asked to pipe into a root shell can be read, reviewed, and tested like
   the rest of the code. CI lints it and installs the latest release with it on

--- a/android/app/src/main/java/uniffi/ray_mobile/ray_mobile.kt
+++ b/android/app/src/main/java/uniffi/ray_mobile/ray_mobile.kt
@@ -786,6 +786,8 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 
 
 
+
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -840,6 +842,8 @@ fun uniffi_ray_mobile_checksum_method_node_list_connect_requests(
 fun uniffi_ray_mobile_checksum_method_node_list_file_offers(
 ): Short
 fun uniffi_ray_mobile_checksum_method_node_list_join_requests(
+): Short
+fun uniffi_ray_mobile_checksum_method_node_list_transfers(
 ): Short
 fun uniffi_ray_mobile_checksum_method_node_log_snapshot(
 ): Short
@@ -967,6 +971,8 @@ fun uniffi_ray_mobile_fn_method_node_list_connect_requests(`ptr`: Pointer,uniffi
 fun uniffi_ray_mobile_fn_method_node_list_file_offers(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_ray_mobile_fn_method_node_list_join_requests(`ptr`: Pointer,`network`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
+fun uniffi_ray_mobile_fn_method_node_list_transfers(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_ray_mobile_fn_method_node_log_snapshot(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
@@ -1182,6 +1188,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ray_mobile_checksum_method_node_list_join_requests() != 56409.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_ray_mobile_checksum_method_node_list_transfers() != 2731.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ray_mobile_checksum_method_node_log_snapshot() != 20955.toShort()) {
@@ -1741,6 +1750,13 @@ public interface NodeInterface {
     fun `listJoinRequests`(`network`: kotlin.String): List<PendingRequest>
     
     /**
+     * In-flight and recently finished transfers, both directions. Terminal entries
+     * linger for 60s so a poller can see them before they expire. Cheap: safe to
+     * poll on a timer while a notification is on screen.
+     */
+    fun `listTransfers`(): List<Transfer>
+    
+    /**
      * The full buffered core log, for the "Send diagnostics" button.
      */
     fun `logSnapshot`(): kotlin.String
@@ -2270,6 +2286,24 @@ open class Node: Disposable, AutoCloseable, NodeInterface
     uniffiRustCallWithError(RayException) { _status ->
     UniffiLib.INSTANCE.uniffi_ray_mobile_fn_method_node_list_join_requests(
         it, FfiConverterString.lower(`network`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
+     * In-flight and recently finished transfers, both directions. Terminal entries
+     * linger for 60s so a poller can see them before they expire. Cheap: safe to
+     * poll on a timer while a notification is on screen.
+     */
+    @Throws(RayException::class)override fun `listTransfers`(): List<Transfer> {
+            return FfiConverterSequenceTypeTransfer.lift(
+    callWithPointer {
+    uniffiRustCallWithError(RayException) { _status ->
+    UniffiLib.INSTANCE.uniffi_ray_mobile_fn_method_node_list_transfers(
+        it, _status)
 }
     }
     )
@@ -3073,6 +3107,61 @@ public object FfiConverterTypeStatus: FfiConverterRustBuffer<Status> {
 
 
 /**
+ * One in-flight (or recently finished) file transfer, either direction.
+ */
+data class Transfer (
+    var `id`: kotlin.ULong, 
+    var `outgoing`: kotlin.Boolean, 
+    var `peer`: kotlin.String, 
+    var `filename`: kotlin.String, 
+    var `size`: kotlin.ULong, 
+    var `transferred`: kotlin.ULong, 
+    var `state`: TransferState
+) {
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeTransfer: FfiConverterRustBuffer<Transfer> {
+    override fun read(buf: ByteBuffer): Transfer {
+        return Transfer(
+            FfiConverterULong.read(buf),
+            FfiConverterBoolean.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterULong.read(buf),
+            FfiConverterULong.read(buf),
+            FfiConverterTypeTransferState.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: Transfer) = (
+            FfiConverterULong.allocationSize(value.`id`) +
+            FfiConverterBoolean.allocationSize(value.`outgoing`) +
+            FfiConverterString.allocationSize(value.`peer`) +
+            FfiConverterString.allocationSize(value.`filename`) +
+            FfiConverterULong.allocationSize(value.`size`) +
+            FfiConverterULong.allocationSize(value.`transferred`) +
+            FfiConverterTypeTransferState.allocationSize(value.`state`)
+    )
+
+    override fun write(value: Transfer, buf: ByteBuffer) {
+            FfiConverterULong.write(value.`id`, buf)
+            FfiConverterBoolean.write(value.`outgoing`, buf)
+            FfiConverterString.write(value.`peer`, buf)
+            FfiConverterString.write(value.`filename`, buf)
+            FfiConverterULong.write(value.`size`, buf)
+            FfiConverterULong.write(value.`transferred`, buf)
+            FfiConverterTypeTransferState.write(value.`state`, buf)
+    }
+}
+
+
+
+/**
  * The outcome of following a `rayfish://` deep link, reflected in the UI.
  */
 sealed class LinkAction {
@@ -3292,6 +3381,43 @@ public object FfiConverterTypeRayError : FfiConverterRustBuffer<RayException> {
     }
 
 }
+
+
+
+/**
+ * Where a transfer is. A send is `Offered` until the peer accepts and starts
+ * pulling the bytes: `send_file` returns once the offer lands, not once the file
+ * has arrived, so `Done` on an outgoing transfer is the real "they have it".
+ */
+
+enum class TransferState {
+    
+    OFFERED,
+    TRANSFERRING,
+    DONE,
+    FAILED;
+    companion object
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeTransferState: FfiConverterRustBuffer<TransferState> {
+    override fun read(buf: ByteBuffer) = try {
+        TransferState.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: TransferState) = 4UL
+
+    override fun write(value: TransferState, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
 
 
 
@@ -3517,6 +3643,34 @@ public object FfiConverterSequenceTypePendingRequest: FfiConverterRustBuffer<Lis
         buf.putInt(value.size)
         value.iterator().forEach {
             FfiConverterTypePendingRequest.write(it, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterSequenceTypeTransfer: FfiConverterRustBuffer<List<Transfer>> {
+    override fun read(buf: ByteBuffer): List<Transfer> {
+        val len = buf.getInt()
+        return List<Transfer>(len) {
+            FfiConverterTypeTransfer.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<Transfer>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterTypeTransfer.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<Transfer>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterTypeTransfer.write(it, buf)
         }
     }
 }

--- a/android/app/src/main/java/xyz/rayfish/android/Files.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/Files.kt
@@ -93,9 +93,18 @@ internal fun stageUriForSend(context: Context, uri: Uri): File? {
  * Gated by the user's opt-out toggle (default on). Idempotent: a process-lived set
  * of accepted ids prevents re-accepting the same offer across the many pollers that
  * call this (the foreground HomeScreen poll and the VpnService background poll).
+ *
+ * Accepts run on a small bounded pool rather than one raw thread per offer: with two
+ * pollers (HomeScreen every 2s, the VPN service every 4s) and no cap, a persistently
+ * failing offer would otherwise respawn an unbounded number of concurrent blocking
+ * downloads. Retries are also capped per offer id; past [MAX_ATTEMPTS] the id is left
+ * in [handled] for good so it stops being retried.
  */
 object FileAutoAccept {
     private val handled = java.util.Collections.synchronizedSet(HashSet<ULong>())
+    private val attempts = java.util.concurrent.ConcurrentHashMap<ULong, Int>()
+    private val executor = java.util.concurrent.Executors.newFixedThreadPool(2)
+    private const val MAX_ATTEMPTS = 3
 
     /** Runs on the caller's coroutine context; callers dispatch it on IO. */
     fun run(context: Context) {
@@ -107,18 +116,25 @@ object FileAutoAccept {
         for (f in offers) {
             if (!f.ownDevice) continue
             if (!handled.add(f.id)) continue
-            // Accept on its own thread: acceptFileOffer blocks for the whole download,
-            // and the caller here is the same 4s poller that reports progress. The
-            // core registers the transfer, so TransferNotifier picks it up.
-            kotlin.concurrent.thread(name = "rayfish-accept-${f.id}") {
+            // acceptFileOffer blocks for the whole download; the bounded pool caps
+            // how many can run at once regardless of how many offers are pending.
+            // The core registers the transfer, so TransferNotifier picks it up.
+            executor.execute {
                 try {
                     node.acceptFileOffer(f.id, saveDir)
                     moveToDownloads(context, File(saveDir, f.filename), f.filename, f.mimeType)
+                    attempts.remove(f.id)
                     Log.i("RayfishFiles", "auto-accepted own-device file ${f.filename}")
                 } catch (t: Throwable) {
-                    // Let a later poll retry this id.
-                    handled.remove(f.id)
-                    Log.w("RayfishFiles", "auto-accept failed for ${f.filename}", t)
+                    val tries = attempts.merge(f.id, 1) { old, inc -> old + inc } ?: 1
+                    if (tries < MAX_ATTEMPTS) {
+                        // Let a later poll retry this id.
+                        handled.remove(f.id)
+                        Log.w("RayfishFiles", "auto-accept failed for ${f.filename}, will retry ($tries/$MAX_ATTEMPTS)", t)
+                    } else {
+                        // Give up: id stays in `handled` so no poller respawns it again.
+                        Log.w("RayfishFiles", "auto-accept giving up on ${f.filename} after $tries attempts", t)
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/xyz/rayfish/android/Files.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/Files.kt
@@ -16,27 +16,75 @@ import java.util.UUID
  */
 
 /**
- * Whether the most recent [moveToDownloads] call for a given filename actually
+ * Identifies one accept call's worth of work for [DownloadsOutcome], on both sides
+ * of the accept (FileAutoAccept / HomeScreen's Save) and the later TransferNotifier
+ * poll that reports the terminal result. There is no id shared across the FFI
+ * boundary here: the offer id (FileOffer.id) and the transfer id the core assigns
+ * once accept_file starts (Transfer.id) are two independent counters, and
+ * Node.acceptFileOffer returns nothing that would let Kotlin learn the resulting
+ * transfer id. (peer, filename, size) is the closest thing to unique available on
+ * both sides; it only collides if the same peer sends two files with the same name
+ * and size at the same time, an accepted rough edge, not a correctness requirement
+ * here.
+ */
+internal data class TransferKey(val peer: String, val filename: String, val size: ULong)
+
+/**
+ * Whether the most recent [moveToDownloads] call for a given transfer actually
  * landed the file in the public Downloads collection, so [TransferNotifier] can
  * report the truth instead of assuming Downloads whenever a receive completes.
  *
- * Keyed by filename rather than transfer id: the accept call site (FileAutoAccept,
- * or HomeScreen's manual Save) and the later TransferNotifier poll that reports
- * the terminal result are on different call chains with no transfer id in common
- * at accept time. A same-name collision between two receives in flight at once is
- * an accepted rough edge, not a correctness requirement here.
+ * The core reports a receive as DONE inside the blocking acceptFileOffer call,
+ * before moveToDownloads (the MediaStore byte copy) even starts, so a poller can
+ * observe DONE while the copy is still running. [markPending] records that a save
+ * is in flight for a key *before* acceptFileOffer is called; TransferNotifier
+ * checks [isPending] and, while true, defers posting the result entirely (and
+ * does not mark the transfer terminal) rather than posting a guess that can be
+ * permanently wrong. [record] (success) and [clearPending] (the accept itself
+ * failed, so no Downloads outcome will ever be recorded) both clear it.
  */
 internal object DownloadsOutcome {
-    private val outcomes = java.util.Collections.synchronizedMap(HashMap<String, Boolean>())
+    private val outcomes = java.util.Collections.synchronizedMap(HashMap<TransferKey, Boolean>())
+    private val pending = java.util.Collections.synchronizedMap(HashMap<TransferKey, Long>())
 
-    fun record(filename: String, reachedDownloads: Boolean) {
-        outcomes[filename] = reachedDownloads
+    // A save that never completes (process death mid-copy, a wedged MediaStore
+    // call) must not mute the result notification forever: past this much time
+    // since markPending, isPending gives up waiting and lets the poller post
+    // whatever it can determine (no Downloads claim, since none was ever
+    // recorded). Comfortably under the core's 60s terminal-listability window, so
+    // a poll still has time left to observe and post the terminal state once this
+    // expires instead of the entry aging out of the registry unreported.
+    private const val PENDING_TIMEOUT_MS = 45_000L
+
+    fun markPending(key: TransferKey) {
+        pending[key] = android.os.SystemClock.elapsedRealtime()
+    }
+
+    /** The accept itself failed before a Downloads outcome could ever be recorded
+     * for this key: stop treating it as pending so the failure result can post on
+     * the very next poll instead of waiting out [PENDING_TIMEOUT_MS]. */
+    fun clearPending(key: TransferKey) {
+        pending.remove(key)
+    }
+
+    fun isPending(key: TransferKey): Boolean {
+        val since = pending[key] ?: return false
+        if (android.os.SystemClock.elapsedRealtime() - since > PENDING_TIMEOUT_MS) {
+            pending.remove(key)
+            return false
+        }
+        return true
+    }
+
+    fun record(key: TransferKey, reachedDownloads: Boolean) {
+        pending.remove(key)
+        outcomes[key] = reachedDownloads
     }
 
     /** Consumes (removes) the recorded outcome so a later receive reusing the same
-     * filename does not read a stale value. Defaults to false (the neutral "Saved"
+     * key does not read a stale value. Defaults to false (the neutral "Saved"
      * copy, no Downloads tap target) when nothing was recorded. */
-    fun consume(filename: String): Boolean = outcomes.remove(filename) ?: false
+    fun consume(key: TransferKey): Boolean = outcomes.remove(key) ?: false
 }
 
 /**
@@ -127,8 +175,14 @@ internal fun stageUriForSend(context: Context, uri: Uri): File? {
 object FileAutoAccept {
     private val handled = java.util.Collections.synchronizedSet(HashSet<ULong>())
     private val attempts = java.util.concurrent.ConcurrentHashMap<ULong, Int>()
-    private val executor = java.util.concurrent.Executors.newFixedThreadPool(2)
+    private val executor = java.util.concurrent.Executors.newFixedThreadPool(2) as java.util.concurrent.ThreadPoolExecutor
     private const val MAX_ATTEMPTS = 3
+
+    /** Best-effort: whether an accept is currently running on [executor]. Used only
+     * to log plainly when a forced offline teardown (see RayfishVpnService's
+     * handleBringUpFailure) is about to drop an in-flight receive; not a signal
+     * anything waits on or retries against. */
+    fun hasInFlightAccepts(): Boolean = executor.activeCount > 0
     // Ids we have permanently given up retrying. Exposed so HomeScreen can exempt
     // them from the "hide own-device offers while auto-accept is on" filter: once
     // we give up, the offer would otherwise be invisible with no way to save it.
@@ -160,6 +214,13 @@ object FileAutoAccept {
         for (f in offers) {
             if (!f.ownDevice) continue
             if (!handled.add(f.id)) continue
+            val key = TransferKey(f.from, f.filename, f.size)
+            // Mark the save pending before the blocking accept even starts: the
+            // core reports the transfer DONE from inside acceptFileOffer, well
+            // before moveToDownloads below has copied a single byte, so a poller
+            // racing this thread must see "pending" from the first moment DONE
+            // can appear.
+            DownloadsOutcome.markPending(key)
             // acceptFileOffer blocks for the whole download; the bounded pool caps
             // how many can run at once regardless of how many offers are pending.
             // The core registers the transfer, so TransferNotifier picks it up.
@@ -167,10 +228,15 @@ object FileAutoAccept {
                 try {
                     node.acceptFileOffer(f.id, saveDir)
                     val reached = moveToDownloads(context, File(saveDir, f.filename), f.filename, f.mimeType)
-                    DownloadsOutcome.record(f.filename, reached)
+                    DownloadsOutcome.record(key, reached)
                     attempts.remove(f.id)
                     Log.i("RayfishFiles", "auto-accepted own-device file ${f.filename}")
                 } catch (t: Throwable) {
+                    // The accept itself failed: no Downloads outcome is ever coming
+                    // for this key, so stop treating it as pending immediately
+                    // rather than making the result notification wait out the
+                    // timeout for a failure that has already happened.
+                    DownloadsOutcome.clearPending(key)
                     val tries = attempts.merge(f.id, 1) { old, inc -> old + inc } ?: 1
                     if (tries < MAX_ATTEMPTS) {
                         // Let a later poll retry this id.

--- a/android/app/src/main/java/xyz/rayfish/android/Files.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/Files.kt
@@ -105,6 +105,14 @@ object FileAutoAccept {
     private val attempts = java.util.concurrent.ConcurrentHashMap<ULong, Int>()
     private val executor = java.util.concurrent.Executors.newFixedThreadPool(2)
     private const val MAX_ATTEMPTS = 3
+    // Ids we have permanently given up retrying. Exposed so HomeScreen can exempt
+    // them from the "hide own-device offers while auto-accept is on" filter: once
+    // we give up, the offer would otherwise be invisible with no way to save it.
+    private val gaveUp = java.util.Collections.synchronizedSet(HashSet<ULong>())
+
+    /** True once auto-accept has permanently given up on this offer id (past
+     * MAX_ATTEMPTS). Lets the caller fall back to a manual Save row. */
+    fun hasGivenUp(id: ULong): Boolean = id in gaveUp
 
     /** Runs on the caller's coroutine context; callers dispatch it on IO. */
     fun run(context: Context) {
@@ -132,7 +140,10 @@ object FileAutoAccept {
                         handled.remove(f.id)
                         Log.w("RayfishFiles", "auto-accept failed for ${f.filename}, will retry ($tries/$MAX_ATTEMPTS)", t)
                     } else {
-                        // Give up: id stays in `handled` so no poller respawns it again.
+                        // Give up: id stays in `handled` so no poller respawns it
+                        // again, and is recorded in `gaveUp` so the offer can still
+                        // be saved manually instead of vanishing for good.
+                        gaveUp.add(f.id)
                         Log.w("RayfishFiles", "auto-accept giving up on ${f.filename} after $tries attempts", t)
                     }
                 }

--- a/android/app/src/main/java/xyz/rayfish/android/Files.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/Files.kt
@@ -51,9 +51,14 @@ internal object DownloadsOutcome {
     // call) must not mute the result notification forever: past this much time
     // since markPending, isPending gives up waiting and lets the poller post
     // whatever it can determine (no Downloads claim, since none was ever
-    // recorded). Comfortably under the core's 60s terminal-listability window, so
-    // a poll still has time left to observe and post the terminal state once this
-    // expires instead of the entry aging out of the registry unreported.
+    // recorded). This window is meant to bound moveToDownloads alone, not the
+    // download that precedes it: acceptFileOffer blocks for the whole fetch, so
+    // callers re-stamp markPending right after acceptFileOffer returns and
+    // before moveToDownloads starts, restarting this clock at the point it is
+    // actually meant to cover. Comfortably under the core's 60s
+    // terminal-listability window, so a poll still has time left to observe and
+    // post the terminal state once this expires instead of the entry aging out
+    // of the registry unreported.
     private const val PENDING_TIMEOUT_MS = 45_000L
 
     fun markPending(key: TransferKey) {
@@ -77,8 +82,11 @@ internal object DownloadsOutcome {
     }
 
     fun record(key: TransferKey, reachedDownloads: Boolean) {
-        pending.remove(key)
+        // Write the outcome before clearing pending: otherwise a poll landing
+        // between the two writes would see neither pending nor recorded, and
+        // fall back to the neutral "Saved" guess.
         outcomes[key] = reachedDownloads
+        pending.remove(key)
     }
 
     /** Consumes (removes) the recorded outcome so a later receive reusing the same
@@ -227,6 +235,13 @@ object FileAutoAccept {
             executor.execute {
                 try {
                     node.acceptFileOffer(f.id, saveDir)
+                    // Re-stamp pending now that the download is done and the copy
+                    // is about to start: the first markPending call above only
+                    // needed to cover the wait for DONE to appear, and acceptFileOffer
+                    // can block far longer than PENDING_TIMEOUT_MS on a large file,
+                    // which would otherwise expire the entry before the copy even
+                    // begins.
+                    DownloadsOutcome.markPending(key)
                     val reached = moveToDownloads(context, File(saveDir, f.filename), f.filename, f.mimeType)
                     DownloadsOutcome.record(key, reached)
                     attempts.remove(f.id)

--- a/android/app/src/main/java/xyz/rayfish/android/Files.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/Files.kt
@@ -107,14 +107,19 @@ object FileAutoAccept {
         for (f in offers) {
             if (!f.ownDevice) continue
             if (!handled.add(f.id)) continue
-            try {
-                node.acceptFileOffer(f.id, saveDir)
-                moveToDownloads(context, File(saveDir, f.filename), f.filename, f.mimeType)
-                Log.i("RayfishFiles", "auto-accepted own-device file ${f.filename}")
-            } catch (t: Throwable) {
-                // Let a later poll retry this id.
-                handled.remove(f.id)
-                Log.w("RayfishFiles", "auto-accept failed for ${f.filename}", t)
+            // Accept on its own thread: acceptFileOffer blocks for the whole download,
+            // and the caller here is the same 4s poller that reports progress. The
+            // core registers the transfer, so TransferNotifier picks it up.
+            kotlin.concurrent.thread(name = "rayfish-accept-${f.id}") {
+                try {
+                    node.acceptFileOffer(f.id, saveDir)
+                    moveToDownloads(context, File(saveDir, f.filename), f.filename, f.mimeType)
+                    Log.i("RayfishFiles", "auto-accepted own-device file ${f.filename}")
+                } catch (t: Throwable) {
+                    // Let a later poll retry this id.
+                    handled.remove(f.id)
+                    Log.w("RayfishFiles", "auto-accept failed for ${f.filename}", t)
+                }
             }
         }
     }

--- a/android/app/src/main/java/xyz/rayfish/android/Files.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/Files.kt
@@ -114,6 +114,18 @@ object FileAutoAccept {
      * MAX_ATTEMPTS). Lets the caller fall back to a manual Save row. */
     fun hasGivenUp(id: ULong): Boolean = id in gaveUp
 
+    /**
+     * Clear all process-wide offer-id bookkeeping. The core's file offer ids
+     * restart at 1 on the next Node.start(), so a stale entry here would
+     * otherwise mute (or, having given up, wrongly un-hide) an offer that
+     * happens to reuse an old id. Safe to call when nothing is running.
+     */
+    fun reset() {
+        handled.clear()
+        attempts.clear()
+        gaveUp.clear()
+    }
+
     /** Runs on the caller's coroutine context; callers dispatch it on IO. */
     fun run(context: Context) {
         if (!NodeHolder.isAutoAcceptOwnDevices(context)) return

--- a/android/app/src/main/java/xyz/rayfish/android/Files.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/Files.kt
@@ -16,6 +16,30 @@ import java.util.UUID
  */
 
 /**
+ * Whether the most recent [moveToDownloads] call for a given filename actually
+ * landed the file in the public Downloads collection, so [TransferNotifier] can
+ * report the truth instead of assuming Downloads whenever a receive completes.
+ *
+ * Keyed by filename rather than transfer id: the accept call site (FileAutoAccept,
+ * or HomeScreen's manual Save) and the later TransferNotifier poll that reports
+ * the terminal result are on different call chains with no transfer id in common
+ * at accept time. A same-name collision between two receives in flight at once is
+ * an accepted rough edge, not a correctness requirement here.
+ */
+internal object DownloadsOutcome {
+    private val outcomes = java.util.Collections.synchronizedMap(HashMap<String, Boolean>())
+
+    fun record(filename: String, reachedDownloads: Boolean) {
+        outcomes[filename] = reachedDownloads
+    }
+
+    /** Consumes (removes) the recorded outcome so a later receive reusing the same
+     * filename does not read a stale value. Defaults to false (the neutral "Saved"
+     * copy, no Downloads tap target) when nothing was recorded. */
+    fun consume(filename: String): Boolean = outcomes.remove(filename) ?: false
+}
+
+/**
  * Copy [src] into the device's public Downloads collection via MediaStore and
  * delete the app-private staging copy. Returns true on success. On API < 29
  * (no scoped MediaStore Downloads) it leaves the file in place and returns
@@ -142,7 +166,8 @@ object FileAutoAccept {
             executor.execute {
                 try {
                     node.acceptFileOffer(f.id, saveDir)
-                    moveToDownloads(context, File(saveDir, f.filename), f.filename, f.mimeType)
+                    val reached = moveToDownloads(context, File(saveDir, f.filename), f.filename, f.mimeType)
+                    DownloadsOutcome.record(f.filename, reached)
                     attempts.remove(f.id)
                     Log.i("RayfishFiles", "auto-accepted own-device file ${f.filename}")
                 } catch (t: Throwable) {

--- a/android/app/src/main/java/xyz/rayfish/android/MainActivity.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/MainActivity.kt
@@ -1,9 +1,14 @@
 package xyz.rayfish.android
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import xyz.rayfish.android.ui.RayfishApp
 import xyz.rayfish.android.ui.theme.RayfishTheme
 
@@ -12,8 +17,15 @@ class MainActivity : ComponentActivity() {
     /** Guards against handling the same launch intent twice (config change, recomposition). */
     private var handledIntentUri: String? = null
 
+    // Registered here (before the activity is STARTED, as the API requires). The
+    // result is ignored: if the user denies, the service still runs, only its
+    // notification stays hidden, which is the pre-request behavior.
+    private val requestNotificationPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        maybeRequestNotificationPermission()
         // Only treat the launch intent's data as a NEW deep link on first creation.
         // On recreation (e.g. rotation) the same Intent is redelivered, but it was
         // already consumed by the first instance, so skip it here.
@@ -30,6 +42,21 @@ class MainActivity : ComponentActivity() {
                 )
             }
         }
+    }
+
+    /**
+     * On Android 13+ POST_NOTIFICATIONS is a runtime permission that defaults to
+     * denied, which silently suppresses even the foreground-service notification
+     * (the VPN/standby status and the file-transfer progress). Ask for it on
+     * launch if we don't already hold it. No-op below API 33, where the manifest
+     * grant is enough.
+     */
+    private fun maybeRequestNotificationPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        val granted = ContextCompat.checkSelfPermission(
+            this, Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!granted) requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
@@ -163,10 +163,12 @@ object NodeHolder {
             runCatching { node?.stop() }
             started = false
         }
-        // The core's transfer ids restart at 1 on the next start(); reset the
-        // notifier's process-wide bookkeeping so a later transfer landing on a
-        // reused id is never muted by a stale terminal/postedProgress entry.
+        // The core's transfer and file-offer ids both restart at 1 on the next
+        // start(); reset the process-wide bookkeeping for each so a later
+        // transfer or offer landing on a reused id is never muted (or, for a
+        // given-up offer, wrongly left un-hidden) by a stale entry.
         TransferNotifier.reset(context)
+        FileAutoAccept.reset()
     }
 
     /**

--- a/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
@@ -48,6 +48,14 @@ object NodeHolder {
     // surfaced as FileOffer.own_device; this toggle is only the opt-out.
     private const val KEY_AUTO_ACCEPT_OWN = "auto_accept_own_devices"
 
+    // Keep the control plane connected when the VPN tunnel is off, so file send
+    // and receive keep working and the device stays visible in the mesh. Default
+    // off: it holds a network connection open in the background. The motivating
+    // case is running another VPN (Android allows only one VpnService at a time,
+    // and our tunnel claims the same 100.64.0.0/10 range Tailscale uses), so the
+    // tunnel goes away and only the data plane goes with it.
+    private const val KEY_STAY_ONLINE = "stay_online"
+
     fun isEnabled(context: Context): Boolean =
         context.applicationContext
             .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -68,6 +76,17 @@ object NodeHolder {
         context.applicationContext
             .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .edit().putBoolean(KEY_AUTO_ACCEPT_OWN, value).apply()
+    }
+
+    fun isStayOnline(context: Context): Boolean =
+        context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_STAY_ONLINE, false)
+
+    fun setStayOnline(context: Context, value: Boolean) {
+        context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().putBoolean(KEY_STAY_ONLINE, value).apply()
     }
 
     fun isCrashReportingEnabled(context: Context): Boolean =
@@ -143,6 +162,22 @@ object NodeHolder {
         synchronized(this) {
             runCatching { node?.stop() }
             started = false
+        }
+    }
+
+    /**
+     * Standby: tear the data plane down (TUN detached) but keep the control plane
+     * connected, so files still flow and the device stays online in the mesh. This
+     * is the mobile equivalent of desktop `ray down`.
+     *
+     * Deliberately does NOT clear [started]: the daemon stays built, so a later
+     * enable is a plain Node.up(fd) with no rebuild (near-instant, like `ray up`).
+     * No-op if the node was never started.
+     */
+    fun downNode(context: Context) {
+        synchronized(this) {
+            if (!started) return
+            runCatching { node?.down() }
         }
     }
 }

--- a/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
@@ -2,8 +2,6 @@ package xyz.rayfish.android
 
 import android.content.Context
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import uniffi.ray_mobile.Node
 
@@ -24,13 +22,8 @@ object NodeHolder {
         }
     }
 
-    private val startMutex = Mutex()
-
     @Volatile
     private var started = false
-
-    /** True once the daemon is built and not yet stopped. */
-    val isStarted: Boolean get() = started
 
     // The user's persisted enable/disable intent. This is the authority for
     // whether the device should be online: the status poll must never start the
@@ -136,20 +129,32 @@ object NodeHolder {
     /**
      * Starts the node exactly once for the process, however many callers race to
      * invoke this concurrently (e.g. the initial UI launch and a cold-start deep
-     * link firing at the same time). Later callers just await the first start.
+     * link firing at the same time). Later callers just wait for the first start.
+     *
+     * This function, [stopNode] and [downNode] all guard their work with the same
+     * `synchronized(this)` monitor on this singleton, so a start can never
+     * interleave with a stop or a down: one always finishes before the other
+     * begins, whichever thread it runs on. That serialization is worth a blocked
+     * thread rather than a suspended coroutine, so this switches to
+     * [Dispatchers.IO] first and only then takes the monitor: the blocking
+     * `node.start()` FFI call and the `synchronized` block it runs in both then
+     * execute on a plain IO-pool thread, never on whatever dispatcher the caller
+     * happened to be on (composables here call this from the main-thread
+     * coroutine scope; suspending into IO before blocking keeps that safe).
      */
     suspend fun ensureStarted(context: Context) {
         if (started) return
-        startMutex.withLock {
-            if (started) return@withLock
-            withContext(Dispatchers.IO) {
-                // Register Android's trust store before start(): building the
-                // iroh endpoint sets up TLS, which fails without it.
-                RustlsInit.ensureInitialized(context)
-                get(context).start()
-                seedDeviceName(context)
+        withContext(Dispatchers.IO) {
+            synchronized(this@NodeHolder) {
+                if (!started) {
+                    // Register Android's trust store before start(): building the
+                    // iroh endpoint sets up TLS, which fails without it.
+                    RustlsInit.ensureInitialized(context)
+                    get(context).start()
+                    seedDeviceName(context)
+                    started = true
+                }
             }
-            started = true
         }
     }
 
@@ -157,6 +162,11 @@ object NodeHolder {
      * Fully stop the node so the device goes offline (control plane torn down,
      * not just the data plane). Clears the started flag so the next
      * [ensureStarted] rebuilds a fresh daemon. Safe to call when never started.
+     *
+     * The reset calls below deliberately run after the monitor is released:
+     * [TransferNotifier.reset] and [FileAutoAccept.reset] take their own locks,
+     * and neither is ever called from inside this object's monitor, so there is
+     * no path back into this monitor from theirs to deadlock against.
      */
     fun stopNode(context: Context) {
         synchronized(this) {

--- a/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
@@ -163,6 +163,10 @@ object NodeHolder {
             runCatching { node?.stop() }
             started = false
         }
+        // The core's transfer ids restart at 1 on the next start(); reset the
+        // notifier's process-wide bookkeeping so a later transfer landing on a
+        // reused id is never muted by a stale terminal/postedProgress entry.
+        TransferNotifier.reset(context)
     }
 
     /**

--- a/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
@@ -41,13 +41,22 @@ object NodeHolder {
     // surfaced as FileOffer.own_device; this toggle is only the opt-out.
     private const val KEY_AUTO_ACCEPT_OWN = "auto_accept_own_devices"
 
-    // Keep the control plane connected when the VPN tunnel is off, so file send
-    // and receive keep working and the device stays visible in the mesh. Default
-    // off: it holds a network connection open in the background. The motivating
-    // case is running another VPN (Android allows only one VpnService at a time,
-    // and our tunnel claims the same 100.64.0.0/10 range Tailscale uses), so the
+    // Standby is now the default: disabling Rayfish drops the data plane (TUN,
+    // VPN slot) but keeps the control plane connected, so file send and receive
+    // keep working and the device stays visible in the mesh. The motivating case
+    // is running another VPN (Android allows only one VpnService at a time, and
+    // our tunnel claims the same 100.64.0.0/10 range Tailscale uses), so the
     // tunnel goes away and only the data plane goes with it.
-    private const val KEY_STAY_ONLINE = "stay_online"
+    //
+    // This key is an escape hatch for a user who wants disabling Rayfish to take
+    // the device fully offline instead. Default false (standby). This is a NEW
+    // key, not a flip of the old "stay_online" pref (default false, opt-in
+    // standby): a user who had already turned that on has a stored
+    // stay_online = true, and flipping its default in place would silently hand
+    // them the opposite of what they asked for. The old key is left unread and
+    // unmigrated; any leftover stay_online value in an existing install's
+    // SharedPreferences is inert.
+    private const val KEY_GO_OFFLINE_WHEN_DISABLED = "go_offline_when_disabled"
 
     fun isEnabled(context: Context): Boolean =
         context.applicationContext
@@ -71,15 +80,15 @@ object NodeHolder {
             .edit().putBoolean(KEY_AUTO_ACCEPT_OWN, value).apply()
     }
 
-    fun isStayOnline(context: Context): Boolean =
+    fun isGoOfflineWhenDisabled(context: Context): Boolean =
         context.applicationContext
             .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            .getBoolean(KEY_STAY_ONLINE, false)
+            .getBoolean(KEY_GO_OFFLINE_WHEN_DISABLED, false)
 
-    fun setStayOnline(context: Context, value: Boolean) {
+    fun setGoOfflineWhenDisabled(context: Context, value: Boolean) {
         context.applicationContext
             .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-            .edit().putBoolean(KEY_STAY_ONLINE, value).apply()
+            .edit().putBoolean(KEY_GO_OFFLINE_WHEN_DISABLED, value).apply()
     }
 
     fun isCrashReportingEnabled(context: Context): Boolean =

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -116,6 +116,14 @@ class RayfishVpnService : VpnService() {
                 // triggers the VPN consent dialog. enterStandby() is idempotent,
                 // so a repeat call (fast toggle off-then-on) is harmless.
                 Log.i(TAG, "ACTION_STANDBY received")
+                if (tunnel != null) {
+                    // The tunnel is already up: this is a pref-flip racing with a live
+                    // tunnel, not the "VPN is off, bring up the control plane only"
+                    // case this action exists for. Never tear a live tunnel down
+                    // because of it.
+                    Log.i(TAG, "ACTION_STANDBY ignored: tunnel already up")
+                    return START_STICKY
+                }
                 enterStandby()
                 return START_STICKY
             }

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -113,18 +113,39 @@ class RayfishVpnService : VpnService() {
                 // from YouScreen while the tunnel is off. Must bring up the
                 // control plane only: never touch the Builder/establish() path,
                 // so it never contends for the single VpnService slot and never
-                // triggers the VPN consent dialog. enterStandby() is idempotent,
-                // so a repeat call (fast toggle off-then-on) is harmless.
+                // triggers the VPN consent dialog.
+                //
+                // The tunnel != null decision cannot be made here, on the main
+                // thread: tunnel is only written on nodeExecutor, so a main-thread
+                // read is stale for the whole duration of an in-flight bring-up or
+                // teardown (seconds). A stale null here would run enterStandby
+                // while a bring-up is still landing; a stale non-null would skip
+                // standby entirely while a teardown is still clearing the field.
+                // So post the notification this call is obligated to post right
+                // away (this is a startForegroundService start), then decide for
+                // real on nodeExecutor, where the check is serialized against
+                // startTunnelBlocking and stopTunnel and therefore sees the
+                // settled value.
                 Log.i(TAG, "ACTION_STANDBY received")
-                if (tunnel != null) {
-                    // The tunnel is already up: this is a pref-flip racing with a live
-                    // tunnel, not the "VPN is off, bring up the control plane only"
-                    // case this action exists for. Never tear a live tunnel down
-                    // because of it.
-                    Log.i(TAG, "ACTION_STANDBY ignored: tunnel already up")
-                    return START_STICKY
+                startForegroundNotification(standby = true)
+                nodeExecutor.execute {
+                    // See the ACTION_STOP execute() block for why this must never
+                    // let a throwable escape.
+                    try {
+                        if (tunnel != null) {
+                            // A tunnel is genuinely up (or came up while this call
+                            // queued behind a bring-up): never tear it down for
+                            // this. Correct the notification posted above, which
+                            // assumed standby.
+                            Log.i(TAG, "ACTION_STANDBY: tunnel is up, correcting notification instead of entering standby")
+                            startForegroundNotification(standby = false)
+                            return@execute
+                        }
+                        enterStandbyBlocking()
+                    } catch (t: Throwable) {
+                        Log.e(TAG, "ACTION_STANDBY task crashed", t)
+                    }
                 }
-                enterStandby()
                 return START_STICKY
             }
             ACTION_EXIT_STANDBY -> {
@@ -133,26 +154,33 @@ class RayfishVpnService : VpnService() {
                 // Meaning: "the user no longer wants standby; if nothing else needs
                 // the control plane up (no tunnel), take the node fully offline and
                 // stop the service." If a tunnel is up, the VPN is on and this pref
-                // only governs what happens at the next teardown, so do nothing:
-                // the same guard ACTION_STANDBY applies in the other direction.
-                Log.i(TAG, "ACTION_EXIT_STANDBY received (tunnel fd present=${tunnel != null})")
-                if (tunnel != null) {
-                    Log.i(TAG, "ACTION_EXIT_STANDBY ignored: tunnel is up")
-                    return START_STICKY
-                }
-                // No tunnel: either genuine standby the user no longer wants, or a
-                // fresh service instance (process was dead) with nothing started at
-                // all. Either way the same offline teardown ACTION_STOP performs
-                // with stay-online off, idempotent if there was nothing to tear
-                // down. No standby notification is posted here (unlike ACTION_STOP's
-                // standby branch): this path never leaves the service in standby, so
-                // there is nothing true to say about it, and the intent that reaches
-                // here is a plain startService, not a foreground one, so there is no
-                // foreground-notification deadline to meet.
+                // only governs what happens at the next teardown, so do nothing.
+                //
+                // As with ACTION_STANDBY above, the tunnel != null decision must be
+                // made on nodeExecutor, not here: a main-thread read stays stale for
+                // as long as a bring-up or teardown is in flight, so this call could
+                // otherwise queue a full offline teardown behind a bring-up that
+                // hasn't reached its tunnel assignment yet, and then kill a tunnel
+                // the user just turned on. No notification obligation here (unlike
+                // ACTION_STANDBY): this intent is a plain startService from a
+                // visible Activity, not a foreground one, so there is no
+                // foreground-notification deadline to meet, and this path never
+                // leaves the service in standby so there is nothing true to say on
+                // a freshly created instance.
+                Log.i(TAG, "ACTION_EXIT_STANDBY received")
                 nodeExecutor.execute {
                     // See the ACTION_STOP execute() block for why this must never
                     // let a throwable escape.
                     try {
+                        if (tunnel != null) {
+                            Log.i(TAG, "ACTION_EXIT_STANDBY: a tunnel came up, nothing to exit")
+                            return@execute
+                        }
+                        // No tunnel: either genuine standby the user no longer
+                        // wants, or a fresh service instance (process was dead)
+                        // with nothing started at all. Either way the same offline
+                        // teardown ACTION_STOP performs with stay-online off,
+                        // idempotent if there was nothing to tear down.
                         stopTunnel(standby = false)
                         Log.i(TAG, "ACTION_EXIT_STANDBY: stopTunnel returned; calling stopSelf(startId=$startId)")
                         stopSelf(startId)
@@ -160,7 +188,13 @@ class RayfishVpnService : VpnService() {
                         Log.e(TAG, "ACTION_EXIT_STANDBY task crashed", t)
                     }
                 }
-                return START_NOT_STICKY
+                // START_STICKY, not START_NOT_STICKY: stopSelf(startId) above still
+                // cancels the sticky restart on the path that actually stops.
+                // Returning START_NOT_STICKY here would make it the last command's
+                // return value while a live tunnel is running (the tunnel != null
+                // path above returns without calling stopSelf), so a process kill
+                // would not restart the service to serve that tunnel.
+                return START_STICKY
             }
             // An action-less start intent is the normal "turn the VPN on" path
             // (see HomeScreen / RayfishApp, which both start the service with a
@@ -389,26 +423,37 @@ class RayfishVpnService : VpnService() {
     private fun enterStandby() {
         startForegroundNotification(standby = true)
         nodeExecutor.execute {
-            // Outer catch: see the ACTION_STOP execute() block. The inner catch
-            // below is deliberately narrower: a control-plane bring-up failure
-            // still needs the poller started, so it's caught and logged there
-            // rather than aborting this whole task.
+            // See the ACTION_STOP execute() block for why this must never let a
+            // throwable escape.
             try {
-                try {
-                    runBlocking { NodeHolder.ensureStarted(applicationContext) }
-                    Log.i(TAG, "standby: control plane up, no tunnel")
-                } catch (t: Throwable) {
-                    Log.e(TAG, "standby bring-up failed", t)
-                }
-                // Moved inside the executor task: autoAcceptPoller (like dnsProxy) is
-                // only read and written from nodeExecutor's thread (startTunnelBlocking,
-                // stopTunnel). Calling this from the main thread, as before, made it the
-                // one field touched from two threads with no lock between them.
-                startAutoAcceptPoller()
+                enterStandbyBlocking()
             } catch (t: Throwable) {
                 Log.e(TAG, "enterStandby task crashed", t)
             }
         }
+    }
+
+    /**
+     * The blocking half of standby bring-up: ensureStarted plus starting the
+     * poller. Runs on nodeExecutor, called both from enterStandby() above (the
+     * null-intent restart path and ACTION_STANDBY's own helper) and directly
+     * from ACTION_STANDBY's executor task once that task has confirmed, on
+     * nodeExecutor itself, that no tunnel is up.
+     */
+    private fun enterStandbyBlocking() {
+        // The control-plane bring-up failure below still needs the poller
+        // started, so it's caught and logged here rather than aborting the
+        // rest of this function.
+        try {
+            runBlocking { NodeHolder.ensureStarted(applicationContext) }
+            Log.i(TAG, "standby: control plane up, no tunnel")
+        } catch (t: Throwable) {
+            Log.e(TAG, "standby bring-up failed", t)
+        }
+        // autoAcceptPoller (like dnsProxy) is only read and written from
+        // nodeExecutor's thread (startTunnelBlocking, stopTunnel), so this must
+        // run here and not on the main thread.
+        startAutoAcceptPoller()
     }
 
     /**

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -41,15 +41,6 @@ class RayfishVpnService : VpnService() {
     // shared to this device land in Downloads even with the app UI closed.
     private var autoAcceptPoller: ScheduledExecutorService? = null
 
-    // Serializes bring-up (startTunnel/enterStandby) and teardown (stopTunnel) so
-    // they can never interleave. Both read and write the tunnel/dnsProxy fields;
-    // running them on the same single-threaded executor means a queued task only
-    // starts once the previous one has fully finished, so an off-then-on always
-    // ends with the tunnel up and an on-then-off always ends in standby/offline,
-    // regardless of how quickly the two requests arrive. Neither task may run on
-    // the main thread: both block on FFI calls into the Rust core.
-    private val nodeExecutor: ExecutorService = Executors.newSingleThreadExecutor()
-
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent == null) {
             // A genuinely null intent means the system restarted us after killing
@@ -410,7 +401,15 @@ class RayfishVpnService : VpnService() {
             startForegroundNotification(standby = true)
             startAutoAcceptPoller()
         } else {
-            Log.e(TAG, "$reason; tunnel not up, stopping service (startId=$startId)")
+            // With stay-online off, "VPN off" must mean fully offline. Without
+            // this, startTunnelBlocking's ensureStarted call above already
+            // brought the control plane up before the tunnel build failed, and
+            // nothing else would ever stop it: the daemon would keep its mesh
+            // connection open and the device would stay visible to peers with
+            // both the VPN toggle and stay-online off, contradicting what the
+            // user asked for.
+            Log.e(TAG, "$reason; tunnel not up and stay-online off, stopping node and service (startId=$startId)")
+            NodeHolder.stopNode(applicationContext)
             stopSelf(startId)
         }
     }
@@ -634,7 +633,14 @@ class RayfishVpnService : VpnService() {
                 Log.e(TAG, "onDestroy teardown task crashed", t)
             }
         }
-        nodeExecutor.shutdown()
+        // nodeExecutor is process-wide (see the companion object), not shut down
+        // here: a fast off-then-on can create a brand new service instance while
+        // this queued teardown is still running or waiting its turn, and that new
+        // instance's bring-up must serialize behind this task on the very same
+        // executor. Shutting it down would either reject the new instance's work
+        // or, if it raced ahead, run the two instances' bring-up/teardown on two
+        // different executors with no ordering between them at all, which is the
+        // bug this design exists to prevent.
         super.onDestroy()
     }
 
@@ -675,6 +681,22 @@ class RayfishVpnService : VpnService() {
         private const val TAG = "RayfishVpn"
         private const val CHANNEL_ID = "rayfish_vpn"
         private const val NOTIF_ID = 1
+
+        // Serializes bring-up (startTunnel/enterStandby) and teardown (stopTunnel)
+        // so they can never interleave. Process-wide, not per-instance: Android can
+        // destroy this service and create a fresh instance (a new nodeExecutor,
+        // were it an instance field) while the old instance's queued teardown is
+        // still running, e.g. a fast VPN off-then-on. A per-instance executor would
+        // let the two instances' bring-up and teardown run unserialized against
+        // each other, which is exactly the interleaving this executor exists to
+        // rule out. One executor for the whole process closes that gap: every
+        // instance's work queues on the same thread, so a queued task only starts
+        // once the previous one (from any instance) has fully finished. Never shut
+        // down (see onDestroy): it outlives any single service instance by design.
+        // Neither task may run on the main thread: both block on FFI calls into the
+        // Rust core.
+        private val nodeExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+
         const val ACTION_STOP = "xyz.rayfish.android.STOP"
         const val ACTION_STANDBY = "xyz.rayfish.android.STANDBY"
         const val ACTION_EXIT_STANDBY = "xyz.rayfish.android.EXIT_STANDBY"

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -489,15 +489,20 @@ class RayfishVpnService : VpnService() {
 
     /**
      * Auto-accept own-device file offers, so a file shared to this device from one
-     * of the user's own devices lands in Downloads without the app being open. Runs
-     * in standby too: that is what makes files keep working with the VPN off. Gated
-     * by the user's opt-out toggle inside FileAutoAccept.run. Idempotent.
+     * of the user's own devices lands in Downloads without the app being open, and
+     * drive [TransferNotifier] so a transfer that completes while the app is closed
+     * still gets its progress/result notification. Runs in standby too: that is what
+     * makes files keep working with the VPN off. Auto-accept is gated by the user's
+     * opt-out toggle inside FileAutoAccept.run. Idempotent.
      */
     private fun startAutoAcceptPoller() {
         if (autoAcceptPoller != null) return
         autoAcceptPoller = Executors.newSingleThreadScheduledExecutor().also { exec ->
             exec.scheduleWithFixedDelay(
-                { runCatching { FileAutoAccept.run(applicationContext) } },
+                {
+                    runCatching { FileAutoAccept.run(applicationContext) }
+                    runCatching { TransferNotifier.poll(applicationContext) }
+                },
                 4, 4, TimeUnit.SECONDS,
             )
         }

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -108,6 +108,17 @@ class RayfishVpnService : VpnService() {
                 }
                 return if (standby) START_STICKY else START_NOT_STICKY
             }
+            ACTION_STANDBY -> {
+                // "Keep files working when the VPN is off", started explicitly
+                // from YouScreen while the tunnel is off. Must bring up the
+                // control plane only: never touch the Builder/establish() path,
+                // so it never contends for the single VpnService slot and never
+                // triggers the VPN consent dialog. enterStandby() is idempotent,
+                // so a repeat call (fast toggle off-then-on) is harmless.
+                Log.i(TAG, "ACTION_STANDBY received")
+                enterStandby()
+                return START_STICKY
+            }
             // An action-less start intent is the normal "turn the VPN on" path
             // (see HomeScreen / RayfishApp, which both start the service with a
             // plain Intent). It must reach startTunnel(), not be mistaken for
@@ -572,6 +583,7 @@ class RayfishVpnService : VpnService() {
         private const val CHANNEL_ID = "rayfish_vpn"
         private const val NOTIF_ID = 1
         const val ACTION_STOP = "xyz.rayfish.android.STOP"
+        const val ACTION_STANDBY = "xyz.rayfish.android.STANDBY"
 
         // Apps that misbehave behind a VPN (casting, RCS, local-device discovery).
         // Mirrors Tailscale's default Android exclusions. Excluded so they never

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -710,7 +710,7 @@ class RayfishVpnService : VpnService() {
         val builder = Notification.Builder(this, CHANNEL_ID)
             .setContentTitle("Rayfish")
             .setContentText(if (standby) "Online, VPN off · files still work" else "Mesh tunnel active")
-            .setSmallIcon(android.R.drawable.stat_sys_download_done)
+            .setSmallIcon(R.drawable.ic_stat_vpn)
             .setOngoing(true)
             .setContentIntent(openIntent)
 

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -57,7 +57,7 @@ class RayfishVpnService : VpnService() {
             // else brought the node up: decide from the persisted prefs what
             // state to restore.
             if (NodeHolder.isEnabled(applicationContext)) {
-                startTunnel()
+                startTunnel(startId)
             } else if (NodeHolder.isStayOnline(applicationContext)) {
                 enterStandby()
             } else {
@@ -112,12 +112,12 @@ class RayfishVpnService : VpnService() {
             // (see HomeScreen / RayfishApp, which both start the service with a
             // plain Intent). It must reach startTunnel(), not be mistaken for
             // the null-intent restart-recovery branch above.
-            else -> startTunnel()
+            else -> startTunnel(startId)
         }
         return START_STICKY
     }
 
-    private fun startTunnel() {
+    private fun startTunnel(startId: Int) {
         // startForeground must be called promptly so the foreground-service
         // deadline is met; only the blocking node work goes to the executor.
         startForegroundNotification()
@@ -125,14 +125,14 @@ class RayfishVpnService : VpnService() {
             // See the ACTION_STOP execute() block for why this must never let a
             // throwable escape: an uncaught one here kills the process outright.
             try {
-                startTunnelBlocking()
+                startTunnelBlocking(startId)
             } catch (t: Throwable) {
                 Log.e(TAG, "startTunnelBlocking task crashed", t)
             }
         }
     }
 
-    private fun startTunnelBlocking() {
+    private fun startTunnelBlocking(startId: Int) {
         if (tunnel != null) return
 
         // Bring the control plane up before building the tunnel so status() can
@@ -244,7 +244,7 @@ class RayfishVpnService : VpnService() {
             } else {
                 "VpnService.Builder.establish() returned null (VPN slot likely unavailable)"
             }
-            handleBringUpFailure(reason)
+            handleBringUpFailure(reason, startId)
             return
         }
         tunnel = pfd
@@ -278,7 +278,7 @@ class RayfishVpnService : VpnService() {
             // it needs exactly the same recovery, so it goes through the same
             // helper instead of a divergent one that leaves dnsProxy orphaned and
             // the notification claiming a tunnel that isn't there.
-            handleBringUpFailure("Node.up() threw")
+            handleBringUpFailure("Node.up() threw", startId)
         }
     }
 
@@ -292,13 +292,17 @@ class RayfishVpnService : VpnService() {
      * instead of needing a full stop first.
      *
      * Then: with stay-online on, this is exactly the case standby exists for,
-     * so the control plane (already brought up earlier in
-     * startTunnelBlocking) keeps running, the standby notification replaces
-     * whatever startForegroundNotification() posted at the top of
+     * so the control plane must actually be (re)brought up here: the caller may
+     * have reached this point via a failed ensureStarted followed by a
+     * establish()/Node.up() that never needed the node running (see
+     * startTunnelBlocking's fallback tunnel address), so it cannot be assumed
+     * already up. ensureStarted is idempotent, so this is a no-op in the
+     * common case where it is. Once that is done, the standby notification
+     * replaces whatever startForegroundNotification() posted at the top of
      * startTunnel(), and the poller starts so files keep landing. With
      * stay-online off there is nothing left to keep the service alive for.
      */
-    private fun handleBringUpFailure(reason: String) {
+    private fun handleBringUpFailure(reason: String, startId: Int) {
         tunnel = null
         try {
             dnsProxy?.stop()
@@ -309,12 +313,17 @@ class RayfishVpnService : VpnService() {
 
         val standby = NodeHolder.isStayOnline(applicationContext)
         if (standby) {
-            Log.w(TAG, "$reason; staying in standby, control plane stays up")
+            Log.w(TAG, "$reason; staying in standby, ensuring control plane is up")
+            try {
+                runBlocking { NodeHolder.ensureStarted(applicationContext) }
+            } catch (t: Throwable) {
+                Log.e(TAG, "handleBringUpFailure: ensureStarted failed; mesh visibility and file transfer will not work until this recovers", t)
+            }
             startForegroundNotification(standby = true)
             startAutoAcceptPoller()
         } else {
-            Log.e(TAG, "$reason; tunnel not up, stopping service")
-            stopSelf()
+            Log.e(TAG, "$reason; tunnel not up, stopping service (startId=$startId)")
+            stopSelf(startId)
         }
     }
 

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -187,6 +187,7 @@ class RayfishVpnService : VpnService() {
         // path below: previously a Builder throw escaped that path entirely and
         // was swallowed by the outer executor catch, leaving dnsProxy set with no
         // tunnel to serve and no standby fallback.
+        var builderThrew = false
         val pfd = try {
             val builder = Builder()
                 .setSession("Rayfish")
@@ -228,42 +229,22 @@ class RayfishVpnService : VpnService() {
             builder.establish()
         } catch (t: Throwable) {
             Log.e(TAG, "VpnService.Builder chain or establish() threw", t)
+            builderThrew = true
             null
         }
         if (pfd == null) {
             // establish() returns null precisely when we do not hold the single
             // VpnService slot (another VPN app, e.g. Tailscale, took it, or the
-            // user has none configured). With stay-online on, that is exactly
-            // the case standby exists for: the control plane (already brought up
-            // above) must keep running so files and mesh visibility survive,
-            // instead of tearing the whole service down under it.
-            val standby = NodeHolder.isStayOnline(applicationContext)
-            if (standby) {
-                Log.w(TAG, "establish() returned null (VPN slot likely unavailable); staying in standby, control plane stays up")
-                startForegroundNotification(standby = true)
-                // No tunnel exists for dnsProxy to serve (it was started above for
-                // a tunnel that never got built), so it would otherwise leak a
-                // bound socket and a thread on every retry of this path (the user
-                // re-tapping VPN on re-enters startTunnelBlocking and overwrites
-                // dnsProxy without stopping the old one). Stop and clear it here
-                // instead of restructuring the DNS setup to run after establish():
-                // that setup needs to happen before the tunnel is built so the
-                // resolver is pointed at the proxy from the first packet.
-                try {
-                    dnsProxy?.stop()
-                } catch (t: Throwable) {
-                    Log.w(TAG, "dnsProxy.stop() failed in standby fallback", t)
-                }
-                dnsProxy = null
-                // Standby's whole point is that files keep landing with the UI
-                // closed; without this the poller never starts on this path and
-                // that promise is broken. Idempotent, so a later real tunnel
-                // bring-up just no-ops here.
-                startAutoAcceptPoller()
+            // user has none configured); a Builder throw (malformed address) is
+            // the other way this branch is reached. Either way there is no
+            // tunnel, so this goes through the same recovery as a failed
+            // Node.up() below: see handleBringUpFailure.
+            val reason = if (builderThrew) {
+                "VpnService.Builder chain threw"
             } else {
-                Log.e(TAG, "VpnService.Builder.establish() returned null; tunnel not up, stopping service")
-                stopSelf()
+                "VpnService.Builder.establish() returned null (VPN slot likely unavailable)"
             }
+            handleBringUpFailure(reason)
             return
         }
         tunnel = pfd
@@ -287,18 +268,54 @@ class RayfishVpnService : VpnService() {
         try {
             NodeHolder.get(applicationContext).up(pfd.detachFd())
             Log.i(TAG, "Node.up succeeded")
+            startAutoAcceptPoller()
         } catch (t: Throwable) {
             Log.e(TAG, "Node bring-up failed", t)
             // up() threw after detachFd() handed the fd to Rust, so this
             // ParcelFileDescriptor no longer owns anything worth keeping around.
-            // Leaving tunnel non-null would make the next startTunnelBlocking's
-            // `if (tunnel != null) return` guard believe the tunnel is already
-            // up and skip rebuilding it; null it so a retry can rebuild from
-            // scratch instead of needing a full stop first.
-            tunnel = null
+            // This is the third way tunnel bring-up can fail (the other two are
+            // establish() returning null and the Builder chain throwing, above):
+            // it needs exactly the same recovery, so it goes through the same
+            // helper instead of a divergent one that leaves dnsProxy orphaned and
+            // the notification claiming a tunnel that isn't there.
+            handleBringUpFailure("Node.up() threw")
         }
+    }
 
-        startAutoAcceptPoller()
+    /**
+     * Common recovery for every way tunnel bring-up can fail: establish()
+     * returning null, the Builder chain throwing, or Node.up() throwing. Stops
+     * and clears dnsProxy (nothing left to serve; leaving it running leaks a
+     * bound socket and a thread on every retry of startTunnelBlocking, since
+     * DnsProxy.start() overwrites the field without stopping the old one).
+     * tunnel is left null so a retry can rebuild the tunnel from scratch
+     * instead of needing a full stop first.
+     *
+     * Then: with stay-online on, this is exactly the case standby exists for,
+     * so the control plane (already brought up earlier in
+     * startTunnelBlocking) keeps running, the standby notification replaces
+     * whatever startForegroundNotification() posted at the top of
+     * startTunnel(), and the poller starts so files keep landing. With
+     * stay-online off there is nothing left to keep the service alive for.
+     */
+    private fun handleBringUpFailure(reason: String) {
+        tunnel = null
+        try {
+            dnsProxy?.stop()
+        } catch (t: Throwable) {
+            Log.w(TAG, "dnsProxy.stop() failed during bring-up failure recovery", t)
+        }
+        dnsProxy = null
+
+        val standby = NodeHolder.isStayOnline(applicationContext)
+        if (standby) {
+            Log.w(TAG, "$reason; staying in standby, control plane stays up")
+            startForegroundNotification(standby = true)
+            startAutoAcceptPoller()
+        } else {
+            Log.e(TAG, "$reason; tunnel not up, stopping service")
+            stopSelf()
+        }
     }
 
     /**
@@ -413,6 +430,21 @@ class RayfishVpnService : VpnService() {
     private fun stopTunnel(standby: Boolean) {
         try {
             if (standby) {
+                // NodeHolder.started is a process-level flag and RayfishApp
+                // deliberately never calls ensureStarted (it only observes), so
+                // ACTION_STOP/onRevoke can reach this branch on a fresh service
+                // instance where the node was never started (e.g. the VPN slot
+                // was already taken when the app launched, so the service never
+                // ran startTunnelBlocking). Without this, downNode() below is a
+                // no-op, the poller starts polling a node that was never up, and
+                // the notification we already posted ("Online, VPN off · files
+                // still work") is a lie. Idempotent, so this is a no-op if the
+                // node is already started.
+                try {
+                    runBlocking { NodeHolder.ensureStarted(applicationContext) }
+                } catch (t: Throwable) {
+                    Log.e(TAG, "stopTunnel: standby ensureStarted failed; mesh visibility and file transfer will not work until this recovers", t)
+                }
                 Log.i(TAG, "stopTunnel: Node.down (standby, control plane stays up)")
                 NodeHolder.downNode(applicationContext)
                 // Every standby path must start the poller by construction, not

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -179,45 +179,55 @@ class RayfishVpnService : VpnService() {
             Log.e(TAG, "could not set DNS upstreams; only .ray will resolve", t)
         }
 
-        val builder = Builder()
-            .setSession("Rayfish")
-            .addAddress(tunnelAddr, 32)
-            .addRoute("100.64.0.0", 10)
-            .addDnsServer("100.100.100.53")
-            .addSearchDomain("ray")
-            .setMtu(1280)
-
-        // Route the mesh IPv6 range through the tunnel (mirrors the desktop
-        // 200::/7 route). Skipped if we have no v6 address to bind.
-        if (meshV6.isNotBlank()) {
-            builder.addAddress(meshV6, 128)
-            builder.addRoute("200::", 7)
-        }
-        // Exclude Rayfish itself from its own tunnel. Its sockets (the iroh mesh
-        // underlay, the DnsResolver.rawQuery proxy) then use the real underlying
-        // network directly, so DNS forwarding can't loop back through the TUN and
-        // Private DNS keeps working. Split routing already keeps mesh traffic on
-        // the tunnel via the Rust core's fd, not the app's normal sockets.
-        try {
-            builder.addDisallowedApplication(packageName)
-        } catch (_: PackageManager.NameNotFoundException) {
-            Log.w(TAG, "could not exclude self from VPN: $packageName")
-        }
-
-        // Keep VPN-hostile apps (Android Auto, casting, RCS, Sonos) off the
-        // tunnel. Each add is guarded: an uninstalled package must not abort setup.
-        for (pkg in DISALLOWED_APPS) {
-            try {
-                builder.addDisallowedApplication(pkg)
-            } catch (_: PackageManager.NameNotFoundException) {
-                Log.i(TAG, "disallowed app not installed, skipping: $pkg")
-            }
-        }
-
+        // The whole Builder chain and establish() are one try block so a single
+        // failure handler covers both. addAddress()/addRoute() throw
+        // IllegalArgumentException on a malformed address (tunnelAddr/meshV6 come
+        // from status() and are only blank-checked, not validated), and
+        // establish() can return null. Both must land in the same pfd == null
+        // path below: previously a Builder throw escaped that path entirely and
+        // was swallowed by the outer executor catch, leaving dnsProxy set with no
+        // tunnel to serve and no standby fallback.
         val pfd = try {
+            val builder = Builder()
+                .setSession("Rayfish")
+                .addAddress(tunnelAddr, 32)
+                .addRoute("100.64.0.0", 10)
+                .addDnsServer("100.100.100.53")
+                .addSearchDomain("ray")
+                .setMtu(1280)
+
+            // Route the mesh IPv6 range through the tunnel (mirrors the desktop
+            // 200::/7 route). Skipped if we have no v6 address to bind.
+            if (meshV6.isNotBlank()) {
+                builder.addAddress(meshV6, 128)
+                builder.addRoute("200::", 7)
+            }
+            // Exclude Rayfish itself from its own tunnel. Its sockets (the iroh
+            // mesh underlay, the DnsResolver.rawQuery proxy) then use the real
+            // underlying network directly, so DNS forwarding can't loop back
+            // through the TUN and Private DNS keeps working. Split routing
+            // already keeps mesh traffic on the tunnel via the Rust core's fd,
+            // not the app's normal sockets.
+            try {
+                builder.addDisallowedApplication(packageName)
+            } catch (_: PackageManager.NameNotFoundException) {
+                Log.w(TAG, "could not exclude self from VPN: $packageName")
+            }
+
+            // Keep VPN-hostile apps (Android Auto, casting, RCS, Sonos) off the
+            // tunnel. Each add is guarded: an uninstalled package must not abort
+            // setup.
+            for (pkg in DISALLOWED_APPS) {
+                try {
+                    builder.addDisallowedApplication(pkg)
+                } catch (_: PackageManager.NameNotFoundException) {
+                    Log.i(TAG, "disallowed app not installed, skipping: $pkg")
+                }
+            }
+
             builder.establish()
         } catch (t: Throwable) {
-            Log.e(TAG, "VpnService.Builder.establish() threw", t)
+            Log.e(TAG, "VpnService.Builder chain or establish() threw", t)
             null
         }
         if (pfd == null) {
@@ -279,6 +289,13 @@ class RayfishVpnService : VpnService() {
             Log.i(TAG, "Node.up succeeded")
         } catch (t: Throwable) {
             Log.e(TAG, "Node bring-up failed", t)
+            // up() threw after detachFd() handed the fd to Rust, so this
+            // ParcelFileDescriptor no longer owns anything worth keeping around.
+            // Leaving tunnel non-null would make the next startTunnelBlocking's
+            // `if (tunnel != null) return` guard believe the tunnel is already
+            // up and skip rebuilding it; null it so a retry can rebuild from
+            // scratch instead of needing a full stop first.
+            tunnel = null
         }
 
         startAutoAcceptPoller()
@@ -398,6 +415,15 @@ class RayfishVpnService : VpnService() {
             if (standby) {
                 Log.i(TAG, "stopTunnel: Node.down (standby, control plane stays up)")
                 NodeHolder.downNode(applicationContext)
+                // Every standby path must start the poller by construction, not
+                // rely on some earlier path in the same process having already
+                // started it. ACTION_STOP and onRevoke can both reach standby on
+                // a service instance where the node was never started (a fresh
+                // instance from HomeScreen's context.startService, say), in which
+                // case downNode() above is a no-op and nothing else here would
+                // start it. Idempotent, so this is a no-op when it is already
+                // running.
+                startAutoAcceptPoller()
             } else {
                 Log.i(TAG, "stopTunnel: NodeHolder.stopNode (offline)")
                 NodeHolder.stopNode(applicationContext)

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -85,16 +85,25 @@ class RayfishVpnService : VpnService() {
                     startForegroundNotification(standby = true)
                 }
                 nodeExecutor.execute {
-                    stopTunnel(standby)
-                    if (!standby) {
-                        // stopSelf(startId), not the bare stopSelf(): fast off-then-on
-                        // toggling queues this stop behind a start that already
-                        // landed. stopSelf(startId) is a no-op once a newer start
-                        // command has been delivered, so it only kills the service
-                        // if no start arrived after this one; the bare form would
-                        // kill it either way and undo the newer start's tunnel.
-                        Log.i(TAG, "stopTunnel returned; calling stopSelf(startId=$startId)")
-                        stopSelf(startId)
+                    // A Runnable submitted with execute() has no Future to surface a
+                    // throw through; an uncaught one reaches the default
+                    // uncaught-exception handler and kills the process, which is
+                    // worse than whatever this task was trying to clean up. Catch
+                    // and log instead of letting that happen.
+                    try {
+                        stopTunnel(standby)
+                        if (!standby) {
+                            // stopSelf(startId), not the bare stopSelf(): fast off-then-on
+                            // toggling queues this stop behind a start that already
+                            // landed. stopSelf(startId) is a no-op once a newer start
+                            // command has been delivered, so it only kills the service
+                            // if no start arrived after this one; the bare form would
+                            // kill it either way and undo the newer start's tunnel.
+                            Log.i(TAG, "stopTunnel returned; calling stopSelf(startId=$startId)")
+                            stopSelf(startId)
+                        }
+                    } catch (t: Throwable) {
+                        Log.e(TAG, "ACTION_STOP task crashed", t)
                     }
                 }
                 return if (standby) START_STICKY else START_NOT_STICKY
@@ -112,7 +121,15 @@ class RayfishVpnService : VpnService() {
         // startForeground must be called promptly so the foreground-service
         // deadline is met; only the blocking node work goes to the executor.
         startForegroundNotification()
-        nodeExecutor.execute { startTunnelBlocking() }
+        nodeExecutor.execute {
+            // See the ACTION_STOP execute() block for why this must never let a
+            // throwable escape: an uncaught one here kills the process outright.
+            try {
+                startTunnelBlocking()
+            } catch (t: Throwable) {
+                Log.e(TAG, "startTunnelBlocking task crashed", t)
+            }
+        }
     }
 
     private fun startTunnelBlocking() {
@@ -214,6 +231,25 @@ class RayfishVpnService : VpnService() {
             if (standby) {
                 Log.w(TAG, "establish() returned null (VPN slot likely unavailable); staying in standby, control plane stays up")
                 startForegroundNotification(standby = true)
+                // No tunnel exists for dnsProxy to serve (it was started above for
+                // a tunnel that never got built), so it would otherwise leak a
+                // bound socket and a thread on every retry of this path (the user
+                // re-tapping VPN on re-enters startTunnelBlocking and overwrites
+                // dnsProxy without stopping the old one). Stop and clear it here
+                // instead of restructuring the DNS setup to run after establish():
+                // that setup needs to happen before the tunnel is built so the
+                // resolver is pointed at the proxy from the first packet.
+                try {
+                    dnsProxy?.stop()
+                } catch (t: Throwable) {
+                    Log.w(TAG, "dnsProxy.stop() failed in standby fallback", t)
+                }
+                dnsProxy = null
+                // Standby's whole point is that files keep landing with the UI
+                // closed; without this the poller never starts on this path and
+                // that promise is broken. Idempotent, so a later real tunnel
+                // bring-up just no-ops here.
+                startAutoAcceptPoller()
             } else {
                 Log.e(TAG, "VpnService.Builder.establish() returned null; tunnel not up, stopping service")
                 stopSelf()
@@ -256,17 +292,25 @@ class RayfishVpnService : VpnService() {
     private fun enterStandby() {
         startForegroundNotification(standby = true)
         nodeExecutor.execute {
+            // Outer catch: see the ACTION_STOP execute() block. The inner catch
+            // below is deliberately narrower: a control-plane bring-up failure
+            // still needs the poller started, so it's caught and logged there
+            // rather than aborting this whole task.
             try {
-                runBlocking { NodeHolder.ensureStarted(applicationContext) }
-                Log.i(TAG, "standby: control plane up, no tunnel")
+                try {
+                    runBlocking { NodeHolder.ensureStarted(applicationContext) }
+                    Log.i(TAG, "standby: control plane up, no tunnel")
+                } catch (t: Throwable) {
+                    Log.e(TAG, "standby bring-up failed", t)
+                }
+                // Moved inside the executor task: autoAcceptPoller (like dnsProxy) is
+                // only read and written from nodeExecutor's thread (startTunnelBlocking,
+                // stopTunnel). Calling this from the main thread, as before, made it the
+                // one field touched from two threads with no lock between them.
+                startAutoAcceptPoller()
             } catch (t: Throwable) {
-                Log.e(TAG, "standby bring-up failed", t)
+                Log.e(TAG, "enterStandby task crashed", t)
             }
-            // Moved inside the executor task: autoAcceptPoller (like dnsProxy) is
-            // only read and written from nodeExecutor's thread (startTunnelBlocking,
-            // stopTunnel). Calling this from the main thread, as before, made it the
-            // one field touched from two threads with no lock between them.
-            startAutoAcceptPoller()
         }
     }
 
@@ -290,8 +334,14 @@ class RayfishVpnService : VpnService() {
             startForegroundNotification(standby = true)
         }
         nodeExecutor.execute {
-            stopTunnel(standby)
-            if (!standby) stopSelf()
+            // See the ACTION_STOP execute() block for why this must never let a
+            // throwable escape.
+            try {
+                stopTunnel(standby)
+                if (!standby) stopSelf()
+            } catch (t: Throwable) {
+                Log.e(TAG, "onRevoke task crashed", t)
+            }
         }
     }
 
@@ -404,7 +454,15 @@ class RayfishVpnService : VpnService() {
         // lets every queued task, including this one, run to completion in the
         // background.
         Log.i(TAG, "onDestroy: service being destroyed (tunnel fd present=${tunnel != null})")
-        nodeExecutor.execute { stopTunnel(standby = false) }
+        nodeExecutor.execute {
+            // See the ACTION_STOP execute() block for why this must never let a
+            // throwable escape.
+            try {
+                stopTunnel(standby = false)
+            } catch (t: Throwable) {
+                Log.e(TAG, "onDestroy teardown task crashed", t)
+            }
+        }
         nodeExecutor.shutdown()
         super.onDestroy()
     }

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -54,10 +54,13 @@ class RayfishVpnService : VpnService() {
             // state to restore.
             if (NodeHolder.isEnabled(applicationContext)) {
                 startTunnel(startId)
-            } else if (NodeHolder.isStayOnline(applicationContext)) {
+            } else if (!NodeHolder.isGoOfflineWhenDisabled(applicationContext)) {
+                // Standby is the default: the VPN is off, but the user has not
+                // asked to go fully offline, so keep the control plane up.
                 enterStandby()
             } else {
-                // Neither the VPN nor stay-online is wanted: nothing to run.
+                // The VPN is off and the user asked to go fully offline when
+                // disabled: nothing to run.
                 stopSelf()
                 return START_NOT_STICKY
             }
@@ -72,7 +75,7 @@ class RayfishVpnService : VpnService() {
                 // an ANR and to serialize with any concurrent bring-up. In
                 // standby we keep the service alive; only the fully-offline path
                 // calls stopSelf.
-                val standby = NodeHolder.isStayOnline(applicationContext)
+                val standby = !NodeHolder.isGoOfflineWhenDisabled(applicationContext)
                 Log.i(TAG, "ACTION_STOP received; standby=$standby (tunnel fd present=${tunnel != null})")
                 if (standby) {
                     // Post the standby text now, not after the blocking teardown
@@ -105,8 +108,9 @@ class RayfishVpnService : VpnService() {
                 return if (standby) START_STICKY else START_NOT_STICKY
             }
             ACTION_STANDBY -> {
-                // "Keep files working when the VPN is off", started explicitly
-                // from YouScreen while the tunnel is off. Must bring up the
+                // Enter standby explicitly, sent from YouScreen's toggle OFF
+                // branch (the user no longer wants "go fully offline") while the
+                // tunnel is off. Must bring up the
                 // control plane only: never touch the Builder/establish() path,
                 // so it never contends for the single VpnService slot and never
                 // triggers the VPN consent dialog.
@@ -145,8 +149,9 @@ class RayfishVpnService : VpnService() {
                 return START_STICKY
             }
             ACTION_EXIT_STANDBY -> {
-                // Sent unconditionally from YouScreen's toggle OFF branch, which
-                // cannot tell from the stale status cache whether a tunnel is up.
+                // Sent unconditionally from YouScreen's toggle ON branch (the user
+                // asked to go fully offline when disabled), which cannot tell from
+                // the stale status cache whether a tunnel is up.
                 // Meaning: "the user no longer wants standby; if nothing else needs
                 // the control plane up (no tunnel), take the node fully offline and
                 // stop the service." If a tunnel is up, the VPN is on and this pref
@@ -375,27 +380,28 @@ class RayfishVpnService : VpnService() {
      * tunnel is left null so a retry can rebuild the tunnel from scratch
      * instead of needing a full stop first.
      *
-     * Then: with stay-online on, this is exactly the case standby exists for,
-     * so the control plane must actually be (re)brought up here: the caller may
-     * have reached this point via a failed ensureStarted followed by a
-     * establish()/Node.up() that never needed the node running (see
-     * startTunnelBlocking's fallback tunnel address), so it cannot be assumed
-     * already up. ensureStarted is idempotent, so this is a no-op in the
-     * common case where it is. Once that is done, the standby notification
-     * replaces whatever startForegroundNotification() posted at the top of
-     * startTunnel(), and the poller starts so files keep landing. With
-     * stay-online off there is nothing left to keep the service alive for.
+     * Then: unless the user asked to go fully offline when disabled, this is
+     * exactly the case standby exists for, so the control plane must actually be
+     * (re)brought up here: the caller may have reached this point via a failed
+     * ensureStarted followed by a establish()/Node.up() that never needed the
+     * node running (see startTunnelBlocking's fallback tunnel address), so it
+     * cannot be assumed already up. ensureStarted is idempotent, so this is a
+     * no-op in the common case where it is. Once that is done, the standby
+     * notification replaces whatever startForegroundNotification() posted at the
+     * top of startTunnel(), and the poller starts so files keep landing. With
+     * "go fully offline" set there is nothing left to keep the service alive for.
      *
-     * Honesty check on the stay-online-off branch: with the VPN off and
-     * stay-online off, a node started earlier by ShareActivity (own-device
-     * auto-accept, or a manual Save, driven by HomeScreen's poller) can be
-     * mid-receive when the user then asks for the VPN to come on and it fails
-     * here (another VPN app holds the slot). NodeHolder.stopNode below then
-     * kills that in-flight receive and drops the partial file, even though the
-     * user asked to go online, not offline. The "no VPN + stay-online off means
-     * offline" invariant has to win regardless: this is a real, if narrow, cost
-     * of it, not a bug to route around, and no retry/queueing is built for it
-     * here. hasInFlightAccepts() below only makes the cost visible in the log.
+     * Honesty check on the go-fully-offline branch: with the VPN off and "go
+     * fully offline when disabled" set, a node started earlier by ShareActivity
+     * (own-device auto-accept, or a manual Save, driven by HomeScreen's poller)
+     * can be mid-receive when the user then asks for the VPN to come on and it
+     * fails here (another VPN app holds the slot). NodeHolder.stopNode below
+     * then kills that in-flight receive and drops the partial file, even though
+     * the user asked to go online, not offline. The "no VPN + go fully offline
+     * set means offline" invariant has to win regardless: this is a real, if
+     * narrow, cost of it, not a bug to route around, and no retry/queueing is
+     * built for it here. hasInFlightAccepts() below only makes the cost visible
+     * in the log.
      */
     private fun handleBringUpFailure(reason: String, startId: Int) {
         tunnel = null
@@ -406,7 +412,7 @@ class RayfishVpnService : VpnService() {
         }
         dnsProxy = null
 
-        val standby = NodeHolder.isStayOnline(applicationContext)
+        val standby = !NodeHolder.isGoOfflineWhenDisabled(applicationContext)
         if (standby) {
             Log.w(TAG, "$reason; staying in standby, ensuring control plane is up")
             try {
@@ -417,22 +423,22 @@ class RayfishVpnService : VpnService() {
             startForegroundNotification(standby = true)
             startAutoAcceptPoller()
         } else {
-            // With stay-online off, "VPN off" must mean fully offline. Without
-            // this, startTunnelBlocking's ensureStarted call above already
-            // brought the control plane up before the tunnel build failed, and
-            // nothing else would ever stop it: the daemon would keep its mesh
-            // connection open and the device would stay visible to peers with
-            // both the VPN toggle and stay-online off, contradicting what the
-            // user asked for.
+            // With "go fully offline when disabled" set, "VPN off" must mean
+            // fully offline. Without this, startTunnelBlocking's ensureStarted
+            // call above already brought the control plane up before the tunnel
+            // build failed, and nothing else would ever stop it: the daemon
+            // would keep its mesh connection open and the device would stay
+            // visible to peers with both the VPN toggle off and this pref set,
+            // contradicting what the user asked for.
             if (FileAutoAccept.hasInFlightAccepts()) {
-                Log.w(TAG, "$reason; an own-device file accept looks in flight, stopping the node anyway (stay-online off) will drop it")
+                Log.w(TAG, "$reason; an own-device file accept looks in flight, stopping the node anyway (go fully offline set) will drop it")
             }
-            Log.e(TAG, "$reason; tunnel not up and stay-online off, stopping node and service (startId=$startId)")
+            Log.e(TAG, "$reason; tunnel not up and go fully offline set, stopping node and service (startId=$startId)")
             NodeHolder.stopNode(applicationContext)
-            // Nothing is left to poll for: stay-online off means no control plane
-            // is meant to be up, so a poller left running here would just be dead
-            // work spinning every 4s against a stopped node until onDestroy's
-            // teardown eventually lands.
+            // Nothing is left to poll for: "go fully offline" means no control
+            // plane is meant to be up, so a poller left running here would just
+            // be dead work spinning every 4s against a stopped node until
+            // onDestroy's teardown eventually lands.
             autoAcceptPoller?.shutdownNow()
             autoAcceptPoller = null
             stopSelf(startId)
@@ -484,11 +490,13 @@ class RayfishVpnService : VpnService() {
      * Android revoked our VPN, which happens when another VPN app (Tailscale, say)
      * takes the single VpnService slot, or the user disconnects us from system
      * Settings. The default implementation calls stopSelf(), which would take the
-     * whole node offline and defeat the stay-online pref, since this path never
-     * touches our own toggle. Route it to the same place the toggle goes.
+     * whole node offline and defeat standby, since this path never touches our own
+     * toggle. Route it to the same place the toggle goes: standby unless the user
+     * asked to go fully offline when disabled. This is the entire point of the
+     * feature, so this branch must land in standby by default.
      */
     override fun onRevoke() {
-        val standby = NodeHolder.isStayOnline(applicationContext)
+        val standby = !NodeHolder.isGoOfflineWhenDisabled(applicationContext)
         Log.i(TAG, "onRevoke: VPN revoked by the system; standby=$standby")
         // The user did not ask for the tunnel any more, so clear the enable intent.
         // Otherwise a later app launch would re-establish it and yank the VPN slot

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -23,7 +23,6 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
-import kotlin.concurrent.thread
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -201,23 +200,26 @@ class RayfishVpnService : VpnService() {
         tunnel = pfd
 
         // Node.up drives the blocking-ish bring-up (endpoint bind, forward loop
-        // spawn) so keep it off the main thread. detachFd() transfers ownership
-        // of the tunnel fd to the Rust side, which closes it on Node.down; our
-        // ParcelFileDescriptor no longer owns an fd, so tunnel?.close() on stop
-        // is a harmless no-op kept only to clear the reference.
+        // spawn); called inline here, on nodeExecutor's own thread, so it is
+        // fully done (tunnel attached or not) before the next queued task (a
+        // stop, say) can run. A detached thread would return before Node.up
+        // ran, letting a later stopTunnel's down() race ahead of it: a stale
+        // up() would then re-attach the TUN after the user asked for it off.
+        // detachFd() transfers ownership of the tunnel fd to the Rust side,
+        // which closes it on Node.down; our ParcelFileDescriptor no longer
+        // owns an fd, so tunnel?.close() on stop is a harmless no-op kept only
+        // to clear the reference.
         //
         // ensureStarted() MUST run before up(): the node needs start() (which
         // builds the headless daemon and reconnects saved networks) or up()
         // returns NotStarted. The service is START_STICKY, so the system can
         // restart it with no Activity ever created and the UI's ensureStarted
         // never running; starting it here makes the service self-sufficient.
-        thread(name = "rayfish-node-up") {
-            try {
-                NodeHolder.get(applicationContext).up(pfd.detachFd())
-                Log.i(TAG, "Node.up succeeded")
-            } catch (t: Throwable) {
-                Log.e(TAG, "Node bring-up failed", t)
-            }
+        try {
+            NodeHolder.get(applicationContext).up(pfd.detachFd())
+            Log.i(TAG, "Node.up succeeded")
+        } catch (t: Throwable) {
+            Log.e(TAG, "Node bring-up failed", t)
         }
 
         startAutoAcceptPoller()
@@ -354,16 +356,21 @@ class RayfishVpnService : VpnService() {
     override fun onDestroy() {
         // The service is going away for good, so there is no standby to hold: a
         // standby with no foreground service is exactly the process the OS kills.
-        // Tear the node down fully. Routed through nodeExecutor (and waited on)
-        // rather than called inline, so it cannot interleave with a bring-up task
-        // still running or queued there; onDestroy blocks until it is done, since
-        // the executor is shut down right after.
+        // Tear the node down fully. Routed through nodeExecutor (not called
+        // inline) so it cannot interleave with a bring-up task still running or
+        // queued there; it queues behind whatever is already there instead.
+        //
+        // Not waited on: onDestroy runs on the main thread under a 20s
+        // foreground-service ANR deadline, and the queue ahead of this task can
+        // include a full startTunnelBlocking (RustlsInit, Node.start binding the
+        // iroh endpoint and reconnecting saved networks: seconds, network-
+        // dependent) followed by this teardown, which can itself block on a
+        // graceful endpoint close. Blocking here bought nothing anyway: the
+        // process outlives onDestroy and nodeExecutor.shutdown() below already
+        // lets every queued task, including this one, run to completion in the
+        // background.
         Log.i(TAG, "onDestroy: service being destroyed (tunnel fd present=${tunnel != null})")
-        try {
-            nodeExecutor.submit { stopTunnel(standby = false) }.get()
-        } catch (t: Throwable) {
-            Log.w(TAG, "onDestroy: teardown task failed", t)
-        }
+        nodeExecutor.execute { stopTunnel(standby = false) }
         nodeExecutor.shutdown()
         super.onDestroy()
     }

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -41,6 +41,11 @@ class RayfishVpnService : VpnService() {
     // shared to this device land in Downloads even with the app UI closed.
     private var autoAcceptPoller: ScheduledExecutorService? = null
 
+    override fun onCreate() {
+        super.onCreate()
+        isRunning = true
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent == null) {
             // A genuinely null intent means the system restarted us after killing
@@ -380,6 +385,17 @@ class RayfishVpnService : VpnService() {
      * replaces whatever startForegroundNotification() posted at the top of
      * startTunnel(), and the poller starts so files keep landing. With
      * stay-online off there is nothing left to keep the service alive for.
+     *
+     * Honesty check on the stay-online-off branch: with the VPN off and
+     * stay-online off, a node started earlier by ShareActivity (own-device
+     * auto-accept, or a manual Save, driven by HomeScreen's poller) can be
+     * mid-receive when the user then asks for the VPN to come on and it fails
+     * here (another VPN app holds the slot). NodeHolder.stopNode below then
+     * kills that in-flight receive and drops the partial file, even though the
+     * user asked to go online, not offline. The "no VPN + stay-online off means
+     * offline" invariant has to win regardless: this is a real, if narrow, cost
+     * of it, not a bug to route around, and no retry/queueing is built for it
+     * here. hasInFlightAccepts() below only makes the cost visible in the log.
      */
     private fun handleBringUpFailure(reason: String, startId: Int) {
         tunnel = null
@@ -408,8 +424,17 @@ class RayfishVpnService : VpnService() {
             // connection open and the device would stay visible to peers with
             // both the VPN toggle and stay-online off, contradicting what the
             // user asked for.
+            if (FileAutoAccept.hasInFlightAccepts()) {
+                Log.w(TAG, "$reason; an own-device file accept looks in flight, stopping the node anyway (stay-online off) will drop it")
+            }
             Log.e(TAG, "$reason; tunnel not up and stay-online off, stopping node and service (startId=$startId)")
             NodeHolder.stopNode(applicationContext)
+            // Nothing is left to poll for: stay-online off means no control plane
+            // is meant to be up, so a poller left running here would just be dead
+            // work spinning every 4s against a stopped node until onDestroy's
+            // teardown eventually lands.
+            autoAcceptPoller?.shutdownNow()
+            autoAcceptPoller = null
             stopSelf(startId)
         }
     }
@@ -624,6 +649,11 @@ class RayfishVpnService : VpnService() {
         // lets every queued task, including this one, run to completion in the
         // background.
         Log.i(TAG, "onDestroy: service being destroyed (tunnel fd present=${tunnel != null})")
+        // Set now, not after the queued teardown below: TransferNotifier's "only
+        // notified if Rayfish stays running" caveat reads this to decide whether a
+        // poller is still alive, and once onDestroy has been called nothing here
+        // is going to observe a transfer completing any more.
+        isRunning = false
         nodeExecutor.execute {
             // See the ACTION_STOP execute() block for why this must never let a
             // throwable escape.
@@ -696,6 +726,17 @@ class RayfishVpnService : VpnService() {
         // Neither task may run on the main thread: both block on FFI calls into the
         // Rust core.
         private val nodeExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+
+        // Whether an instance of this service is currently alive: set in onCreate,
+        // cleared in onDestroy. Read by TransferNotifier to decide whether its
+        // "only notified if Rayfish stays running" caveat is actually true (a
+        // poller alive in the background, VPN on or standby, will observe and
+        // notify a transfer's completion regardless of whether the app UI is
+        // open). Not a substitute for tunnel/standby state: it says only that a
+        // poller is running, not what it is doing.
+        @Volatile
+        var isRunning: Boolean = false
+            private set
 
         const val ACTION_STOP = "xyz.rayfish.android.STOP"
         const val ACTION_STANDBY = "xyz.rayfish.android.STANDBY"

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -121,13 +121,13 @@ class RayfishVpnService : VpnService() {
                 // teardown (seconds). A stale null here would run enterStandby
                 // while a bring-up is still landing; a stale non-null would skip
                 // standby entirely while a teardown is still clearing the field.
-                // So post the notification this call is obligated to post right
-                // away (this is a startForegroundService start), then decide for
-                // real on nodeExecutor, where the check is serialized against
-                // startTunnelBlocking and stopTunnel and therefore sees the
-                // settled value.
+                // Post a best guess to meet the foreground-service deadline right
+                // now; the executor task below decides for real on nodeExecutor,
+                // where the check is serialized against startTunnelBlocking and
+                // stopTunnel and therefore sees the settled value, and corrects
+                // the notification if needed.
                 Log.i(TAG, "ACTION_STANDBY received")
-                startForegroundNotification(standby = true)
+                startForegroundNotification(standby = tunnel == null)
                 nodeExecutor.execute {
                     // See the ACTION_STOP execute() block for why this must never
                     // let a throwable escape.

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -69,6 +69,14 @@ class RayfishVpnService : VpnService() {
 
         when (intent.action) {
             ACTION_STOP -> {
+                // Persist the disable intent here, not only in the caller. The UI
+                // toggle already sets this false before sending ACTION_STOP, but
+                // the notification "Disable" action (below) delivers ACTION_STOP
+                // straight to the service with no Activity in the loop. Without
+                // this write the launch-time restore would read enabled=true and
+                // bring the tunnel back up. Idempotent with the UI path; mirrors
+                // what onRevoke already does.
+                NodeHolder.setEnabled(applicationContext, false)
                 // Tearing down blocks (a graceful endpoint close on the offline
                 // path, so peers see us drop cleanly and a re-enable rebuilds
                 // without a stale session). Run it on the node executor to avoid
@@ -699,13 +707,37 @@ class RayfishVpnService : VpnService() {
             PendingIntent.FLAG_IMMUTABLE,
         )
 
-        val notification: Notification = Notification.Builder(this, CHANNEL_ID)
+        val builder = Notification.Builder(this, CHANNEL_ID)
             .setContentTitle("Rayfish")
             .setContentText(if (standby) "Online, VPN off · files still work" else "Mesh tunnel active")
             .setSmallIcon(android.R.drawable.stat_sys_download_done)
             .setOngoing(true)
             .setContentIntent(openIntent)
-            .build()
+
+        // With the VPN up, offer a one-tap "Disable" straight from the shade
+        // (like Tailscale), so the user can drop the tunnel and free the single
+        // VpnService slot without opening the app. The action delivers ACTION_STOP
+        // to this service, which persists the disable intent and, under the
+        // standby default, keeps the control plane up so files still work. No
+        // action in standby: turning the VPN back on needs the system consent
+        // dialog, which only an Activity can raise.
+        if (!standby) {
+            val disableIntent = PendingIntent.getService(
+                this,
+                1,
+                Intent(this, RayfishVpnService::class.java).apply { action = ACTION_STOP },
+                PendingIntent.FLAG_IMMUTABLE,
+            )
+            builder.addAction(
+                Notification.Action.Builder(
+                    null as android.graphics.drawable.Icon?,
+                    "Disable",
+                    disableIntent,
+                ).build(),
+            )
+        }
+
+        val notification: Notification = builder.build()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             startForeground(NOTIF_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -41,17 +41,35 @@ class RayfishVpnService : VpnService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_STOP -> {
-                // stopTunnel now blocks on a graceful endpoint close (so peers
-                // see us drop cleanly and re-enable rebuilds without a stale
-                // session). Run it off the main thread to avoid an ANR, then
-                // stop the service.
-                Log.i(TAG, "ACTION_STOP received; tearing tunnel down (tunnel fd present=${tunnel != null})")
+                // Tearing down blocks (a graceful endpoint close on the offline
+                // path, so peers see us drop cleanly and a re-enable rebuilds
+                // without a stale session). Run it off the main thread to avoid an
+                // ANR. In standby we keep the service alive; only the fully-offline
+                // path calls stopSelf.
+                val standby = NodeHolder.isStayOnline(applicationContext)
+                Log.i(TAG, "ACTION_STOP received; standby=$standby (tunnel fd present=${tunnel != null})")
                 thread(name = "rayfish-node-stop") {
-                    stopTunnel()
-                    Log.i(TAG, "stopTunnel returned; calling stopSelf()")
-                    stopSelf()
+                    stopTunnel(standby)
+                    if (!standby) {
+                        Log.i(TAG, "stopTunnel returned; calling stopSelf()")
+                        stopSelf()
+                    }
                 }
-                return START_NOT_STICKY
+                return if (standby) START_STICKY else START_NOT_STICKY
+            }
+            // A null intent means the system restarted us after killing the process
+            // (START_STICKY). No Activity ran, so nothing else brought the node up:
+            // decide from the persisted prefs what state to restore.
+            null -> {
+                if (NodeHolder.isEnabled(applicationContext)) {
+                    startTunnel()
+                } else if (NodeHolder.isStayOnline(applicationContext)) {
+                    enterStandby()
+                } else {
+                    // Neither the VPN nor stay-online is wanted: nothing to run.
+                    stopSelf()
+                    return START_NOT_STICKY
+                }
             }
             else -> startTunnel()
         }
@@ -169,10 +187,55 @@ class RayfishVpnService : VpnService() {
             }
         }
 
-        // Auto-accept own-device file offers while the tunnel is up, so a file
-        // shared to this device from one of the user's own devices lands in
-        // Downloads without the app being open. Gated by the user's opt-out toggle
-        // inside FileAutoAccept.run.
+        startAutoAcceptPoller()
+    }
+
+    /**
+     * Control plane up, no tunnel. The service stays foreground (Android kills the
+     * process, and the tokio runtime with it, once no foreground service is left),
+     * so the node keeps serving files and stays visible in the mesh.
+     */
+    private fun enterStandby() {
+        startForegroundNotification(standby = true)
+        thread(name = "rayfish-node-standby") {
+            try {
+                runBlocking { NodeHolder.ensureStarted(applicationContext) }
+                Log.i(TAG, "standby: control plane up, no tunnel")
+            } catch (t: Throwable) {
+                Log.e(TAG, "standby bring-up failed", t)
+            }
+        }
+        startAutoAcceptPoller()
+    }
+
+    /**
+     * Android revoked our VPN, which happens when another VPN app (Tailscale, say)
+     * takes the single VpnService slot, or the user disconnects us from system
+     * Settings. The default implementation calls stopSelf(), which would take the
+     * whole node offline and defeat the stay-online pref, since this path never
+     * touches our own toggle. Route it to the same place the toggle goes.
+     */
+    override fun onRevoke() {
+        val standby = NodeHolder.isStayOnline(applicationContext)
+        Log.i(TAG, "onRevoke: VPN revoked by the system; standby=$standby")
+        // The user did not ask for the tunnel any more, so clear the enable intent.
+        // Otherwise a later app launch would re-establish it and yank the VPN slot
+        // back from whatever took it.
+        NodeHolder.setEnabled(applicationContext, false)
+        thread(name = "rayfish-node-revoke") {
+            stopTunnel(standby)
+            if (!standby) stopSelf()
+        }
+    }
+
+    /**
+     * Auto-accept own-device file offers, so a file shared to this device from one
+     * of the user's own devices lands in Downloads without the app being open. Runs
+     * in standby too: that is what makes files keep working with the VPN off. Gated
+     * by the user's opt-out toggle inside FileAutoAccept.run. Idempotent.
+     */
+    private fun startAutoAcceptPoller() {
+        if (autoAcceptPoller != null) return
         autoAcceptPoller = java.util.concurrent.Executors.newSingleThreadScheduledExecutor().also { exec ->
             exec.scheduleWithFixedDelay(
                 { runCatching { FileAutoAccept.run(applicationContext) } },
@@ -202,44 +265,61 @@ class RayfishVpnService : VpnService() {
         return servers
     }
 
-    private fun stopTunnel() {
-        // Disable on mobile means go offline, not standby: tear the whole control
-        // plane down (cancels the daemon shutdown token, closes the endpoint) so
-        // the device drops out of the mesh immediately. stopNode also clears the
-        // started flag so a later enable rebuilds the daemon.
+    /**
+     * Bring the tunnel down. In standby the control plane survives (Node.down):
+     * files keep flowing and the device stays online in the mesh. Otherwise this is
+     * a full offline teardown (Node.stop), which also clears NodeHolder.started so
+     * a later enable rebuilds the daemon.
+     */
+    private fun stopTunnel(standby: Boolean) {
         try {
-            Log.i(TAG, "stopTunnel: calling NodeHolder.stopNode (offline)")
-            NodeHolder.stopNode(applicationContext)
-            Log.i(TAG, "stopTunnel: stopNode returned")
+            if (standby) {
+                Log.i(TAG, "stopTunnel: Node.down (standby, control plane stays up)")
+                NodeHolder.downNode(applicationContext)
+            } else {
+                Log.i(TAG, "stopTunnel: NodeHolder.stopNode (offline)")
+                NodeHolder.stopNode(applicationContext)
+            }
+            Log.i(TAG, "stopTunnel: teardown returned")
         } catch (t: Throwable) {
-            Log.w(TAG, "Node stop failed (may not have been up)", t)
+            Log.w(TAG, "Node teardown failed (may not have been up)", t)
         }
         try {
             // Detached to Rust via detachFd(), so this is a no-op; the fd is only
             // closed when the Rust side aborts the TUN tasks. Logged to make that
-            // explicit while debugging the lingering interface.
+            // explicit while debugging a lingering interface.
             Log.i(TAG, "stopTunnel: tunnel?.close() (no-op; fd owned by Rust after detachFd)")
             tunnel?.close()
         } catch (t: Throwable) {
             Log.w(TAG, "closing tunnel fd failed", t)
         }
+        tunnel = null
 
-        autoAcceptPoller?.shutdownNow()
-        autoAcceptPoller = null
-
+        // The DNS proxy exists to serve the tunnel's resolver; with no tunnel there
+        // is nothing pointed at it. Torn down in both cases.
         dnsProxy?.stop()
         dnsProxy = null
 
-        tunnel = null
+        if (standby) {
+            // Keep the poller running (files still work) and tell the user plainly
+            // what state we are in, so the persistent notification is not confusing.
+            startForegroundNotification(standby = true)
+        } else {
+            autoAcceptPoller?.shutdownNow()
+            autoAcceptPoller = null
+        }
     }
 
     override fun onDestroy() {
+        // The service is going away for good, so there is no standby to hold: a
+        // standby with no foreground service is exactly the process the OS kills.
+        // Tear the node down fully.
         Log.i(TAG, "onDestroy: service being destroyed (tunnel fd present=${tunnel != null})")
-        stopTunnel()
+        stopTunnel(standby = false)
         super.onDestroy()
     }
 
-    private fun startForegroundNotification() {
+    private fun startForegroundNotification(standby: Boolean = false) {
         val nm = getSystemService(NotificationManager::class.java)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
@@ -259,7 +339,7 @@ class RayfishVpnService : VpnService() {
 
         val notification: Notification = Notification.Builder(this, CHANNEL_ID)
             .setContentTitle("Rayfish")
-            .setContentText("Mesh tunnel active")
+            .setContentText(if (standby) "Online, VPN off · files still work" else "Mesh tunnel active")
             .setSmallIcon(android.R.drawable.stat_sys_download_done)
             .setOngoing(true)
             .setContentIntent(openIntent)

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -127,6 +127,41 @@ class RayfishVpnService : VpnService() {
                 enterStandby()
                 return START_STICKY
             }
+            ACTION_EXIT_STANDBY -> {
+                // Sent unconditionally from YouScreen's toggle OFF branch, which
+                // cannot tell from the stale status cache whether a tunnel is up.
+                // Meaning: "the user no longer wants standby; if nothing else needs
+                // the control plane up (no tunnel), take the node fully offline and
+                // stop the service." If a tunnel is up, the VPN is on and this pref
+                // only governs what happens at the next teardown, so do nothing:
+                // the same guard ACTION_STANDBY applies in the other direction.
+                Log.i(TAG, "ACTION_EXIT_STANDBY received (tunnel fd present=${tunnel != null})")
+                if (tunnel != null) {
+                    Log.i(TAG, "ACTION_EXIT_STANDBY ignored: tunnel is up")
+                    return START_STICKY
+                }
+                // No tunnel: either genuine standby the user no longer wants, or a
+                // fresh service instance (process was dead) with nothing started at
+                // all. Either way the same offline teardown ACTION_STOP performs
+                // with stay-online off, idempotent if there was nothing to tear
+                // down. No standby notification is posted here (unlike ACTION_STOP's
+                // standby branch): this path never leaves the service in standby, so
+                // there is nothing true to say about it, and the intent that reaches
+                // here is a plain startService, not a foreground one, so there is no
+                // foreground-notification deadline to meet.
+                nodeExecutor.execute {
+                    // See the ACTION_STOP execute() block for why this must never
+                    // let a throwable escape.
+                    try {
+                        stopTunnel(standby = false)
+                        Log.i(TAG, "ACTION_EXIT_STANDBY: stopTunnel returned; calling stopSelf(startId=$startId)")
+                        stopSelf(startId)
+                    } catch (t: Throwable) {
+                        Log.e(TAG, "ACTION_EXIT_STANDBY task crashed", t)
+                    }
+                }
+                return START_NOT_STICKY
+            }
             // An action-less start intent is the normal "turn the VPN on" path
             // (see HomeScreen / RayfishApp, which both start the service with a
             // plain Intent). It must reach startTunnel(), not be mistaken for
@@ -592,6 +627,7 @@ class RayfishVpnService : VpnService() {
         private const val NOTIF_ID = 1
         const val ACTION_STOP = "xyz.rayfish.android.STOP"
         const val ACTION_STANDBY = "xyz.rayfish.android.STANDBY"
+        const val ACTION_EXIT_STANDBY = "xyz.rayfish.android.EXIT_STANDBY"
 
         // Apps that misbehave behind a VPN (casting, RCS, local-device discovery).
         // Mirrors Tailscale's default Android exclusions. Excluded so they never

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -110,10 +110,9 @@ class RayfishVpnService : VpnService() {
             ACTION_STANDBY -> {
                 // Enter standby explicitly, sent from YouScreen's toggle OFF
                 // branch (the user no longer wants "go fully offline") while the
-                // tunnel is off. Must bring up the
-                // control plane only: never touch the Builder/establish() path,
-                // so it never contends for the single VpnService slot and never
-                // triggers the VPN consent dialog.
+                // tunnel is off. Must bring up the control plane only: never touch
+                // the Builder/establish() path, so it never contends for the single
+                // VpnService slot and never triggers the VPN consent dialog.
                 //
                 // The tunnel != null decision cannot be made here, on the main
                 // thread: tunnel is only written on nodeExecutor, so a main-thread
@@ -180,7 +179,7 @@ class RayfishVpnService : VpnService() {
                         // No tunnel: either genuine standby the user no longer
                         // wants, or a fresh service instance (process was dead)
                         // with nothing started at all. Either way the same offline
-                        // teardown ACTION_STOP performs with stay-online off,
+                        // teardown ACTION_STOP performs when go-fully-offline is enabled,
                         // idempotent if there was nothing to tear down.
                         stopTunnel(standby = false)
                         Log.i(TAG, "ACTION_EXIT_STANDBY: stopTunnel returned; calling stopSelf(startId=$startId)")

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -87,8 +87,14 @@ class RayfishVpnService : VpnService() {
                 nodeExecutor.execute {
                     stopTunnel(standby)
                     if (!standby) {
-                        Log.i(TAG, "stopTunnel returned; calling stopSelf()")
-                        stopSelf()
+                        // stopSelf(startId), not the bare stopSelf(): fast off-then-on
+                        // toggling queues this stop behind a start that already
+                        // landed. stopSelf(startId) is a no-op once a newer start
+                        // command has been delivered, so it only kills the service
+                        // if no start arrived after this one; the bare form would
+                        // kill it either way and undo the newer start's tunnel.
+                        Log.i(TAG, "stopTunnel returned; calling stopSelf(startId=$startId)")
+                        stopSelf(startId)
                     }
                 }
                 return if (standby) START_STICKY else START_NOT_STICKY
@@ -191,10 +197,27 @@ class RayfishVpnService : VpnService() {
             }
         }
 
-        val pfd = builder.establish()
+        val pfd = try {
+            builder.establish()
+        } catch (t: Throwable) {
+            Log.e(TAG, "VpnService.Builder.establish() threw", t)
+            null
+        }
         if (pfd == null) {
-            Log.e(TAG, "VpnService.Builder.establish() returned null; tunnel not up")
-            stopSelf()
+            // establish() returns null precisely when we do not hold the single
+            // VpnService slot (another VPN app, e.g. Tailscale, took it, or the
+            // user has none configured). With stay-online on, that is exactly
+            // the case standby exists for: the control plane (already brought up
+            // above) must keep running so files and mesh visibility survive,
+            // instead of tearing the whole service down under it.
+            val standby = NodeHolder.isStayOnline(applicationContext)
+            if (standby) {
+                Log.w(TAG, "establish() returned null (VPN slot likely unavailable); staying in standby, control plane stays up")
+                startForegroundNotification(standby = true)
+            } else {
+                Log.e(TAG, "VpnService.Builder.establish() returned null; tunnel not up, stopping service")
+                stopSelf()
+            }
             return
         }
         tunnel = pfd
@@ -239,8 +262,12 @@ class RayfishVpnService : VpnService() {
             } catch (t: Throwable) {
                 Log.e(TAG, "standby bring-up failed", t)
             }
+            // Moved inside the executor task: autoAcceptPoller (like dnsProxy) is
+            // only read and written from nodeExecutor's thread (startTunnelBlocking,
+            // stopTunnel). Calling this from the main thread, as before, made it the
+            // one field touched from two threads with no lock between them.
+            startAutoAcceptPoller()
         }
-        startAutoAcceptPoller()
     }
 
     /**
@@ -341,8 +368,15 @@ class RayfishVpnService : VpnService() {
         tunnel = null
 
         // The DNS proxy exists to serve the tunnel's resolver; with no tunnel there
-        // is nothing pointed at it. Torn down in both cases.
-        dnsProxy?.stop()
+        // is nothing pointed at it. Torn down in both cases. Wrapped: this runs on
+        // nodeExecutor via execute(), so an uncaught throwable here would reach the
+        // default uncaught-exception handler and kill the process, skipping the
+        // dnsProxy = null reset and the poller shutdown below.
+        try {
+            dnsProxy?.stop()
+        } catch (t: Throwable) {
+            Log.w(TAG, "dnsProxy.stop() failed", t)
+        }
         dnsProxy = null
 
         // Keep the poller running in standby (files still work); shut it down on a

--- a/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/RayfishVpnService.kt
@@ -19,6 +19,10 @@ import android.os.ParcelFileDescriptor
 // when the user has crash reporting opted out (Sentry stays uninitialized).
 import io.sentry.android.core.SentryLogcatAdapter as Log
 import java.net.Inet4Address
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 import kotlinx.coroutines.runBlocking
 
@@ -36,19 +40,52 @@ class RayfishVpnService : VpnService() {
     private var dnsProxy: DnsProxy? = null
     // Polls for incoming own-device file offers and auto-accepts them, so files
     // shared to this device land in Downloads even with the app UI closed.
-    private var autoAcceptPoller: java.util.concurrent.ScheduledExecutorService? = null
+    private var autoAcceptPoller: ScheduledExecutorService? = null
+
+    // Serializes bring-up (startTunnel/enterStandby) and teardown (stopTunnel) so
+    // they can never interleave. Both read and write the tunnel/dnsProxy fields;
+    // running them on the same single-threaded executor means a queued task only
+    // starts once the previous one has fully finished, so an off-then-on always
+    // ends with the tunnel up and an on-then-off always ends in standby/offline,
+    // regardless of how quickly the two requests arrive. Neither task may run on
+    // the main thread: both block on FFI calls into the Rust core.
+    private val nodeExecutor: ExecutorService = Executors.newSingleThreadExecutor()
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        when (intent?.action) {
+        if (intent == null) {
+            // A genuinely null intent means the system restarted us after killing
+            // the process (START_STICKY re-delivery). No Activity ran, so nothing
+            // else brought the node up: decide from the persisted prefs what
+            // state to restore.
+            if (NodeHolder.isEnabled(applicationContext)) {
+                startTunnel()
+            } else if (NodeHolder.isStayOnline(applicationContext)) {
+                enterStandby()
+            } else {
+                // Neither the VPN nor stay-online is wanted: nothing to run.
+                stopSelf()
+                return START_NOT_STICKY
+            }
+            return START_STICKY
+        }
+
+        when (intent.action) {
             ACTION_STOP -> {
                 // Tearing down blocks (a graceful endpoint close on the offline
                 // path, so peers see us drop cleanly and a re-enable rebuilds
-                // without a stale session). Run it off the main thread to avoid an
-                // ANR. In standby we keep the service alive; only the fully-offline
-                // path calls stopSelf.
+                // without a stale session). Run it on the node executor to avoid
+                // an ANR and to serialize with any concurrent bring-up. In
+                // standby we keep the service alive; only the fully-offline path
+                // calls stopSelf.
                 val standby = NodeHolder.isStayOnline(applicationContext)
                 Log.i(TAG, "ACTION_STOP received; standby=$standby (tunnel fd present=${tunnel != null})")
-                thread(name = "rayfish-node-stop") {
+                if (standby) {
+                    // Post the standby text now, not after the blocking teardown
+                    // below returns, so the notification does not keep reading
+                    // "Mesh tunnel active" while downNode() is still running.
+                    startForegroundNotification(standby = true)
+                }
+                nodeExecutor.execute {
                     stopTunnel(standby)
                     if (!standby) {
                         Log.i(TAG, "stopTunnel returned; calling stopSelf()")
@@ -57,28 +94,24 @@ class RayfishVpnService : VpnService() {
                 }
                 return if (standby) START_STICKY else START_NOT_STICKY
             }
-            // A null intent means the system restarted us after killing the process
-            // (START_STICKY). No Activity ran, so nothing else brought the node up:
-            // decide from the persisted prefs what state to restore.
-            null -> {
-                if (NodeHolder.isEnabled(applicationContext)) {
-                    startTunnel()
-                } else if (NodeHolder.isStayOnline(applicationContext)) {
-                    enterStandby()
-                } else {
-                    // Neither the VPN nor stay-online is wanted: nothing to run.
-                    stopSelf()
-                    return START_NOT_STICKY
-                }
-            }
+            // An action-less start intent is the normal "turn the VPN on" path
+            // (see HomeScreen / RayfishApp, which both start the service with a
+            // plain Intent). It must reach startTunnel(), not be mistaken for
+            // the null-intent restart-recovery branch above.
             else -> startTunnel()
         }
         return START_STICKY
     }
 
     private fun startTunnel() {
-        if (tunnel != null) return
+        // startForeground must be called promptly so the foreground-service
+        // deadline is met; only the blocking node work goes to the executor.
         startForegroundNotification()
+        nodeExecutor.execute { startTunnelBlocking() }
+    }
+
+    private fun startTunnelBlocking() {
+        if (tunnel != null) return
 
         // Bring the control plane up before building the tunnel so status() can
         // report our real mesh IP. ensureStarted is idempotent.
@@ -197,7 +230,7 @@ class RayfishVpnService : VpnService() {
      */
     private fun enterStandby() {
         startForegroundNotification(standby = true)
-        thread(name = "rayfish-node-standby") {
+        nodeExecutor.execute {
             try {
                 runBlocking { NodeHolder.ensureStarted(applicationContext) }
                 Log.i(TAG, "standby: control plane up, no tunnel")
@@ -222,7 +255,12 @@ class RayfishVpnService : VpnService() {
         // Otherwise a later app launch would re-establish it and yank the VPN slot
         // back from whatever took it.
         NodeHolder.setEnabled(applicationContext, false)
-        thread(name = "rayfish-node-revoke") {
+        if (standby) {
+            // Post the standby text now, not after the blocking teardown below
+            // returns (see the same fix in the ACTION_STOP path above).
+            startForegroundNotification(standby = true)
+        }
+        nodeExecutor.execute {
             stopTunnel(standby)
             if (!standby) stopSelf()
         }
@@ -236,10 +274,10 @@ class RayfishVpnService : VpnService() {
      */
     private fun startAutoAcceptPoller() {
         if (autoAcceptPoller != null) return
-        autoAcceptPoller = java.util.concurrent.Executors.newSingleThreadScheduledExecutor().also { exec ->
+        autoAcceptPoller = Executors.newSingleThreadScheduledExecutor().also { exec ->
             exec.scheduleWithFixedDelay(
                 { runCatching { FileAutoAccept.run(applicationContext) } },
-                4, 4, java.util.concurrent.TimeUnit.SECONDS,
+                4, 4, TimeUnit.SECONDS,
             )
         }
     }
@@ -270,6 +308,11 @@ class RayfishVpnService : VpnService() {
      * files keep flowing and the device stays online in the mesh. Otherwise this is
      * a full offline teardown (Node.stop), which also clears NodeHolder.started so
      * a later enable rebuilds the daemon.
+     *
+     * Always runs on [nodeExecutor], serialized with [startTunnelBlocking]: the
+     * standby notification text is posted by the caller before this runs, not
+     * here, so it flips the instant the request lands instead of only once this
+     * blocking teardown returns.
      */
     private fun stopTunnel(standby: Boolean) {
         try {
@@ -300,11 +343,9 @@ class RayfishVpnService : VpnService() {
         dnsProxy?.stop()
         dnsProxy = null
 
-        if (standby) {
-            // Keep the poller running (files still work) and tell the user plainly
-            // what state we are in, so the persistent notification is not confusing.
-            startForegroundNotification(standby = true)
-        } else {
+        // Keep the poller running in standby (files still work); shut it down on a
+        // full offline teardown.
+        if (!standby) {
             autoAcceptPoller?.shutdownNow()
             autoAcceptPoller = null
         }
@@ -313,9 +354,17 @@ class RayfishVpnService : VpnService() {
     override fun onDestroy() {
         // The service is going away for good, so there is no standby to hold: a
         // standby with no foreground service is exactly the process the OS kills.
-        // Tear the node down fully.
+        // Tear the node down fully. Routed through nodeExecutor (and waited on)
+        // rather than called inline, so it cannot interleave with a bring-up task
+        // still running or queued there; onDestroy blocks until it is done, since
+        // the executor is shut down right after.
         Log.i(TAG, "onDestroy: service being destroyed (tunnel fd present=${tunnel != null})")
-        stopTunnel(standby = false)
+        try {
+            nodeExecutor.submit { stopTunnel(standby = false) }.get()
+        } catch (t: Throwable) {
+            Log.w(TAG, "onDestroy: teardown task failed", t)
+        }
+        nodeExecutor.shutdown()
         super.onDestroy()
     }
 

--- a/android/app/src/main/java/xyz/rayfish/android/SendService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/SendService.kt
@@ -27,9 +27,9 @@ import uniffi.ray_mobile.TransferState
  * offer reaches a terminal state or [WAIT_TIMEOUT_MS] passes; after that, the
  * only thing left that can report a result is [RayfishVpnService]'s background
  * poller, and that only runs while some instance of that service is actually
- * alive (the VPN on, or stay-online keeping it in standby). A plain
+ * alive (the VPN on, or standby keeping the control plane running). A plain
  * `NodeHolder.ensureStarted` with no `RayfishVpnService` running (e.g.
- * `ShareActivity` sharing with the VPN off and stay-online off) starts no
+ * `ShareActivity` sharing with the VPN off and go-fully-offline enabled) starts no
  * poller at all: the transfer still completes in the core, but nobody is
  * listening, so the result notification never arrives. [TransferNotifier]'s
  * "waiting" notification says this plainly rather than implying a result
@@ -138,7 +138,7 @@ class SendService : Service() {
             // service after WAIT_TIMEOUT_MS. The transfer is not cancelled by that:
             // it keeps running in the core, and the background poller in
             // RayfishVpnService posts the result whenever it lands, provided the node
-            // is still alive (VPN on, or the stay-online pref).
+            // is still alive (VPN on, or in standby).
             //
             // If either snapshot failed, we cannot bound this batch at all: waiting
             // on an unscoped count would silently reinstate the same bug the scoping

--- a/android/app/src/main/java/xyz/rayfish/android/SendService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/SendService.kt
@@ -24,10 +24,16 @@ import uniffi.ray_mobile.TransferState
  * otherwise a manual Save) and pulls the bytes from our blob store when it
  * accepts, which can be minutes later or never. This service stays foreground
  * and reports real per-transfer progress via [TransferNotifier] until every
- * offer reaches a terminal state or [WAIT_TIMEOUT_MS] passes; after that the
- * background poller in [RayfishVpnService] finishes the job, provided the node
- * stays online (the VPN service, or the control plane brought up by
- * ensureStarted).
+ * offer reaches a terminal state or [WAIT_TIMEOUT_MS] passes; after that, the
+ * only thing left that can report a result is [RayfishVpnService]'s background
+ * poller, and that only runs while some instance of that service is actually
+ * alive (the VPN on, or stay-online keeping it in standby). A plain
+ * `NodeHolder.ensureStarted` with no `RayfishVpnService` running (e.g.
+ * `ShareActivity` sharing with the VPN off and stay-online off) starts no
+ * poller at all: the transfer still completes in the core, but nobody is
+ * listening, so the result notification never arrives. [TransferNotifier]'s
+ * "waiting" notification says this plainly rather than implying a result
+ * notification is always coming.
  *
  * Each shared URI is staged to the app cache (the grant rides in on the start
  * intent's ClipData + FLAG_GRANT_READ_URI_PERMISSION), sent, then deleted.

--- a/android/app/src/main/java/xyz/rayfish/android/SendService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/SendService.kt
@@ -63,43 +63,56 @@ class SendService : Service() {
             // max: newly created since we started, and already known to the registry
             // by the time we start waiting.
             //
-            // A single before-only snapshot is not enough with two concurrent shares:
-            // if batch B starts offering while batch A is still in its wait loop, B's
-            // ids are not in A's before-snapshot either, so A's "not in snapshot" count
-            // would include every one of B's transfers too. If B's peer never accepts,
-            // A would burn the full wait timeout for a file it delivered in seconds.
-            val maxIdBeforeBatch = runCatching {
-                NodeHolder.get(applicationContext).listTransfers().maxOfOrNull { it.id.toLong() } ?: -1L
-            }.getOrNull()
-
+            // That two-sided bound is not sufficient by itself with two concurrent
+            // shares: it only excludes a batch that starts after this one's "after"
+            // snapshot. It does nothing about a batch whose offers land while this
+            // one is still in the middle of its own offer loop (staging a large file
+            // can take seconds to tens of seconds, so that window is real): those
+            // ids are newly created and > maxIdBeforeBatch, so the after-snapshot
+            // would wrongly claim them as this batch's own. If that other batch's
+            // peer never accepts, this one would burn the full wait timeout for a
+            // file it delivered in seconds. So the region from taking the "before"
+            // max through the "after" snapshot is serialized behind batchLock: two
+            // batches' offers can never interleave, only one runs that region at a
+            // time. The lock is released before the wait loop below, so concurrent
+            // batches still wait for their own peers in parallel; only the offering
+            // is serialized, not the (much longer) waiting.
             var offered = 0
             var failed = 0
-            for (uri in uris) {
-                val staged = stageUriForSend(applicationContext, uri)
-                if (staged == null) {
-                    failed++
-                    continue
-                }
-                try {
-                    NodeHolder.get(applicationContext).sendFile(staged.absolutePath, peerId)
-                    offered++
-                } catch (t: Throwable) {
-                    failed++
-                    Log.w(TAG, "send failed for ${staged.name}", t)
-                } finally {
-                    // Bytes are in the blob store now; the staging copy is no longer
-                    // needed. Remove the file and its per-item dir.
-                    runCatching { staged.parentFile?.deleteRecursively() ?: staged.delete() }
-                }
-            }
-
-            val batchIds = if (maxIdBeforeBatch == null) {
-                null
-            } else {
-                runCatching {
-                    NodeHolder.get(applicationContext).listTransfers()
-                        .mapNotNullTo(HashSet()) { it.id.takeIf { id -> id.toLong() > maxIdBeforeBatch } }
+            val maxIdBeforeBatch: Long?
+            val batchIds: Set<ULong>?
+            synchronized(batchLock) {
+                maxIdBeforeBatch = runCatching {
+                    NodeHolder.get(applicationContext).listTransfers().maxOfOrNull { it.id.toLong() } ?: -1L
                 }.getOrNull()
+
+                for (uri in uris) {
+                    val staged = stageUriForSend(applicationContext, uri)
+                    if (staged == null) {
+                        failed++
+                        continue
+                    }
+                    try {
+                        NodeHolder.get(applicationContext).sendFile(staged.absolutePath, peerId)
+                        offered++
+                    } catch (t: Throwable) {
+                        failed++
+                        Log.w(TAG, "send failed for ${staged.name}", t)
+                    } finally {
+                        // Bytes are in the blob store now; the staging copy is no
+                        // longer needed. Remove the file and its per-item dir.
+                        runCatching { staged.parentFile?.deleteRecursively() ?: staged.delete() }
+                    }
+                }
+
+                batchIds = if (maxIdBeforeBatch == null) {
+                    null
+                } else {
+                    runCatching {
+                        NodeHolder.get(applicationContext).listTransfers()
+                            .mapNotNullTo(HashSet()) { it.id.takeIf { id -> id.toLong() > maxIdBeforeBatch } }
+                    }.getOrNull()
+                }
             }
 
             // The offers are delivered, but the bytes have not moved: the peer pulls
@@ -219,6 +232,11 @@ class SendService : Service() {
         // Distinguishes failure notifications from concurrent batches that would
         // otherwise share the same NOTIF_RESULT_BASE + failed-count id.
         private val failureNotifSeq = java.util.concurrent.atomic.AtomicInteger(0)
+        // Serializes the before-snapshot/offer-loop/after-snapshot region of
+        // concurrent send batches so their offers can never interleave. Not held
+        // across the wait loop: concurrent batches still wait on their own peers
+        // in parallel, only the offering is serialized.
+        private val batchLock = Any()
         const val EXTRA_PEER_ID = "xyz.rayfish.android.PEER_ID"
         const val EXTRA_PEER_NAME = "xyz.rayfish.android.PEER_NAME"
         const val EXTRA_URIS = "xyz.rayfish.android.URIS"

--- a/android/app/src/main/java/xyz/rayfish/android/SendService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/SendService.kt
@@ -56,15 +56,21 @@ class SendService : Service() {
         // when its batch finishes so concurrent shares each clean up independently.
         thread(name = "rayfish-send-$startId") {
             // sendFile does not return a transfer id, so we cannot name this batch's
-            // transfers directly. Instead snapshot every id already in the registry
-            // before offering anything: an OFFERED entry whose peer never accepts
-            // lives for the whole process, so counting "all outgoing pending"
-            // below would let one stale offer from an earlier batch pin every
-            // later send to the full wait timeout. Anything not in this snapshot
-            // was created by this batch.
-            val idsBeforeBatch = runCatching {
-                NodeHolder.get(applicationContext).listTransfers().mapTo(HashSet()) { it.id }
-            }.getOrDefault(emptySet())
+            // transfers directly. Instead bound them from both sides: take the max
+            // id already in the registry before offering anything, then again right
+            // after the offer loop finishes. This batch's transfers are exactly the
+            // ones present in the "after" snapshot with an id greater than the "before"
+            // max: newly created since we started, and already known to the registry
+            // by the time we start waiting.
+            //
+            // A single before-only snapshot is not enough with two concurrent shares:
+            // if batch B starts offering while batch A is still in its wait loop, B's
+            // ids are not in A's before-snapshot either, so A's "not in snapshot" count
+            // would include every one of B's transfers too. If B's peer never accepts,
+            // A would burn the full wait timeout for a file it delivered in seconds.
+            val maxIdBeforeBatch = runCatching {
+                NodeHolder.get(applicationContext).listTransfers().maxOfOrNull { it.id.toLong() } ?: -1L
+            }.getOrNull()
 
             var offered = 0
             var failed = 0
@@ -87,6 +93,15 @@ class SendService : Service() {
                 }
             }
 
+            val batchIds = if (maxIdBeforeBatch == null) {
+                null
+            } else {
+                runCatching {
+                    NodeHolder.get(applicationContext).listTransfers()
+                        .mapNotNullTo(HashSet()) { it.id.takeIf { id -> id.toLong() > maxIdBeforeBatch } }
+                }.getOrNull()
+            }
+
             // The offers are delivered, but the bytes have not moved: the peer pulls
             // them when it accepts. Stay foreground and let TransferNotifier report
             // real progress until every transfer reaches a terminal state, so the
@@ -98,20 +113,26 @@ class SendService : Service() {
             // it keeps running in the core, and the background poller in
             // RayfishVpnService posts the result whenever it lands, provided the node
             // is still alive (VPN on, or the stay-online pref).
-            if (offered > 0) {
+            //
+            // If either snapshot failed, we cannot bound this batch at all: waiting
+            // on an unscoped count would silently reinstate the same bug the scoping
+            // was meant to kill, so don't wait rather than wait on everything.
+            if (offered > 0 && batchIds != null) {
                 val deadline = System.currentTimeMillis() + WAIT_TIMEOUT_MS
                 while (System.currentTimeMillis() < deadline) {
                     TransferNotifier.poll(applicationContext)
                     val pending = runCatching {
                         NodeHolder.get(applicationContext).listTransfers()
                             .count {
-                                it.outgoing && it.id !in idsBeforeBatch &&
+                                it.outgoing && it.id in batchIds &&
                                     (it.state == TransferState.OFFERED || it.state == TransferState.TRANSFERRING)
                             }
                     }.getOrDefault(0)
                     if (pending == 0) break
                     Thread.sleep(POLL_INTERVAL_MS)
                 }
+                TransferNotifier.poll(applicationContext)
+            } else if (offered > 0) {
                 TransferNotifier.poll(applicationContext)
             }
 

--- a/android/app/src/main/java/xyz/rayfish/android/SendService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/SendService.kt
@@ -66,19 +66,31 @@ class SendService : Service() {
             // That two-sided bound is not sufficient by itself with two concurrent
             // shares: it only excludes a batch that starts after this one's "after"
             // snapshot. It does nothing about a batch whose offers land while this
-            // one is still in the middle of its own offer loop (staging a large file
-            // can take seconds to tens of seconds, so that window is real): those
-            // ids are newly created and > maxIdBeforeBatch, so the after-snapshot
-            // would wrongly claim them as this batch's own. If that other batch's
-            // peer never accepts, this one would burn the full wait timeout for a
-            // file it delivered in seconds. So the region from taking the "before"
-            // max through the "after" snapshot is serialized behind batchLock: two
-            // batches' offers can never interleave, only one runs that region at a
-            // time. The lock is released before the wait loop below, so concurrent
-            // batches still wait for their own peers in parallel; only the offering
-            // is serialized, not the (much longer) waiting.
+            // one is still in the middle of its own offer loop: each sendFile reads
+            // the whole file, hashes it, adds it to the blob store, and then dials
+            // the peer over QUIC with no client-side timeout, so that window can be
+            // long, not just seconds. Those ids are newly created and greater than
+            // maxIdBeforeBatch, so the after-snapshot would wrongly claim them as
+            // this batch's own. If that other batch's peer never accepts, this one
+            // would burn the full wait timeout for a file it delivered in seconds.
+            // So the region from taking the "before" max through the "after"
+            // snapshot is serialized behind batchLock: two batches' offers can never
+            // interleave, only one runs that region at a time.
+            //
+            // Staging (a full byte copy through ContentResolver) allocates no
+            // transfer ids, so it happens before the lock is taken: only the id
+            // snapshots and the sendFile loop itself, which must stay atomic with
+            // respect to id allocation, run inside it. The lock is released before
+            // the wait loop below, so concurrent batches still wait for their own
+            // peers in parallel; only the offering is serialized, not the (much
+            // longer) waiting. A batch can still be blocked by another batch's
+            // sendFile dialing an offline peer, but that is bounded by the QUIC
+            // dial itself rather than by staging plus dial.
             var offered = 0
             var failed = 0
+            val staged = uris.mapNotNull { uri -> stageUriForSend(applicationContext, uri) }
+            failed += uris.size - staged.size
+
             val maxIdBeforeBatch: Long?
             val batchIds: Set<ULong>?
             synchronized(batchLock) {
@@ -86,22 +98,17 @@ class SendService : Service() {
                     NodeHolder.get(applicationContext).listTransfers().maxOfOrNull { it.id.toLong() } ?: -1L
                 }.getOrNull()
 
-                for (uri in uris) {
-                    val staged = stageUriForSend(applicationContext, uri)
-                    if (staged == null) {
-                        failed++
-                        continue
-                    }
+                for (file in staged) {
                     try {
-                        NodeHolder.get(applicationContext).sendFile(staged.absolutePath, peerId)
+                        NodeHolder.get(applicationContext).sendFile(file.absolutePath, peerId)
                         offered++
                     } catch (t: Throwable) {
                         failed++
-                        Log.w(TAG, "send failed for ${staged.name}", t)
+                        Log.w(TAG, "send failed for ${file.name}", t)
                     } finally {
                         // Bytes are in the blob store now; the staging copy is no
                         // longer needed. Remove the file and its per-item dir.
-                        runCatching { staged.parentFile?.deleteRecursively() ?: staged.delete() }
+                        runCatching { file.parentFile?.deleteRecursively() ?: file.delete() }
                     }
                 }
 

--- a/android/app/src/main/java/xyz/rayfish/android/SendService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/SendService.kt
@@ -12,19 +12,23 @@ import android.os.Build
 import android.os.IBinder
 import io.sentry.android.core.SentryLogcatAdapter as Log
 import kotlin.concurrent.thread
+import uniffi.ray_mobile.TransferState
 
 /**
  * Foreground service that delivers shared files over the mesh in the background, so
  * the user is never blocked waiting on a send. Started by [ShareActivity] once a
  * recipient is picked; the activity finishes immediately.
  *
- * Sending is fire-and-forget by design: [uniffi.ray_mobile.Node.sendFile] offers the
- * file (metadata + blob hash) to the peer and returns once the offer is delivered —
- * it does not wait for the peer to download. The recipient decides asynchronously
- * (auto-accept for its own paired devices, otherwise a manual Save) and pulls the
- * bytes from our blob store when it accepts. So "Sent" here means "offered"; the
- * node stays online (via the VPN service, or the control plane brought up by
- * ensureStarted) to serve the bytes on demand.
+ * [uniffi.ray_mobile.Node.sendFile] offers the file (metadata + blob hash) to the
+ * peer and returns once the offer is delivered, not once the peer has it: the
+ * recipient decides asynchronously (auto-accept for its own paired devices,
+ * otherwise a manual Save) and pulls the bytes from our blob store when it
+ * accepts, which can be minutes later or never. This service stays foreground
+ * and reports real per-transfer progress via [TransferNotifier] until every
+ * offer reaches a terminal state or [WAIT_TIMEOUT_MS] passes; after that the
+ * background poller in [RayfishVpnService] finishes the job, provided the node
+ * stays online (the VPN service, or the control plane brought up by
+ * ensureStarted).
  *
  * Each shared URI is staged to the app cache (the grant rides in on the start
  * intent's ClipData + FLAG_GRANT_READ_URI_PERMISSION), sent, then deleted.
@@ -52,7 +56,7 @@ class SendService : Service() {
         // synchronous FFI call. One thread per start command; stop this startId
         // when its batch finishes so concurrent shares each clean up independently.
         thread(name = "rayfish-send-$startId") {
-            var sent = 0
+            var offered = 0
             var failed = 0
             for (uri in uris) {
                 val staged = stageUriForSend(applicationContext, uri)
@@ -62,7 +66,7 @@ class SendService : Service() {
                 }
                 try {
                     NodeHolder.get(applicationContext).sendFile(staged.absolutePath, peerId)
-                    sent++
+                    offered++
                 } catch (t: Throwable) {
                     failed++
                     Log.w(TAG, "send failed for ${staged.name}", t)
@@ -72,7 +76,33 @@ class SendService : Service() {
                     runCatching { staged.parentFile?.deleteRecursively() ?: staged.delete() }
                 }
             }
-            notifyResult(peerName, sent, failed)
+
+            // The offers are delivered, but the bytes have not moved: the peer pulls
+            // them when it accepts. Stay foreground and let TransferNotifier report
+            // real progress until every transfer reaches a terminal state, so the
+            // user sees a progress bar and then a genuine "sent".
+            //
+            // A manual accept on the other end can take arbitrarily long, and an
+            // indefinite foreground service is not acceptable, so give up the
+            // service after WAIT_TIMEOUT_MS. The transfer is not cancelled by that:
+            // it keeps running in the core, and the background poller in
+            // RayfishVpnService posts the result whenever it lands, provided the node
+            // is still alive (VPN on, or the stay-online pref).
+            if (offered > 0) {
+                val deadline = System.currentTimeMillis() + WAIT_TIMEOUT_MS
+                while (System.currentTimeMillis() < deadline) {
+                    TransferNotifier.poll(applicationContext)
+                    val pending = runCatching {
+                        NodeHolder.get(applicationContext).listTransfers()
+                            .count { it.outgoing && (it.state == TransferState.OFFERED || it.state == TransferState.TRANSFERRING) }
+                    }.getOrDefault(0)
+                    if (pending == 0) break
+                    Thread.sleep(POLL_INTERVAL_MS)
+                }
+                TransferNotifier.poll(applicationContext)
+            }
+
+            if (failed > 0) notifyFailure(peerName, failed)
             stopForegroundCompat()
             stopSelf(startId)
         }
@@ -112,27 +142,24 @@ class SendService : Service() {
         }
     }
 
-    private fun notifyResult(peerName: String, sent: Int, failed: Int) {
+    /** Staging or offer failures only. Successful sends are reported per transfer by
+     * [TransferNotifier] once the peer has actually pulled the bytes. */
+    private fun notifyFailure(peerName: String, failed: Int) {
         ensureChannel()
-        val text = when {
-            failed == 0 && sent == 1 -> "Sent 1 item to $peerName"
-            failed == 0 -> "Sent $sent items to $peerName"
-            sent == 0 -> "Failed to send to $peerName"
-            else -> "Sent $sent to $peerName, $failed failed"
-        }
+        val text = if (failed == 1) "Could not send 1 item to $peerName"
+        else "Could not send $failed items to $peerName"
         val open = PendingIntent.getActivity(
             this, 0, Intent(this, MainActivity::class.java), PendingIntent.FLAG_IMMUTABLE,
         )
         val notification = Notification.Builder(this, CHANNEL_ID)
             .setContentTitle("Rayfish")
             .setContentText(text)
-            .setSmallIcon(android.R.drawable.stat_sys_upload_done)
+            .setSmallIcon(android.R.drawable.stat_notify_error)
             .setAutoCancel(true)
             .setContentIntent(open)
             .build()
-        // A fresh id per result so a completion isn't overwritten by the next send.
         getSystemService(NotificationManager::class.java)
-            .notify(NOTIF_RESULT_BASE + (sent + failed), notification)
+            .notify(NOTIF_RESULT_BASE + failed, notification)
     }
 
     private fun ensureChannel() {
@@ -157,6 +184,11 @@ class SendService : Service() {
         private const val CHANNEL_ID = "rayfish_transfers"
         private const val NOTIF_ONGOING = 2
         private const val NOTIF_RESULT_BASE = 100
+        // How long the foreground service waits for recipients to pull the bytes
+        // before handing off to the background poller. A manual accept can take far
+        // longer than this; the transfer survives, only the foreground service ends.
+        private const val WAIT_TIMEOUT_MS = 3 * 60 * 1000L
+        private const val POLL_INTERVAL_MS = 1000L
         const val EXTRA_PEER_ID = "xyz.rayfish.android.PEER_ID"
         const val EXTRA_PEER_NAME = "xyz.rayfish.android.PEER_NAME"
         const val EXTRA_URIS = "xyz.rayfish.android.URIS"

--- a/android/app/src/main/java/xyz/rayfish/android/SendService.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/SendService.kt
@@ -1,7 +1,6 @@
 package xyz.rayfish.android
 
 import android.app.Notification
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
@@ -56,6 +55,17 @@ class SendService : Service() {
         // synchronous FFI call. One thread per start command; stop this startId
         // when its batch finishes so concurrent shares each clean up independently.
         thread(name = "rayfish-send-$startId") {
+            // sendFile does not return a transfer id, so we cannot name this batch's
+            // transfers directly. Instead snapshot every id already in the registry
+            // before offering anything: an OFFERED entry whose peer never accepts
+            // lives for the whole process, so counting "all outgoing pending"
+            // below would let one stale offer from an earlier batch pin every
+            // later send to the full wait timeout. Anything not in this snapshot
+            // was created by this batch.
+            val idsBeforeBatch = runCatching {
+                NodeHolder.get(applicationContext).listTransfers().mapTo(HashSet()) { it.id }
+            }.getOrDefault(emptySet())
+
             var offered = 0
             var failed = 0
             for (uri in uris) {
@@ -94,7 +104,10 @@ class SendService : Service() {
                     TransferNotifier.poll(applicationContext)
                     val pending = runCatching {
                         NodeHolder.get(applicationContext).listTransfers()
-                            .count { it.outgoing && (it.state == TransferState.OFFERED || it.state == TransferState.TRANSFERRING) }
+                            .count {
+                                it.outgoing && it.id !in idsBeforeBatch &&
+                                    (it.state == TransferState.OFFERED || it.state == TransferState.TRANSFERRING)
+                            }
                     }.getOrDefault(0)
                     if (pending == 0) break
                     Thread.sleep(POLL_INTERVAL_MS)
@@ -127,9 +140,9 @@ class SendService : Service() {
     }
 
     private fun startForegroundNotification(count: Int, peerName: String) {
-        ensureChannel()
+        TransferNotifier.ensureChannel(this)
         val label = if (count == 1) "1 item" else "$count items"
-        val notification: Notification = Notification.Builder(this, CHANNEL_ID)
+        val notification: Notification = Notification.Builder(this, TransferNotifier.CHANNEL_ID)
             .setContentTitle("Sending to $peerName")
             .setContentText("$label over Rayfish")
             .setSmallIcon(android.R.drawable.stat_sys_upload)
@@ -145,29 +158,23 @@ class SendService : Service() {
     /** Staging or offer failures only. Successful sends are reported per transfer by
      * [TransferNotifier] once the peer has actually pulled the bytes. */
     private fun notifyFailure(peerName: String, failed: Int) {
-        ensureChannel()
+        TransferNotifier.ensureChannel(this)
         val text = if (failed == 1) "Could not send 1 item to $peerName"
         else "Could not send $failed items to $peerName"
         val open = PendingIntent.getActivity(
             this, 0, Intent(this, MainActivity::class.java), PendingIntent.FLAG_IMMUTABLE,
         )
-        val notification = Notification.Builder(this, CHANNEL_ID)
+        val notification = Notification.Builder(this, TransferNotifier.CHANNEL_ID)
             .setContentTitle("Rayfish")
             .setContentText(text)
             .setSmallIcon(android.R.drawable.stat_notify_error)
             .setAutoCancel(true)
             .setContentIntent(open)
             .build()
+        // A distinct id per call: two batches with the same failure count (e.g. one
+        // item each, to different peers) must not overwrite each other's notification.
         getSystemService(NotificationManager::class.java)
-            .notify(NOTIF_RESULT_BASE + failed, notification)
-    }
-
-    private fun ensureChannel() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-        val channel = NotificationChannel(
-            CHANNEL_ID, "Rayfish file transfers", NotificationManager.IMPORTANCE_LOW,
-        ).apply { description = "Progress of files you share over Rayfish" }
-        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+            .notify(NOTIF_RESULT_BASE + failureNotifSeq.incrementAndGet(), notification)
     }
 
     private fun stopForegroundCompat() {
@@ -181,7 +188,6 @@ class SendService : Service() {
 
     companion object {
         private const val TAG = "RayfishSend"
-        private const val CHANNEL_ID = "rayfish_transfers"
         private const val NOTIF_ONGOING = 2
         private const val NOTIF_RESULT_BASE = 100
         // How long the foreground service waits for recipients to pull the bytes
@@ -189,6 +195,9 @@ class SendService : Service() {
         // longer than this; the transfer survives, only the foreground service ends.
         private const val WAIT_TIMEOUT_MS = 3 * 60 * 1000L
         private const val POLL_INTERVAL_MS = 1000L
+        // Distinguishes failure notifications from concurrent batches that would
+        // otherwise share the same NOTIF_RESULT_BASE + failed-count id.
+        private val failureNotifSeq = java.util.concurrent.atomic.AtomicInteger(0)
         const val EXTRA_PEER_ID = "xyz.rayfish.android.PEER_ID"
         const val EXTRA_PEER_NAME = "xyz.rayfish.android.PEER_NAME"
         const val EXTRA_URIS = "xyz.rayfish.android.URIS"

--- a/android/app/src/main/java/xyz/rayfish/android/TransferNotifier.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/TransferNotifier.kt
@@ -24,29 +24,93 @@ import uniffi.ray_mobile.TransferState
  * duplicates, and a terminal state is posted exactly once.
  */
 object TransferNotifier {
-    private const val CHANNEL_ID = "rayfish_transfers"
+    internal const val CHANNEL_ID = "rayfish_transfers"
     // Offset well clear of the VPN (1) and SendService notification ids.
     private const val NOTIF_BASE = 5000
     private val terminal = java.util.Collections.synchronizedSet(HashSet<ULong>())
+    // Transfer ids we have posted an ongoing progress notification for in this
+    // process. Used to cancel the notification once the transfer leaves the
+    // registry (Critical 1a) without ever having reached a terminal state we
+    // observed ourselves.
+    private val postedProgress = java.util.Collections.synchronizedSet(HashSet<ULong>())
+    private var channelEnsured = false
+    private var cancelledStaleOnStart = false
 
-    /** Read the registry and reconcile notifications. Safe on any thread. */
+    /**
+     * Read the registry and reconcile notifications. Safe on any thread.
+     *
+     * The whole body runs under a single lock: [SendService] and the VPN
+     * poller both call this concurrently, and without serializing the read
+     * (listTransfers) plus the write (notify) as one step, one driver can
+     * post a "Sent" result and the other, working off a snapshot taken a
+     * moment earlier, can then post a progress bar over it that nothing
+     * ever clears (Critical 2).
+     */
     fun poll(context: Context) {
-        val transfers = runCatching { NodeHolder.get(context).listTransfers() }.getOrNull() ?: return
-        for (t in transfers) {
-            when (t.state) {
-                TransferState.OFFERED, TransferState.TRANSFERRING -> postProgress(context, t)
-                TransferState.DONE, TransferState.FAILED -> {
-                    // Terminal entries stay listable for 60s, so guard against
-                    // re-posting the same result on every poll.
-                    if (terminal.add(t.id)) postResult(context, t)
+        synchronized(this) {
+            // The core's transfer registry starts empty on every process start, so
+            // any ongoing notification still showing at this point is necessarily
+            // left over from a previous process and can never be resolved by this
+            // one (Critical 1b). Clear it once, before posting anything ourselves.
+            if (!cancelledStaleOnStart) {
+                cancelledStaleOnStart = true
+                cancelStaleOngoingNotifications(context)
+            }
+
+            val transfers = runCatching { NodeHolder.get(context).listTransfers() }.getOrNull() ?: return
+            val liveIds = transfers.mapTo(HashSet()) { it.id }
+            for (t in transfers) {
+                when (t.state) {
+                    TransferState.OFFERED, TransferState.TRANSFERRING -> postProgress(context, t)
+                    TransferState.DONE, TransferState.FAILED -> {
+                        // Terminal entries stay listable for 60s, so guard against
+                        // re-posting the same result on every poll.
+                        if (terminal.add(t.id)) postResult(context, t)
+                    }
+                }
+            }
+            pruneVanished(context, liveIds)
+        }
+    }
+
+    /** Cancel every ongoing notification on our channel, regardless of what it is
+     * for. Only called once, before this process has posted anything of its own. */
+    private fun cancelStaleOngoingNotifications(context: Context) {
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) return
+        val nm = context.getSystemService(NotificationManager::class.java)
+        runCatching {
+            for (sbn in nm.activeNotifications) {
+                val n = sbn.notification
+                if (n.channelId == CHANNEL_ID && (n.flags and Notification.FLAG_ONGOING_EVENT) != 0) {
+                    nm.cancel(sbn.id)
                 }
             }
         }
     }
 
-    private fun notifId(id: ULong): Int = NOTIF_BASE + (id.toInt() and 0xffff)
+    /** Anything we posted a progress bar for that has since left the registry
+     * (transfer completed and its 60s window elapsed, or it was never observed
+     * reaching a terminal state) is stale: cancel it so it cannot outlive the
+     * transfer it describes. Also prunes [terminal] so it does not grow forever
+     * (minor 6). */
+    private fun pruneVanished(context: Context, liveIds: Set<ULong>) {
+        val nm = context.getSystemService(NotificationManager::class.java)
+        val vanished = postedProgress.filter { it !in liveIds }
+        for (id in vanished) {
+            nm.cancel(notifId(id))
+            postedProgress.remove(id)
+        }
+        terminal.removeAll { it !in liveIds }
+    }
+
+    private fun notifId(id: ULong): Int = NOTIF_BASE + (id.toInt() and 0x7fffffff)
 
     private fun postProgress(context: Context, t: uniffi.ray_mobile.Transfer) {
+        // A terminal result for this id has already been posted (or is about to
+        // be, by whichever driver won the race): never draw a progress bar back
+        // over it (Critical 2).
+        if (t.id in terminal) return
+        postedProgress.add(t.id)
         ensureChannel(context)
         val waiting = t.state == TransferState.OFFERED
         val title = if (t.outgoing) "Sending ${t.filename}" else "Receiving ${t.filename}"
@@ -114,7 +178,14 @@ object TransferNotifier {
         Log.i("RayfishTransfers", "transfer ${t.id} ${t.state} (${t.filename})")
     }
 
-    private fun ensureChannel(context: Context) {
+    /** Called on every post, but only does binder work once per process: creating an
+     * already-existing channel also silently overwrites its name/description, so a
+     * second definition anywhere would make the label in system Settings flip-flop
+     * depending on which ran last (minor 7). This is the one definition; [SendService]
+     * reuses it instead of declaring its own. */
+    internal fun ensureChannel(context: Context) {
+        if (channelEnsured) return
+        channelEnsured = true
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) return
         val channel = NotificationChannel(
             CHANNEL_ID,

--- a/android/app/src/main/java/xyz/rayfish/android/TransferNotifier.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/TransferNotifier.kt
@@ -28,11 +28,16 @@ object TransferNotifier {
     // Offset well clear of the VPN (1) and SendService notification ids.
     private const val NOTIF_BASE = 5000
     private val terminal = java.util.Collections.synchronizedSet(HashSet<ULong>())
-    // Transfer ids we have posted an ongoing progress notification for in this
-    // process. Used to cancel the notification once the transfer leaves the
-    // registry (Critical 1a) without ever having reached a terminal state we
-    // observed ourselves.
-    private val postedProgress = java.util.Collections.synchronizedSet(HashSet<ULong>())
+
+    // What we last posted for a given transfer id, keyed so a poll that finds
+    // nothing new can skip notify() entirely instead of reposting an unchanged
+    // notification: a dismissed notification must stay dismissed until the
+    // transfer's state actually changes, not get resurrected by the next poll
+    // a few seconds later. Also doubles as "we have a live progress notification
+    // out for this id" for pruneVanished below.
+    private data class Posted(val transferring: Boolean, val pct: Int)
+    private val postedProgress = java.util.Collections.synchronizedMap(HashMap<ULong, Posted>())
+
     @Volatile private var channelEnsured = false
     private var cancelledStaleOnStart = false
 
@@ -44,14 +49,14 @@ object TransferNotifier {
      * (listTransfers) plus the write (notify) as one step, one driver can
      * post a "Sent" result and the other, working off a snapshot taken a
      * moment earlier, can then post a progress bar over it that nothing
-     * ever clears (Critical 2).
+     * ever clears.
      */
     fun poll(context: Context) {
         synchronized(this) {
             // The core's transfer registry starts empty on every process start, so
             // any ongoing notification still showing at this point is necessarily
             // left over from a previous process and can never be resolved by this
-            // one (Critical 1b). Clear it once, before posting anything ourselves.
+            // one. Clear it once, before posting anything ourselves.
             if (!cancelledStaleOnStart) {
                 cancelledStaleOnStart = true
                 cancelStaleOngoingNotifications(context)
@@ -67,7 +72,7 @@ object TransferNotifier {
                         // terminal marker so postProgress does not keep suppressing
                         // it and a fresh result can post once it finishes again,
                         // instead of leaving a stale "Could not send" in the shade
-                        // for a file that actually arrived (minor 4).
+                        // for a file that actually arrived.
                         terminal.remove(t.id)
                         postProgress(context, t)
                     }
@@ -108,20 +113,20 @@ object TransferNotifier {
         }
     }
 
-    /** Anything we posted a progress bar for that has since left the registry
-     * without ever reaching a terminal state we observed (the process died and
-     * restarted mid-transfer, or the entry simply vanished) is stale: cancel it
-     * so it cannot outlive the transfer it describes.
+    /** Anything we posted a progress notification for that has since left the
+     * registry without ever reaching a terminal state we observed (the process
+     * died and restarted mid-transfer, or the entry simply vanished) is stale:
+     * cancel it so it cannot outlive the transfer it describes.
      *
      * A result notification's id is removed from [postedProgress] by [postResult]
      * itself, precisely so this loop can never reach it: once a result is posted,
      * that notification is done and permanent (until the user dismisses it or
      * taps it), it must not be cancelled just because the terminal entry aged out
      * of the registry 60s later. Also prunes [terminal] so it does not grow
-     * forever (minor 6). */
+     * forever. */
     private fun pruneVanished(context: Context, liveIds: Set<ULong>) {
         val nm = context.getSystemService(NotificationManager::class.java)
-        val vanished = postedProgress.filter { it !in liveIds }
+        val vanished = postedProgress.keys.filter { it !in liveIds }
         for (id in vanished) {
             nm.cancel(notifId(id))
             postedProgress.remove(id)
@@ -139,9 +144,9 @@ object TransferNotifier {
      * terminal.add returns false), while a stale result notification from the
      * previous run keeps sitting in the shade looking like the answer.
      *
-     * Only cancels notifications we posted a live progress bar for: a result
-     * notification's id is already out of [postedProgress] by the time it is
-     * posted (postResult removes it), so this can never cancel a result the
+     * Only cancels notifications we posted a live progress notification for: a
+     * result notification's id is already out of [postedProgress] by the time it
+     * is posted (postResult removes it), so this can never cancel a result the
      * user has not yet seen or acted on. Re-arms the one-shot stale sweep so a
      * leftover ongoing notification from before the stop still gets cleaned up
      * on the next poll. Safe to call when nothing is running.
@@ -149,7 +154,7 @@ object TransferNotifier {
     fun reset(context: Context) {
         synchronized(this) {
             val nm = context.getSystemService(NotificationManager::class.java)
-            for (id in postedProgress) {
+            for (id in postedProgress.keys) {
                 runCatching { nm.cancel(notifId(id)) }
             }
             postedProgress.clear()
@@ -161,14 +166,33 @@ object TransferNotifier {
     private fun postProgress(context: Context, t: uniffi.ray_mobile.Transfer) {
         // A terminal result for this id has already been posted (or is about to
         // be, by whichever driver won the race): never draw a progress bar back
-        // over it (Critical 2).
+        // over it.
         if (t.id in terminal) return
-        postedProgress.add(t.id)
-        ensureChannel(context)
+
         val waiting = t.state == TransferState.OFFERED
+        // size can be 0 for an empty file; treat that like "waiting" (indeterminate)
+        // rather than dividing by zero.
+        val pct = if (waiting || t.size == 0uL) {
+            -1
+        } else {
+            ((t.transferred.toDouble() / t.size.toDouble()) * 100).toInt().coerceIn(0, 100)
+        }
+        val newState = Posted(transferring = !waiting, pct = pct)
+        // Nothing changed since the last notify() for this id: skip it. Without
+        // this, a poller running every few seconds would repost the same
+        // notification every time, which on modern Android silently undoes a
+        // swipe-to-dismiss a few seconds after the user does it.
+        if (postedProgress[t.id] == newState) return
+        postedProgress[t.id] = newState
+
+        ensureChannel(context)
         val title = if (t.outgoing) "Sending ${t.filename}" else "Receiving ${t.filename}"
         val text = when {
-            waiting -> "Waiting for ${t.peer} to accept"
+            // Waiting on a human on the other end can take arbitrarily long, or
+            // never resolve at all, and we have no way to tell the user which.
+            // Say so plainly rather than let the notification imply a result is
+            // always coming.
+            waiting -> "Waiting for ${t.peer} to accept · only notified if Rayfish stays running"
             t.outgoing -> "To ${t.peer}"
             else -> "From ${t.peer}"
         }
@@ -179,14 +203,16 @@ object TransferNotifier {
                 if (t.outgoing) android.R.drawable.stat_sys_upload
                 else android.R.drawable.stat_sys_download,
             )
-            .setOngoing(true)
+            // Only a transfer that is actually moving bytes locks the notification
+            // in place. An OFFERED transfer is waiting on a human on the other end
+            // who may never act, so it must stay swipe-dismissible: an ongoing
+            // notification here would otherwise sit forever (older Android cannot
+            // swipe it away at all) for every send nobody ever accepts.
+            .setOngoing(newState.transferring)
             .setOnlyAlertOnce(true)
-        // Indeterminate while we are only waiting on the peer; a real bar once bytes
-        // move. size can be 0 for an empty file, so guard the division.
         if (waiting || t.size == 0uL) {
             builder.setProgress(0, 0, true)
         } else {
-            val pct = ((t.transferred.toDouble() / t.size.toDouble()) * 100).toInt().coerceIn(0, 100)
             builder.setProgress(100, pct, false)
         }
         context.getSystemService(NotificationManager::class.java)
@@ -196,12 +222,19 @@ object TransferNotifier {
     private fun postResult(context: Context, t: uniffi.ray_mobile.Transfer) {
         // This id no longer names an ongoing notification: it is about to become a
         // result notification instead. Drop it from postedProgress so pruneVanished
-        // can never mistake the result for a vanished progress bar and cancel it out
-        // from under the user 60s later when the terminal entry ages out of the
-        // registry (Critical 1).
+        // can never mistake the result for a vanished progress notification and
+        // cancel it out from under the user 60s later when the terminal entry ages
+        // out of the registry.
         postedProgress.remove(t.id)
         ensureChannel(context)
         val ok = t.state == TransferState.DONE
+        // moveToDownloads is best-effort (unavailable below API 29, or the
+        // MediaStore insert can fail), and its result is only known at accept
+        // time in FileAutoAccept / HomeScreen, not here. Consume what they
+        // recorded rather than assume Downloads: claiming a file landed there
+        // when it is actually sitting in app-private storage sends the user to
+        // an empty Downloads view with no way to find their file.
+        val savedToDownloads = ok && !t.outgoing && DownloadsOutcome.consume(t.filename)
         val title = when {
             ok && t.outgoing -> "Sent ${t.filename}"
             ok -> "Saved ${t.filename}"
@@ -210,11 +243,14 @@ object TransferNotifier {
         }
         val text = when {
             ok && t.outgoing -> "${t.peer} has it"
-            ok -> "Saved to Downloads"
+            savedToDownloads -> "Saved to Downloads"
+            ok -> "Saved"
             else -> "Transfer with ${t.peer} failed"
         }
-        // Tapping a received file opens Downloads; a sent one opens the app.
-        val intent = if (ok && !t.outgoing) {
+        // Tapping a file actually saved to Downloads opens Downloads; anything
+        // else (a send, or a receive that landed in app storage instead) opens
+        // the app, since Downloads has nothing relevant to show.
+        val intent = if (savedToDownloads) {
             Intent(android.app.DownloadManager.ACTION_VIEW_DOWNLOADS)
         } else {
             Intent(context, MainActivity::class.java)
@@ -240,7 +276,7 @@ object TransferNotifier {
     /** Called on every post, but only does binder work once per process: creating an
      * already-existing channel also silently overwrites its name/description, so a
      * second definition anywhere would make the label in system Settings flip-flop
-     * depending on which ran last (minor 7). This is the one definition; [SendService]
+     * depending on which ran last. This is the one definition; [SendService]
      * reuses it instead of declaring its own. */
     internal fun ensureChannel(context: Context) {
         if (channelEnsured) return

--- a/android/app/src/main/java/xyz/rayfish/android/TransferNotifier.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/TransferNotifier.kt
@@ -61,7 +61,16 @@ object TransferNotifier {
             val liveIds = transfers.mapTo(HashSet()) { it.id }
             for (t in transfers) {
                 when (t.state) {
-                    TransferState.OFFERED, TransferState.TRANSFERRING -> postProgress(context, t)
+                    TransferState.OFFERED, TransferState.TRANSFERRING -> {
+                        // The core can revive a Failed outgoing transfer back to
+                        // Transferring if the peer retries the pull. Drop the stale
+                        // terminal marker so postProgress does not keep suppressing
+                        // it and a fresh result can post once it finishes again,
+                        // instead of leaving a stale "Could not send" in the shade
+                        // for a file that actually arrived (minor 4).
+                        terminal.remove(t.id)
+                        postProgress(context, t)
+                    }
                     TransferState.DONE, TransferState.FAILED -> {
                         // Terminal entries stay listable for 60s, so guard against
                         // re-posting the same result on every poll.
@@ -121,6 +130,33 @@ object TransferNotifier {
     }
 
     private fun notifId(id: ULong): Int = NOTIF_BASE + (id.toInt() and 0x7fffffff)
+
+    /**
+     * Reset all bookkeeping to a fresh-boot state. Node.stop() drops the core's
+     * TransferRegistry, so the next start's ids restart at 1: without this, a
+     * later transfer that happens to land on an id still sitting in [terminal]
+     * from before the stop would be silently muted (postProgress suppresses it,
+     * terminal.add returns false), while a stale result notification from the
+     * previous run keeps sitting in the shade looking like the answer.
+     *
+     * Only cancels notifications we posted a live progress bar for: a result
+     * notification's id is already out of [postedProgress] by the time it is
+     * posted (postResult removes it), so this can never cancel a result the
+     * user has not yet seen or acted on. Re-arms the one-shot stale sweep so a
+     * leftover ongoing notification from before the stop still gets cleaned up
+     * on the next poll. Safe to call when nothing is running.
+     */
+    fun reset(context: Context) {
+        synchronized(this) {
+            val nm = context.getSystemService(NotificationManager::class.java)
+            for (id in postedProgress) {
+                runCatching { nm.cancel(notifId(id)) }
+            }
+            postedProgress.clear()
+            terminal.clear()
+            cancelledStaleOnStart = false
+        }
+    }
 
     private fun postProgress(context: Context, t: uniffi.ray_mobile.Transfer) {
         // A terminal result for this id has already been posted (or is about to

--- a/android/app/src/main/java/xyz/rayfish/android/TransferNotifier.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/TransferNotifier.kt
@@ -77,9 +77,21 @@ object TransferNotifier {
                         postProgress(context, t)
                     }
                     TransferState.DONE, TransferState.FAILED -> {
+                        // The core reports a receive as DONE from inside the
+                        // blocking acceptFileOffer call, before moveToDownloads (the
+                        // MediaStore byte copy) even runs, so this poll can land
+                        // mid-copy. Defer entirely while that save is still in
+                        // flight: do not post a result (it would be a guess that
+                        // can end up permanently wrong) and do not mark the
+                        // transfer terminal, so a later poll retries once the
+                        // outcome is actually known. DownloadsOutcome bounds how
+                        // long a save can stay "pending" so a copy that never
+                        // finishes cannot wedge this transfer's result forever.
+                        val awaitingSave = !t.outgoing &&
+                            DownloadsOutcome.isPending(TransferKey(t.peer, t.filename, t.size))
                         // Terminal entries stay listable for 60s, so guard against
                         // re-posting the same result on every poll.
-                        if (terminal.add(t.id)) postResult(context, t)
+                        if (!awaitingSave && terminal.add(t.id)) postResult(context, t)
                     }
                 }
             }
@@ -183,22 +195,29 @@ object TransferNotifier {
         // notification every time, which on modern Android silently undoes a
         // swipe-to-dismiss a few seconds after the user does it.
         if (postedProgress[t.id] == newState) return
-        postedProgress[t.id] = newState
 
         ensureChannel(context)
         val title = if (t.outgoing) "Sending ${t.filename}" else "Receiving ${t.filename}"
         val text = when {
             // Waiting on a human on the other end can take arbitrarily long, or
             // never resolve at all, and we have no way to tell the user which.
-            // Say so plainly rather than let the notification imply a result is
-            // always coming.
-            waiting -> "Waiting for ${t.peer} to accept · only notified if Rayfish stays running"
+            // Say so plainly, but only when it is actually true: with a poller
+            // alive in the background (RayfishVpnService, VPN on or standby), the
+            // completion will be observed and notified regardless of whether
+            // Rayfish's UI is open, so the caveat would be simply wrong there.
+            waiting && !RayfishVpnService.isRunning ->
+                "Waiting for ${t.peer} to accept · only notified if Rayfish stays running"
+            waiting -> "Waiting for ${t.peer} to accept"
             t.outgoing -> "To ${t.peer}"
             else -> "From ${t.peer}"
         }
         val builder = Notification.Builder(context, CHANNEL_ID)
             .setContentTitle(title)
             .setContentText(text)
+            // BigTextStyle so the shade's collapsed view does not truncate the
+            // caveat: a single-line setContentText was getting cut right around
+            // the middle dot, and the caveat is exactly the half that disappeared.
+            .setStyle(Notification.BigTextStyle().bigText(text))
             .setSmallIcon(
                 if (t.outgoing) android.R.drawable.stat_sys_upload
                 else android.R.drawable.stat_sys_download,
@@ -217,6 +236,11 @@ object TransferNotifier {
         }
         context.getSystemService(NotificationManager::class.java)
             .notify(notifId(t.id), builder.build())
+        // Written only after notify() has actually run: if notify() throws, this
+        // id must not be marked posted, or a poll a few seconds later would see an
+        // unchanged key and skip it forever, silently muting the transfer for a
+        // notification that was never shown.
+        postedProgress[t.id] = newState
     }
 
     private fun postResult(context: Context, t: uniffi.ray_mobile.Transfer) {
@@ -234,7 +258,8 @@ object TransferNotifier {
         // recorded rather than assume Downloads: claiming a file landed there
         // when it is actually sitting in app-private storage sends the user to
         // an empty Downloads view with no way to find their file.
-        val savedToDownloads = ok && !t.outgoing && DownloadsOutcome.consume(t.filename)
+        val savedToDownloads = ok && !t.outgoing &&
+            DownloadsOutcome.consume(TransferKey(t.peer, t.filename, t.size))
         val title = when {
             ok && t.outgoing -> "Sent ${t.filename}"
             ok -> "Saved ${t.filename}"

--- a/android/app/src/main/java/xyz/rayfish/android/TransferNotifier.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/TransferNotifier.kt
@@ -33,7 +33,7 @@ object TransferNotifier {
     // registry (Critical 1a) without ever having reached a terminal state we
     // observed ourselves.
     private val postedProgress = java.util.Collections.synchronizedSet(HashSet<ULong>())
-    private var channelEnsured = false
+    @Volatile private var channelEnsured = false
     private var cancelledStaleOnStart = false
 
     /**
@@ -73,14 +73,25 @@ object TransferNotifier {
         }
     }
 
-    /** Cancel every ongoing notification on our channel, regardless of what it is
-     * for. Only called once, before this process has posted anything of its own. */
+    /** Cancel any ongoing notification left over from a previous process, on our
+     * channel and in our own id range. Only called once, before this process has
+     * posted anything of its own.
+     *
+     * This must never be able to touch SendService's live foreground notification:
+     * on a cold share the foreground notification is posted (id 2, same channel,
+     * ongoing) before the send thread's first poll, so a sweep that only checked
+     * channel + FLAG_ONGOING_EVENT would match it too. Two guards keep it out:
+     * FLAG_FOREGROUND_SERVICE (a foreground notification always carries it) and
+     * the id range (our own notifications are all >= NOTIF_BASE; SendService's
+     * ids are below it). */
     private fun cancelStaleOngoingNotifications(context: Context) {
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) return
         val nm = context.getSystemService(NotificationManager::class.java)
         runCatching {
             for (sbn in nm.activeNotifications) {
                 val n = sbn.notification
+                if (sbn.id < NOTIF_BASE) continue
+                if ((n.flags and Notification.FLAG_FOREGROUND_SERVICE) != 0) continue
                 if (n.channelId == CHANNEL_ID && (n.flags and Notification.FLAG_ONGOING_EVENT) != 0) {
                     nm.cancel(sbn.id)
                 }
@@ -89,10 +100,16 @@ object TransferNotifier {
     }
 
     /** Anything we posted a progress bar for that has since left the registry
-     * (transfer completed and its 60s window elapsed, or it was never observed
-     * reaching a terminal state) is stale: cancel it so it cannot outlive the
-     * transfer it describes. Also prunes [terminal] so it does not grow forever
-     * (minor 6). */
+     * without ever reaching a terminal state we observed (the process died and
+     * restarted mid-transfer, or the entry simply vanished) is stale: cancel it
+     * so it cannot outlive the transfer it describes.
+     *
+     * A result notification's id is removed from [postedProgress] by [postResult]
+     * itself, precisely so this loop can never reach it: once a result is posted,
+     * that notification is done and permanent (until the user dismisses it or
+     * taps it), it must not be cancelled just because the terminal entry aged out
+     * of the registry 60s later. Also prunes [terminal] so it does not grow
+     * forever (minor 6). */
     private fun pruneVanished(context: Context, liveIds: Set<ULong>) {
         val nm = context.getSystemService(NotificationManager::class.java)
         val vanished = postedProgress.filter { it !in liveIds }
@@ -141,6 +158,12 @@ object TransferNotifier {
     }
 
     private fun postResult(context: Context, t: uniffi.ray_mobile.Transfer) {
+        // This id no longer names an ongoing notification: it is about to become a
+        // result notification instead. Drop it from postedProgress so pruneVanished
+        // can never mistake the result for a vanished progress bar and cancel it out
+        // from under the user 60s later when the terminal entry ages out of the
+        // registry (Critical 1).
+        postedProgress.remove(t.id)
         ensureChannel(context)
         val ok = t.state == TransferState.DONE
         val title = when {
@@ -185,13 +208,20 @@ object TransferNotifier {
      * reuses it instead of declaring its own. */
     internal fun ensureChannel(context: Context) {
         if (channelEnsured) return
-        channelEnsured = true
-        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) return
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
+            channelEnsured = true
+            return
+        }
         val channel = NotificationChannel(
             CHANNEL_ID,
             "File transfers",
             NotificationManager.IMPORTANCE_LOW,
         ).apply { description = "Progress and results for files sent and received over the mesh" }
         context.getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+        // Set only after the channel actually exists: another thread reading
+        // channelEnsured == true before createNotificationChannel returns could
+        // notify() on a channel the platform doesn't know about yet and have the
+        // notification silently dropped.
+        channelEnsured = true
     }
 }

--- a/android/app/src/main/java/xyz/rayfish/android/TransferNotifier.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/TransferNotifier.kt
@@ -1,0 +1,126 @@
+package xyz.rayfish.android
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import io.sentry.android.core.SentryLogcatAdapter as Log
+import uniffi.ray_mobile.TransferState
+
+/**
+ * Turns the core's transfer registry into notifications: a progress bar while bytes
+ * move, then a done or failed result.
+ *
+ * A send sits in [TransferState.OFFERED] until the recipient accepts, which can be
+ * a while (or never) for a manual accept. Only when they start pulling the blob out
+ * of our store do real byte counts arrive, so OFFERED shows as indeterminate
+ * "waiting for <peer>", and DONE means they actually have the file.
+ *
+ * Whichever service is alive drives this: [SendService] during an active send, the
+ * [RayfishVpnService] poller in the background. Both call [poll]; notification ids
+ * are derived from the transfer id, so a double-drive updates rather than
+ * duplicates, and a terminal state is posted exactly once.
+ */
+object TransferNotifier {
+    private const val CHANNEL_ID = "rayfish_transfers"
+    // Offset well clear of the VPN (1) and SendService notification ids.
+    private const val NOTIF_BASE = 5000
+    private val terminal = java.util.Collections.synchronizedSet(HashSet<ULong>())
+
+    /** Read the registry and reconcile notifications. Safe on any thread. */
+    fun poll(context: Context) {
+        val transfers = runCatching { NodeHolder.get(context).listTransfers() }.getOrNull() ?: return
+        for (t in transfers) {
+            when (t.state) {
+                TransferState.OFFERED, TransferState.TRANSFERRING -> postProgress(context, t)
+                TransferState.DONE, TransferState.FAILED -> {
+                    // Terminal entries stay listable for 60s, so guard against
+                    // re-posting the same result on every poll.
+                    if (terminal.add(t.id)) postResult(context, t)
+                }
+            }
+        }
+    }
+
+    private fun notifId(id: ULong): Int = NOTIF_BASE + (id.toInt() and 0xffff)
+
+    private fun postProgress(context: Context, t: uniffi.ray_mobile.Transfer) {
+        ensureChannel(context)
+        val waiting = t.state == TransferState.OFFERED
+        val title = if (t.outgoing) "Sending ${t.filename}" else "Receiving ${t.filename}"
+        val text = when {
+            waiting -> "Waiting for ${t.peer} to accept"
+            t.outgoing -> "To ${t.peer}"
+            else -> "From ${t.peer}"
+        }
+        val builder = Notification.Builder(context, CHANNEL_ID)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setSmallIcon(
+                if (t.outgoing) android.R.drawable.stat_sys_upload
+                else android.R.drawable.stat_sys_download,
+            )
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+        // Indeterminate while we are only waiting on the peer; a real bar once bytes
+        // move. size can be 0 for an empty file, so guard the division.
+        if (waiting || t.size == 0uL) {
+            builder.setProgress(0, 0, true)
+        } else {
+            val pct = ((t.transferred.toDouble() / t.size.toDouble()) * 100).toInt().coerceIn(0, 100)
+            builder.setProgress(100, pct, false)
+        }
+        context.getSystemService(NotificationManager::class.java)
+            .notify(notifId(t.id), builder.build())
+    }
+
+    private fun postResult(context: Context, t: uniffi.ray_mobile.Transfer) {
+        ensureChannel(context)
+        val ok = t.state == TransferState.DONE
+        val title = when {
+            ok && t.outgoing -> "Sent ${t.filename}"
+            ok -> "Saved ${t.filename}"
+            t.outgoing -> "Could not send ${t.filename}"
+            else -> "Could not receive ${t.filename}"
+        }
+        val text = when {
+            ok && t.outgoing -> "${t.peer} has it"
+            ok -> "Saved to Downloads"
+            else -> "Transfer with ${t.peer} failed"
+        }
+        // Tapping a received file opens Downloads; a sent one opens the app.
+        val intent = if (ok && !t.outgoing) {
+            Intent(android.app.DownloadManager.ACTION_VIEW_DOWNLOADS)
+        } else {
+            Intent(context, MainActivity::class.java)
+        }
+        val tap = PendingIntent.getActivity(
+            context, notifId(t.id), intent, PendingIntent.FLAG_IMMUTABLE,
+        )
+        val notification = Notification.Builder(context, CHANNEL_ID)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setSmallIcon(
+                if (ok) android.R.drawable.stat_sys_download_done
+                else android.R.drawable.stat_notify_error,
+            )
+            .setAutoCancel(true)
+            .setContentIntent(tap)
+            .build()
+        context.getSystemService(NotificationManager::class.java)
+            .notify(notifId(t.id), notification)
+        Log.i("RayfishTransfers", "transfer ${t.id} ${t.state} (${t.filename})")
+    }
+
+    private fun ensureChannel(context: Context) {
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "File transfers",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply { description = "Progress and results for files sent and received over the mesh" }
+        context.getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+}

--- a/android/app/src/main/java/xyz/rayfish/android/ui/RayfishApp.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/RayfishApp.kt
@@ -69,7 +69,7 @@ fun RayfishApp(initialLinkUri: String?, alreadyHandled: (String) -> Boolean, mar
                     // screen's stay-online guard sees the real state instead of this
                     // leftover intent.
                     NodeHolder.setEnabled(context, false)
-                    if (NodeHolder.isStayOnline(context)) {
+                    if (!NodeHolder.isGoOfflineWhenDisabled(context)) {
                         ContextCompat.startForegroundService(
                             context,
                             Intent(context, RayfishVpnService::class.java).apply {
@@ -78,10 +78,11 @@ fun RayfishApp(initialLinkUri: String?, alreadyHandled: (String) -> Boolean, mar
                         )
                     }
                 }
-            } else if (NodeHolder.isStayOnline(context)) {
-                // The VPN is not being restored, but the user wants files to keep
-                // working in the background. Nothing else brings the control plane up
-                // after a process death: bring it up now via standby.
+            } else if (!NodeHolder.isGoOfflineWhenDisabled(context)) {
+                // The VPN is not being restored, and the user has not asked to go
+                // fully offline when disabled, so standby is the default: files
+                // should keep working. Nothing else brings the control plane up
+                // after a process death; bring it up now via standby.
                 ContextCompat.startForegroundService(
                     context,
                     Intent(context, RayfishVpnService::class.java).apply {

--- a/android/app/src/main/java/xyz/rayfish/android/ui/RayfishApp.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/RayfishApp.kt
@@ -66,8 +66,8 @@ fun RayfishApp(initialLinkUri: String?, alreadyHandled: (String) -> Boolean, mar
                     // had the tunnel, but we can no longer get it back. Clear it now,
                     // the same reasoning onRevoke already uses, so the toggle stops
                     // reading "on" for a tunnel that will never come up, and the You
-                    // screen's stay-online guard sees the real state instead of this
-                    // leftover intent.
+                    // screen's go-fully-offline control sees the real state instead of
+                    // this leftover intent.
                     NodeHolder.setEnabled(context, false)
                     if (!NodeHolder.isGoOfflineWhenDisabled(context)) {
                         ContextCompat.startForegroundService(

--- a/android/app/src/main/java/xyz/rayfish/android/ui/RayfishApp.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/RayfishApp.kt
@@ -55,9 +55,38 @@ fun RayfishApp(initialLinkUri: String?, alreadyHandled: (String) -> Boolean, mar
     // stay offline. Then poll every 2s while foregrounded; suspend in background.
     LaunchedEffect(Unit) {
         try {
-            if (NodeHolder.isEnabled(context) && VpnService.prepare(context) == null) {
+            if (NodeHolder.isEnabled(context)) {
+                if (VpnService.prepare(context) == null) {
+                    ContextCompat.startForegroundService(
+                        context, Intent(context, RayfishVpnService::class.java),
+                    )
+                } else {
+                    // Another app (Tailscale, say) holds the single VpnService slot, so
+                    // our saved enable intent is stale: it was set true when we still
+                    // had the tunnel, but we can no longer get it back. Clear it now,
+                    // the same reasoning onRevoke already uses, so the toggle stops
+                    // reading "on" for a tunnel that will never come up, and the You
+                    // screen's stay-online guard sees the real state instead of this
+                    // leftover intent.
+                    NodeHolder.setEnabled(context, false)
+                    if (NodeHolder.isStayOnline(context)) {
+                        ContextCompat.startForegroundService(
+                            context,
+                            Intent(context, RayfishVpnService::class.java).apply {
+                                action = RayfishVpnService.ACTION_STANDBY
+                            },
+                        )
+                    }
+                }
+            } else if (NodeHolder.isStayOnline(context)) {
+                // The VPN is not being restored, but the user wants files to keep
+                // working in the background. Nothing else brings the control plane up
+                // after a process death: bring it up now via standby.
                 ContextCompat.startForegroundService(
-                    context, Intent(context, RayfishVpnService::class.java),
+                    context,
+                    Intent(context, RayfishVpnService::class.java).apply {
+                        action = RayfishVpnService.ACTION_STANDBY
+                    },
                 )
             }
             readStatus()

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
@@ -157,6 +157,13 @@ fun HomeScreen(status: Status?, starting: Boolean, onToast: (String) -> Unit) {
             try {
                 withContext(Dispatchers.IO) {
                     NodeHolder.get(context).acceptFileOffer(f.id, saveDir)
+                    // Re-stamp pending now that the download is done and the copy
+                    // is about to start: the first markPending call above only
+                    // needed to cover the wait for DONE to appear, and acceptFileOffer
+                    // can block far longer than PENDING_TIMEOUT_MS on a large file,
+                    // which would otherwise expire the entry before the copy even
+                    // begins.
+                    DownloadsOutcome.markPending(key)
                     val reached = moveToDownloads(context, File(saveDir, f.filename), f.filename, f.mimeType)
                     DownloadsOutcome.record(key, reached)
                 }

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
@@ -26,6 +26,7 @@ import uniffi.ray_mobile.Status
 import xyz.rayfish.android.FileAutoAccept
 import xyz.rayfish.android.NodeHolder
 import xyz.rayfish.android.RayfishVpnService
+import xyz.rayfish.android.TransferNotifier
 import xyz.rayfish.android.moveToDownloads
 import xyz.rayfish.android.ui.components.*
 import xyz.rayfish.android.ui.theme.*
@@ -98,6 +99,11 @@ fun HomeScreen(status: Status?, starting: Boolean, onToast: (String) -> Unit) {
             // Auto-accept own-device offers first so they don't linger as manual
             // "Save" prompts; the list below then shows only offers from others.
             runCatching { FileAutoAccept.run(context) }
+            // With the VPN off and stay-online off, RayfishVpnService is not running,
+            // so this 2s loop is the only poller while the app is open: without this,
+            // an own-device auto-accept (and any other in-flight transfer) would show
+            // no progress and no result notification at all.
+            runCatching { TransferNotifier.poll(context) }
             files = runCatching { node.listFileOffers() }.getOrDefault(emptyList())
             connects = runCatching { node.listConnectRequests() }.getOrDefault(emptyList())
             joins = currentNets.filter { it.isCoordinator }.flatMap { n ->

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
@@ -105,10 +105,12 @@ fun HomeScreen(status: Status?, starting: Boolean, onToast: (String) -> Unit) {
             // gone, or the user sees a manual "Save" row for a file that is already
             // downloading and can fire a second, concurrent accept for the same id.
             runCatching { FileAutoAccept.run(context) }
-            // With the VPN off and stay-online off, RayfishVpnService is not running,
-            // so this 2s loop is the only poller while the app is open: without this,
-            // an own-device auto-accept (and any other in-flight transfer) would show
-            // no progress and no result notification at all.
+            // With the VPN off and go-fully-offline enabled, RayfishVpnService is not
+            // running, so this 2s loop becomes the only poller while the app is open:
+            // without this, an own-device auto-accept (and any other in-flight
+            // transfer) would show no progress and no result notification at all.
+            // This is uncommon (standby is the default); the common case keeps the
+            // control plane running in the background.
             runCatching { TransferNotifier.poll(context) }
             val autoAccepting = NodeHolder.isAutoAcceptOwnDevices(context)
             files = runCatching { node.listFileOffers() }.getOrDefault(emptyList())

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
@@ -96,15 +96,21 @@ fun HomeScreen(status: Status?, starting: Boolean, onToast: (String) -> Unit) {
     suspend fun reloadNotifs() {
         withContext(Dispatchers.IO) {
             val node = NodeHolder.get(context)
-            // Auto-accept own-device offers first so they don't linger as manual
-            // "Save" prompts; the list below then shows only offers from others.
+            // FileAutoAccept.run only starts own-device downloads on its bounded
+            // executor and returns immediately; it does not wait for them to finish.
+            // So an own-device offer is still present in listFileOffers() for the
+            // whole download, and must be filtered out below rather than assumed
+            // gone, or the user sees a manual "Save" row for a file that is already
+            // downloading and can fire a second, concurrent accept for the same id.
             runCatching { FileAutoAccept.run(context) }
             // With the VPN off and stay-online off, RayfishVpnService is not running,
             // so this 2s loop is the only poller while the app is open: without this,
             // an own-device auto-accept (and any other in-flight transfer) would show
             // no progress and no result notification at all.
             runCatching { TransferNotifier.poll(context) }
+            val autoAccepting = NodeHolder.isAutoAcceptOwnDevices(context)
             files = runCatching { node.listFileOffers() }.getOrDefault(emptyList())
+                .filter { !(autoAccepting && it.ownDevice) }
             connects = runCatching { node.listConnectRequests() }.getOrDefault(emptyList())
             joins = currentNets.filter { it.isCoordinator }.flatMap { n ->
                 runCatching { node.listJoinRequests(n.name) }.getOrDefault(emptyList()).map { n.name to it }

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.withContext
 import uniffi.ray_mobile.FileOffer
 import uniffi.ray_mobile.PendingRequest
 import uniffi.ray_mobile.Status
+import xyz.rayfish.android.DownloadsOutcome
 import xyz.rayfish.android.FileAutoAccept
 import xyz.rayfish.android.NodeHolder
 import xyz.rayfish.android.RayfishVpnService
@@ -149,7 +150,8 @@ fun HomeScreen(status: Status?, starting: Boolean, onToast: (String) -> Unit) {
             try {
                 withContext(Dispatchers.IO) {
                     NodeHolder.get(context).acceptFileOffer(f.id, saveDir)
-                    moveToDownloads(context, File(saveDir, f.filename), f.filename, f.mimeType)
+                    val reached = moveToDownloads(context, File(saveDir, f.filename), f.filename, f.mimeType)
+                    DownloadsOutcome.record(f.filename, reached)
                 }
                 accepting.remove(f.id)
                 doneFiles[f.id] = f

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
@@ -110,7 +110,10 @@ fun HomeScreen(status: Status?, starting: Boolean, onToast: (String) -> Unit) {
             runCatching { TransferNotifier.poll(context) }
             val autoAccepting = NodeHolder.isAutoAcceptOwnDevices(context)
             files = runCatching { node.listFileOffers() }.getOrDefault(emptyList())
-                .filter { !(autoAccepting && it.ownDevice) }
+                // Hide own-device offers while auto-accept is downloading or still
+                // retrying them, but not ones it has permanently given up on: those
+                // would otherwise be invisible with no way to save them at all.
+                .filter { !(autoAccepting && it.ownDevice) || FileAutoAccept.hasGivenUp(it.id) }
             connects = runCatching { node.listConnectRequests() }.getOrDefault(emptyList())
             joins = currentNets.filter { it.isCoordinator }.flatMap { n ->
                 runCatching { node.listJoinRequests(n.name) }.getOrDefault(emptyList()).map { n.name to it }

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/HomeScreen.kt
@@ -27,6 +27,7 @@ import xyz.rayfish.android.DownloadsOutcome
 import xyz.rayfish.android.FileAutoAccept
 import xyz.rayfish.android.NodeHolder
 import xyz.rayfish.android.RayfishVpnService
+import xyz.rayfish.android.TransferKey
 import xyz.rayfish.android.TransferNotifier
 import xyz.rayfish.android.moveToDownloads
 import xyz.rayfish.android.ui.components.*
@@ -146,12 +147,18 @@ fun HomeScreen(status: Status?, starting: Boolean, onToast: (String) -> Unit) {
     val doneFiles = remember { mutableStateMapOf<ULong, FileOffer>() }
     fun acceptFile(f: FileOffer) {
         accepting[f.id] = f
+        val key = TransferKey(f.from, f.filename, f.size)
+        // Mark pending before the blocking accept starts: the core reports the
+        // transfer DONE from inside acceptFileOffer, before moveToDownloads below
+        // has copied anything, so TransferNotifier's poller must see "pending"
+        // from the first moment DONE can appear.
+        DownloadsOutcome.markPending(key)
         scope.launch {
             try {
                 withContext(Dispatchers.IO) {
                     NodeHolder.get(context).acceptFileOffer(f.id, saveDir)
                     val reached = moveToDownloads(context, File(saveDir, f.filename), f.filename, f.mimeType)
-                    DownloadsOutcome.record(f.filename, reached)
+                    DownloadsOutcome.record(key, reached)
                 }
                 accepting.remove(f.id)
                 doneFiles[f.id] = f
@@ -159,6 +166,11 @@ fun HomeScreen(status: Status?, starting: Boolean, onToast: (String) -> Unit) {
                 kotlinx.coroutines.delay(2000)
                 doneFiles.remove(f.id)
             } catch (t: Throwable) {
+                // The accept itself failed: no Downloads outcome is ever coming for
+                // this key, so stop treating it as pending rather than making the
+                // result notification wait out the timeout for a failure that has
+                // already happened.
+                DownloadsOutcome.clearPending(key)
                 accepting.remove(f.id)
                 onToast("Failed: ${t.message}")
             }

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
@@ -123,9 +123,10 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
                 // null right after an Activity recreation: it can read stale-false
                 // while the VPN just came up in Home, or stale-true right after Home
                 // just took it down. Deciding from it here can silently kill a live
-                // VPN or silently no-op a real request. The service's tunnel field
-                // is the only state that never lags, so send unconditionally and let
-                // the service decide from that.
+                // VPN or silently no-op a real request. The service's tunnel field is
+                // authoritative only once the service re-checks it on nodeExecutor
+                // (the thread that writes it), so send unconditionally and let the
+                // service decide there instead of guessing from this stale cache.
                 if (on) {
                     // Bring the control plane up only, never a tunnel: a plain
                     // intent would land in startTunnel() and try to grab the

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
@@ -107,18 +107,23 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
                 }
             }
         }
-        var stayOnline by remember { mutableStateOf(NodeHolder.isStayOnline(context)) }
+        // Default off: standby is the normal behavior now, so disabling Rayfish
+        // keeps files working with the VPN off (that is what lets you run another
+        // VPN, Tailscale say, at the same time). This toggle is the escape hatch
+        // for a user who wants disabling Rayfish to take the device fully offline
+        // instead.
+        var goOfflineWhenDisabled by remember { mutableStateOf(NodeHolder.isGoOfflineWhenDisabled(context)) }
         ToggleCard(
-            title = "Keep files working when the VPN is off",
-            subtitle = if (stayOnline) {
-                "on · stays online in the background, so you can run another VPN and still send and receive"
+            title = "Go fully offline when disabled",
+            subtitle = if (goOfflineWhenDisabled) {
+                "on · turning the VPN off takes this device offline"
             } else {
-                "off · turning the VPN off takes this device offline"
+                "off · Rayfish keeps working for files with the VPN off, so you can run another VPN"
             },
-            checked = stayOnline,
+            checked = goOfflineWhenDisabled,
             onCheckedChange = { on ->
-                stayOnline = on
-                NodeHolder.setStayOnline(context, on)
+                goOfflineWhenDisabled = on
+                NodeHolder.setGoOfflineWhenDisabled(context, on)
                 // status is a poll cache (RayfishApp refreshes it every 2s), and is
                 // null right after an Activity recreation: it can read stale-false
                 // while the VPN just came up in Home, or stale-true right after Home
@@ -128,10 +133,24 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
                 // (the thread that writes it), so send unconditionally and let the
                 // service decide there instead of guessing from this stale cache.
                 if (on) {
-                    // Bring the control plane up only, never a tunnel: a plain
-                    // intent would land in startTunnel() and try to grab the
-                    // single VpnService slot (and pop the consent dialog),
-                    // which is exactly what this toggle exists to avoid when
+                    // The user asked to go fully offline when disabled. Do not send
+                    // bare ACTION_STOP: that unconditionally tears down whatever is
+                    // running, which is correct for Home's VPN toggle but not here,
+                    // since a live VPN must not be touched by this pref.
+                    // ACTION_EXIT_STANDBY means "if there is no tunnel, take the node
+                    // fully offline and stop the service; if there is a tunnel, leave
+                    // it alone, since the pref only governs the next teardown."
+                    context.startService(
+                        Intent(context, RayfishVpnService::class.java).apply {
+                            action = RayfishVpnService.ACTION_EXIT_STANDBY
+                        },
+                    )
+                } else {
+                    // Back to the default: bring the control plane up in standby if
+                    // the VPN is currently off. Bring the control plane up only,
+                    // never a tunnel: a plain intent would land in startTunnel() and
+                    // try to grab the single VpnService slot (and pop the consent
+                    // dialog), which is exactly what standby exists to avoid when
                     // another VPN (Tailscale) is meant to hold that slot.
                     // ACTION_STANDBY routes to enterStandbyBlocking() on nodeExecutor.
                     // If a tunnel is up, it re-posts the notification to correct text
@@ -140,18 +159,6 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
                         context,
                         Intent(context, RayfishVpnService::class.java).apply {
                             action = RayfishVpnService.ACTION_STANDBY
-                        },
-                    )
-                } else {
-                    // Do not send bare ACTION_STOP: that unconditionally tears down
-                    // whatever is running, which is correct for Home's VPN toggle but
-                    // not here, since a live VPN must not be touched by this pref.
-                    // ACTION_EXIT_STANDBY means "if there is no tunnel, take the node
-                    // fully offline and stop the service; if there is a tunnel, leave
-                    // it alone, since the pref only governs the next teardown."
-                    context.startService(
-                        Intent(context, RayfishVpnService::class.java).apply {
-                            action = RayfishVpnService.ACTION_EXIT_STANDBY
                         },
                     )
                 }

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
@@ -119,13 +119,14 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
             onCheckedChange = { on ->
                 stayOnline = on
                 NodeHolder.setStayOnline(context, on)
-                // If the VPN tunnel is up (NodeHolder.isEnabled), leave it alone in
-                // either direction: this only changes what happens at the next
-                // teardown. Otherwise drive the service now, since with the VPN off
-                // nothing else reacts to this pref: RayfishApp only starts the
-                // service when isEnabled is true, and never calls ensureStarted
-                // itself.
-                if (!NodeHolder.isEnabled(context)) {
+                // If the VPN is actually running (status.running, the real data-plane
+                // state, not the persisted isEnabled intent), leave it alone in either
+                // direction: this only changes what happens at the next teardown.
+                // Otherwise drive the service now, since with the VPN off nothing else
+                // reacts to this pref: RayfishApp's launch restore is the only other
+                // place that starts the service from these prefs, and that only runs
+                // once at launch.
+                if (status?.running != true) {
                     if (on) {
                         // Bring the control plane up only, never a tunnel: a plain
                         // intent would land in startTunnel() and try to grab the

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
@@ -119,39 +119,39 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
             onCheckedChange = { on ->
                 stayOnline = on
                 NodeHolder.setStayOnline(context, on)
-                // If the VPN is actually running (status.running, the real data-plane
-                // state, not the persisted isEnabled intent), leave it alone in either
-                // direction: this only changes what happens at the next teardown.
-                // Otherwise drive the service now, since with the VPN off nothing else
-                // reacts to this pref: RayfishApp's launch restore is the only other
-                // place that starts the service from these prefs, and that only runs
-                // once at launch.
-                if (status?.running != true) {
-                    if (on) {
-                        // Bring the control plane up only, never a tunnel: a plain
-                        // intent would land in startTunnel() and try to grab the
-                        // single VpnService slot (and pop the consent dialog),
-                        // which is exactly what this toggle exists to avoid when
-                        // another VPN (Tailscale) is meant to hold that slot.
-                        // ACTION_STANDBY routes straight to enterStandby().
-                        ContextCompat.startForegroundService(
-                            context,
-                            Intent(context, RayfishVpnService::class.java).apply {
-                                action = RayfishVpnService.ACTION_STANDBY
-                            },
-                        )
-                    } else {
-                        // Already in standby (service running, control plane up,
-                        // VPN off) and the user just asked to stop keeping it
-                        // online: take the node fully offline. The service reads
-                        // the now-false pref and does the full offline teardown,
-                        // including stopSelf.
-                        context.startService(
-                            Intent(context, RayfishVpnService::class.java).apply {
-                                action = RayfishVpnService.ACTION_STOP
-                            },
-                        )
-                    }
+                // status is a poll cache (RayfishApp refreshes it every 2s), and is
+                // null right after an Activity recreation: it can read stale-false
+                // while the VPN just came up in Home, or stale-true right after Home
+                // just took it down. Deciding from it here can silently kill a live
+                // VPN or silently no-op a real request. The service's tunnel field
+                // is the only state that never lags, so send unconditionally and let
+                // the service decide from that.
+                if (on) {
+                    // Bring the control plane up only, never a tunnel: a plain
+                    // intent would land in startTunnel() and try to grab the
+                    // single VpnService slot (and pop the consent dialog),
+                    // which is exactly what this toggle exists to avoid when
+                    // another VPN (Tailscale) is meant to hold that slot.
+                    // ACTION_STANDBY routes straight to enterStandby(), and is
+                    // already a no-op there when a tunnel is up.
+                    ContextCompat.startForegroundService(
+                        context,
+                        Intent(context, RayfishVpnService::class.java).apply {
+                            action = RayfishVpnService.ACTION_STANDBY
+                        },
+                    )
+                } else {
+                    // Do not send bare ACTION_STOP: that unconditionally tears down
+                    // whatever is running, which is correct for Home's VPN toggle but
+                    // not here, since a live VPN must not be touched by this pref.
+                    // ACTION_EXIT_STANDBY means "if there is no tunnel, take the node
+                    // fully offline and stop the service; if there is a tunnel, leave
+                    // it alone, since the pref only governs the next teardown."
+                    context.startService(
+                        Intent(context, RayfishVpnService::class.java).apply {
+                            action = RayfishVpnService.ACTION_EXIT_STANDBY
+                        },
+                    )
                 }
             },
         )

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
@@ -1,5 +1,6 @@
 package xyz.rayfish.android.ui.screens
 
+import android.content.Intent
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -11,11 +12,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import uniffi.ray_mobile.Status
 import xyz.rayfish.android.NodeHolder
+import xyz.rayfish.android.RayfishVpnService
 import xyz.rayfish.android.Telemetry
 import xyz.rayfish.android.ui.components.*
 import xyz.rayfish.android.ui.qr.rememberQrScanner
@@ -104,6 +107,49 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
                 }
             }
         }
+        var stayOnline by remember { mutableStateOf(NodeHolder.isStayOnline(context)) }
+        ToggleCard(
+            title = "Keep files working when the VPN is off",
+            subtitle = if (stayOnline) {
+                "on · stays online in the background, so you can run another VPN and still send and receive"
+            } else {
+                "off · turning the VPN off takes this device offline"
+            },
+            checked = stayOnline,
+            onCheckedChange = { on ->
+                stayOnline = on
+                NodeHolder.setStayOnline(context, on)
+                // If the VPN tunnel is up (NodeHolder.isEnabled), leave it alone in
+                // either direction: this only changes what happens at the next
+                // teardown. Otherwise drive the service now, since with the VPN off
+                // nothing else reacts to this pref: RayfishApp only starts the
+                // service when isEnabled is true, and never calls ensureStarted
+                // itself.
+                if (!NodeHolder.isEnabled(context)) {
+                    if (on) {
+                        // Bring the control plane up so the phone stays visible in
+                        // the mesh and keeps sending/receiving files. Same call
+                        // HomeScreen uses to start the service; with no VPN
+                        // requested, onStartCommand's plain-intent path settles
+                        // into standby (see enterStandby / handleBringUpFailure).
+                        ContextCompat.startForegroundService(
+                            context, Intent(context, RayfishVpnService::class.java),
+                        )
+                    } else {
+                        // Already in standby (service running, control plane up,
+                        // VPN off) and the user just asked to stop keeping it
+                        // online: take the node fully offline. The service reads
+                        // the now-false pref and does the full offline teardown,
+                        // including stopSelf.
+                        context.startService(
+                            Intent(context, RayfishVpnService::class.java).apply {
+                                action = RayfishVpnService.ACTION_STOP
+                            },
+                        )
+                    }
+                }
+            },
+        )
         var autoAcceptOwn by remember { mutableStateOf(NodeHolder.isAutoAcceptOwnDevices(context)) }
         ToggleCard(
             title = "Auto-accept from my devices",

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
@@ -133,8 +133,9 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
                     // single VpnService slot (and pop the consent dialog),
                     // which is exactly what this toggle exists to avoid when
                     // another VPN (Tailscale) is meant to hold that slot.
-                    // ACTION_STANDBY routes straight to enterStandby(), and is
-                    // already a no-op there when a tunnel is up.
+                    // ACTION_STANDBY routes to enterStandbyBlocking() on nodeExecutor.
+                    // If a tunnel is up, it re-posts the notification to correct text
+                    // instead of entering standby.
                     ContextCompat.startForegroundService(
                         context,
                         Intent(context, RayfishVpnService::class.java).apply {

--- a/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/ui/screens/YouScreen.kt
@@ -127,13 +127,17 @@ fun YouScreen(status: Status?, onToast: (String) -> Unit, onChanged: () -> Unit)
                 // itself.
                 if (!NodeHolder.isEnabled(context)) {
                     if (on) {
-                        // Bring the control plane up so the phone stays visible in
-                        // the mesh and keeps sending/receiving files. Same call
-                        // HomeScreen uses to start the service; with no VPN
-                        // requested, onStartCommand's plain-intent path settles
-                        // into standby (see enterStandby / handleBringUpFailure).
+                        // Bring the control plane up only, never a tunnel: a plain
+                        // intent would land in startTunnel() and try to grab the
+                        // single VpnService slot (and pop the consent dialog),
+                        // which is exactly what this toggle exists to avoid when
+                        // another VPN (Tailscale) is meant to hold that slot.
+                        // ACTION_STANDBY routes straight to enterStandby().
                         ContextCompat.startForegroundService(
-                            context, Intent(context, RayfishVpnService::class.java),
+                            context,
+                            Intent(context, RayfishVpnService::class.java).apply {
+                                action = RayfishVpnService.ACTION_STANDBY
+                            },
                         )
                     } else {
                         // Already in standby (service running, control plane up,

--- a/android/app/src/main/res/drawable/ic_stat_vpn.xml
+++ b/android/app/src/main/res/drawable/ic_stat_vpn.xml
@@ -1,0 +1,13 @@
+<!-- Monochrome status-bar icon for the foreground VPN/standby notification.
+     Status-bar icons use only the alpha channel, so this is a solid white
+     silhouette; the system applies its own tint. A shield reads as "protected
+     connection" and is not the download glyph it replaced. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12V5L12,1z" />
+</vector>

--- a/ray-mobile/src/lib.rs
+++ b/ray-mobile/src/lib.rs
@@ -66,6 +66,7 @@ use std::sync::{Arc, Mutex};
 use android_tun::{AndroidTunReader, AndroidTunWriter};
 use rayfish::config;
 use rayfish::control;
+use rayfish::daemon::transfers;
 use rayfish::daemon::{DaemonState, build_headless};
 use rayfish::deeplink::{self, RayfishLink};
 use rayfish::firewall::{Action, Direction, Protocol};
@@ -202,6 +203,29 @@ pub struct FileOffer {
     /// True when the sender is one of this user's own paired devices. The UI
     /// auto-accepts these (own-device shares) without a manual tap.
     pub own_device: bool,
+}
+
+/// Where a transfer is. A send is `Offered` until the peer accepts and starts
+/// pulling the bytes: `send_file` returns once the offer lands, not once the file
+/// has arrived, so `Done` on an outgoing transfer is the real "they have it".
+#[derive(uniffi::Enum)]
+pub enum TransferState {
+    Offered,
+    Transferring,
+    Done,
+    Failed,
+}
+
+/// One in-flight (or recently finished) file transfer, either direction.
+#[derive(uniffi::Record)]
+pub struct Transfer {
+    pub id: u64,
+    pub outgoing: bool,
+    pub peer: String,
+    pub filename: String,
+    pub size: u64,
+    pub transferred: u64,
+    pub state: TransferState,
 }
 
 /// A pending request awaiting the user's decision: an incoming `ray connect`
@@ -658,6 +682,31 @@ impl Node {
                 "unexpected files response: {other:?}"
             ))),
         }
+    }
+
+    /// In-flight and recently finished transfers, both directions. Terminal entries
+    /// linger for 60s so a poller can see them before they expire. Cheap: safe to
+    /// poll on a timer while a notification is on screen.
+    pub fn list_transfers(&self) -> Result<Vec<Transfer>, RayError> {
+        let state = self.state()?;
+        Ok(state
+            .list_transfers()
+            .into_iter()
+            .map(|t| Transfer {
+                id: t.id,
+                outgoing: t.outgoing,
+                peer: t.peer,
+                filename: t.filename,
+                size: t.size,
+                transferred: t.transferred,
+                state: match t.state {
+                    transfers::TransferState::Offered => TransferState::Offered,
+                    transfers::TransferState::Transferring => TransferState::Transferring,
+                    transfers::TransferState::Done => TransferState::Done,
+                    transfers::TransferState::Failed => TransferState::Failed,
+                },
+            })
+            .collect())
     }
 
     /// Accept a file offer, saving it under `output_dir` (an app-writable path).

--- a/src/daemon/file_service.rs
+++ b/src/daemon/file_service.rs
@@ -8,9 +8,13 @@
 //! /…) stay on `Daemon` since they orchestrate over core handles (endpoint,
 //! peers, the shared blob store) and read this service's state.
 
+use super::transfers;
 use super::*;
 use std::ffi::CString;
 use std::path::PathBuf;
+
+use futures::StreamExt;
+use iroh_blobs::api::remote::GetProgressItem;
 
 /// A received file offer awaiting `ray files accept`.
 pub(crate) struct PendingFile {
@@ -39,6 +43,8 @@ pub(crate) struct FileService {
     device_cert: Option<control::DeviceCert>,
     /// Transport-key → user-identity map, to resolve a file sender's owner.
     device_user_map: peers::DeviceUserMap,
+    /// In-flight transfers, for progress reporting.
+    pub(crate) transfers: Arc<transfers::TransferRegistry>,
 }
 
 impl FileService {
@@ -48,6 +54,7 @@ impl FileService {
         registry: Arc<NetworkRegistry>,
         device_cert: Option<control::DeviceCert>,
         device_user_map: peers::DeviceUserMap,
+        transfers: Arc<transfers::TransferRegistry>,
     ) -> Self {
         Self {
             pending_files: Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -58,6 +65,7 @@ impl FileService {
             registry,
             device_cert,
             device_user_map,
+            transfers,
         }
     }
 
@@ -213,14 +221,45 @@ impl FileService {
             }
         };
 
-        if let Err(e) = self
-            .transport
-            .blob_store
-            .remote()
-            .fetch(conn, iroh_blobs::HashAndFormat::raw(blob_hash))
-            .await
-        {
-            return ipc_err(format!("blob fetch failed: {e}"));
+        let peer_label = pending_file
+            .from
+            .to_string()
+            .chars()
+            .take(8)
+            .collect::<String>();
+        let transfer_id = self.transfers.register_receive(
+            peer_label,
+            pending_file.filename.clone(),
+            pending_file.size,
+        );
+
+        // `fetch` returns a `GetProgress`: awaiting it directly discards the
+        // progress, so take the stream instead and report bytes as they land. It
+        // yields `Progress(n)` items (n = payload bytes read so far) and exactly
+        // one terminal `Done`/`Error` item.
+        let mut stream = Box::pin(
+            self.transport
+                .blob_store
+                .remote()
+                .fetch(conn, iroh_blobs::HashAndFormat::raw(blob_hash))
+                .stream(),
+        );
+        loop {
+            match stream.next().await {
+                Some(GetProgressItem::Progress(n)) => self.transfers.note_progress(transfer_id, n),
+                Some(GetProgressItem::Done(_)) => {
+                    self.transfers.finish(transfer_id, true);
+                    break;
+                }
+                Some(GetProgressItem::Error(e)) => {
+                    self.transfers.finish(transfer_id, false);
+                    return ipc_err(format!("blob fetch failed: {e}"));
+                }
+                None => {
+                    self.transfers.finish(transfer_id, false);
+                    return ipc_err("blob fetch ended without a result".to_string());
+                }
+            }
         }
 
         let bytes = match self.transport.blob_store.blobs().get_bytes(blob_hash).await {

--- a/src/daemon/file_service.rs
+++ b/src/daemon/file_service.rs
@@ -395,6 +395,19 @@ impl FileService {
             return ipc_err(format!("blob store error: {e}"));
         }
 
+        // Register the transfer now, before the peer can possibly learn the hash:
+        // it is only after `add_slice` above that the blob exists to be pulled, and
+        // the offer that tells the peer about it hasn't even been dialed yet. On
+        // auto-accept, the receiver can fetch the entire blob and close its
+        // connection before this function's own `conn.closed()` await below
+        // returns, so every provider event (Started/Progress/Completed) can arrive
+        // before an entry registered "at the end" would have existed; registering
+        // here instead means the entry always exists first.
+        let blob_hash = iroh_blobs::Hash::from_bytes(*hash.as_bytes());
+        let transfer_id = self
+            .transfers
+            .register_send(peer_id, filename.clone(), size, blob_hash);
+
         let msg = control::ControlMsg::FileOffer {
             from: self.transport.endpoint.id(),
             filename: filename.clone(),
@@ -415,6 +428,7 @@ impl FileService {
                     // File offers ride the separate FILES_ALPN, not the mesh demux,
                     // so they carry no network scope.
                     if let Err(e) = control::send_msg(&mut send, None, &msg).await {
+                        self.transfers.finish(transfer_id, false);
                         return ipc_err(format!("failed to send offer: {e}"));
                     }
                     // send_msg already finished the stream; wait for the peer to
@@ -422,25 +436,20 @@ impl FileService {
                     let _ = tokio::time::timeout(Duration::from_secs(5), conn.closed()).await;
                 }
                 Err(e) => {
+                    self.transfers.finish(transfer_id, false);
                     return ipc_err(format!("failed to open stream: {e}"));
                 }
             },
             Err(e) => {
+                self.transfers.finish(transfer_id, false);
                 return ipc_err(format!("cannot reach peer '{peer}': {e}"));
             }
         }
 
-        // The bytes have not moved yet: `send_file` returns once the *offer* is
-        // delivered. The peer pulls the blob out of our store when it accepts, and
-        // that is what the provider events (wired up in bootstrap) report against
-        // this hash. So the transfer starts life as Offered.
-        self.transfers.register_send(
-            peer.to_string(),
-            filename.clone(),
-            size,
-            iroh_blobs::Hash::from_bytes(*hash.as_bytes()),
-        );
-
+        // The bytes have not moved yet: the offer has only just been delivered.
+        // The peer pulls the blob out of our store when it accepts, and that is
+        // what the provider events (wired up in bootstrap) report against this
+        // hash and peer. The entry stays Offered until then.
         IpcMessage::Ok {
             message: format!("offered {} ({}) to {}", filename, format_size(size), peer),
         }

--- a/src/daemon/file_service.rs
+++ b/src/daemon/file_service.rs
@@ -430,6 +430,17 @@ impl FileService {
             }
         }
 
+        // The bytes have not moved yet: `send_file` returns once the *offer* is
+        // delivered. The peer pulls the blob out of our store when it accepts, and
+        // that is what the provider events (wired up in bootstrap) report against
+        // this hash. So the transfer starts life as Offered.
+        self.transfers.register_send(
+            peer.to_string(),
+            filename.clone(),
+            size,
+            iroh_blobs::Hash::from_bytes(*hash.as_bytes()),
+        );
+
         IpcMessage::Ok {
             message: format!("offered {} ({}) to {}", filename, format_size(size), peer),
         }

--- a/src/daemon/file_service.rs
+++ b/src/daemon/file_service.rs
@@ -428,7 +428,7 @@ impl FileService {
                     // File offers ride the separate FILES_ALPN, not the mesh demux,
                     // so they carry no network scope.
                     if let Err(e) = control::send_msg(&mut send, None, &msg).await {
-                        self.transfers.finish(transfer_id, false);
+                        self.transfers.fail_offer(transfer_id);
                         return ipc_err(format!("failed to send offer: {e}"));
                     }
                     // send_msg already finished the stream; wait for the peer to
@@ -436,12 +436,12 @@ impl FileService {
                     let _ = tokio::time::timeout(Duration::from_secs(5), conn.closed()).await;
                 }
                 Err(e) => {
-                    self.transfers.finish(transfer_id, false);
+                    self.transfers.fail_offer(transfer_id);
                     return ipc_err(format!("failed to open stream: {e}"));
                 }
             },
             Err(e) => {
-                self.transfers.finish(transfer_id, false);
+                self.transfers.fail_offer(transfer_id);
                 return ipc_err(format!("cannot reach peer '{peer}': {e}"));
             }
         }

--- a/src/daemon/file_service.rs
+++ b/src/daemon/file_service.rs
@@ -221,22 +221,24 @@ impl FileService {
             }
         };
 
-        let peer_label = pending_file
-            .from
-            .to_string()
-            .chars()
-            .take(8)
-            .collect::<String>();
+        let peer_label = pending_file.from.fmt_short().to_string();
         let transfer_id = self.transfers.register_receive(
             peer_label,
             pending_file.filename.clone(),
             pending_file.size,
         );
+        // Guards against a cancelled fetch (or an early return below) leaving
+        // the entry stuck in `Transferring`: its `Drop` marks the transfer
+        // failed unless `success()` disarms it first, which only happens once
+        // the file is actually on disk.
+        let finish_guard = transfers::FinishGuard::new(self.transfers.clone(), transfer_id);
 
         // `fetch` returns a `GetProgress`: awaiting it directly discards the
         // progress, so take the stream instead and report bytes as they land. It
         // yields `Progress(n)` items (n = payload bytes read so far) and exactly
-        // one terminal `Done`/`Error` item.
+        // one terminal `Done`/`Error` item. Note: reaching `Done` here means only
+        // the fetch succeeded, not the transfer; the registry is not finished
+        // until the file is written to disk below.
         let mut stream = Box::pin(
             self.transport
                 .blob_store
@@ -247,16 +249,11 @@ impl FileService {
         loop {
             match stream.next().await {
                 Some(GetProgressItem::Progress(n)) => self.transfers.note_progress(transfer_id, n),
-                Some(GetProgressItem::Done(_)) => {
-                    self.transfers.finish(transfer_id, true);
-                    break;
-                }
+                Some(GetProgressItem::Done(_)) => break,
                 Some(GetProgressItem::Error(e)) => {
-                    self.transfers.finish(transfer_id, false);
                     return ipc_err(format!("blob fetch failed: {e}"));
                 }
                 None => {
-                    self.transfers.finish(transfer_id, false);
                     return ipc_err("blob fetch ended without a result".to_string());
                 }
             }
@@ -296,6 +293,10 @@ impl FileService {
                 unsafe { libc::chown(c.as_ptr(), uid, gid) };
             }
         }
+
+        // The file is fully on disk (chown failures are ignored, by design,
+        // and never fail the transfer): only now is the transfer really done.
+        finish_guard.success();
 
         IpcMessage::Ok {
             message: format!("saved to {}", dest.display()),

--- a/src/daemon/mesh/bootstrap.rs
+++ b/src/daemon/mesh/bootstrap.rs
@@ -11,7 +11,7 @@
 use std::sync::Mutex;
 
 use iroh_blobs::provider::events::{
-    EventMask, EventSender, ProviderMessage, RequestMode, RequestUpdate,
+    ConnectMode, EventMask, EventSender, ProviderMessage, RequestMode, RequestUpdate,
 };
 
 use super::super::*;
@@ -193,10 +193,14 @@ async fn build_daemon(
     // which is the only signal a sender gets that its file arrived: `send_file`
     // returns when the *offer* lands, not when the bytes move. `NotifyLog` gives us
     // per-request transfer events with no interception, so a slow pump can never
-    // stall the provider.
+    // stall the provider. `connected: Notify` (also non-intercepting) is the only
+    // way to learn *who* is pulling: a `GetRequestReceivedNotify` carries a
+    // connection id, not a peer id, so without this we could only match on hash,
+    // which can't tell two recipients of the same file apart.
     let (blob_events, mut blob_event_rx) = EventSender::channel(
         64,
         EventMask {
+            connected: ConnectMode::Notify,
             get: RequestMode::NotifyLog,
             ..EventMask::DEFAULT
         },
@@ -205,11 +209,15 @@ async fn build_daemon(
 
     // Pump provider events into the transfer registry. Roster (group blob) fetches
     // ride the same blobs ALPN, so events for hashes we never registered as an
-    // outgoing file send are dropped by the registry.
+    // outgoing file send are dropped by the registry regardless of who pulled them.
     {
         let transfers = transfers.clone();
         let token = token.clone();
         tokio::spawn(async move {
+            // Connection id -> resolved peer, built from `ClientConnected` and
+            // pruned on `ConnectionClosed`. Only ever touched from this single
+            // task, so a plain map needs no lock.
+            let mut connections: HashMap<u64, EndpointId> = HashMap::new();
             loop {
                 let msg = tokio::select! {
                     _ = token.cancelled() => break,
@@ -218,28 +226,60 @@ async fn build_daemon(
                         None => break,
                     },
                 };
-                // Only the notify variant arrives under `NotifyLog`, and only for get
-                // requests: everything else in the mask is off.
-                if let ProviderMessage::GetRequestReceivedNotify(msg) = msg {
-                    let hash = msg.inner.request.hash;
-                    let transfers = transfers.clone();
-                    let mut updates = msg.rx;
-                    tokio::spawn(async move {
-                        while let Ok(Some(update)) = updates.recv().await {
-                            match update {
-                                RequestUpdate::Started(_) => transfers.provider_started(hash),
-                                RequestUpdate::Progress(p) => {
-                                    transfers.provider_progress(hash, p.end_offset)
-                                }
-                                RequestUpdate::Completed(_) => {
-                                    transfers.provider_finished(hash, true)
-                                }
-                                RequestUpdate::Aborted(_) => {
-                                    transfers.provider_finished(hash, false)
+                match msg {
+                    ProviderMessage::ClientConnectedNotify(msg) => {
+                        if let Some(endpoint_id) = msg.inner.endpoint_id {
+                            connections.insert(msg.inner.connection_id, endpoint_id);
+                        }
+                    }
+                    ProviderMessage::ConnectionClosed(msg) => {
+                        connections.remove(&msg.inner.connection_id);
+                    }
+                    // Only the notify variant arrives under `NotifyLog`, and only for
+                    // get requests: everything else in the mask is off.
+                    ProviderMessage::GetRequestReceivedNotify(msg) => {
+                        let hash = msg.inner.request.hash;
+                        let connection_id = msg.inner.connection_id;
+                        // Resolved now, synchronously, while still on the single task
+                        // that owns `connections`; the request-tracking task below
+                        // only needs the already-resolved value.
+                        let peer = connections.get(&connection_id).copied();
+                        let transfers = transfers.clone();
+                        let mut updates = msg.rx;
+                        tokio::spawn(async move {
+                            let Some(peer) = peer else {
+                                // No resolved peer for this connection (a roster
+                                // fetch, or a connection whose `ClientConnected` we
+                                // missed): drain without matching, so we never fall
+                                // back to hash-only matching and never stall the
+                                // provider by leaving its update channel unread.
+                                tracing::debug!(
+                                    connection_id,
+                                    %hash,
+                                    "provider event with no resolved peer; dropping"
+                                );
+                                while let Ok(Some(_)) = updates.recv().await {}
+                                return;
+                            };
+                            while let Ok(Some(update)) = updates.recv().await {
+                                match update {
+                                    RequestUpdate::Started(_) => {
+                                        transfers.provider_started(hash, peer)
+                                    }
+                                    RequestUpdate::Progress(p) => {
+                                        transfers.provider_progress(hash, peer, p.end_offset)
+                                    }
+                                    RequestUpdate::Completed(_) => {
+                                        transfers.provider_finished(hash, peer, true)
+                                    }
+                                    RequestUpdate::Aborted(_) => {
+                                        transfers.provider_finished(hash, peer, false)
+                                    }
                                 }
                             }
-                        }
-                    });
+                        });
+                    }
+                    _ => {}
                 }
             }
         });

--- a/src/daemon/mesh/bootstrap.rs
+++ b/src/daemon/mesh/bootstrap.rs
@@ -174,6 +174,11 @@ async fn build_daemon(
     )
     .await?;
 
+    // Built before the blob store below, because the provider event pump that
+    // feeds it (an upcoming send-side wiring) attaches to `BlobsProtocol` at
+    // construction and needs the same registry.
+    let transfers = Arc::new(transfers::TransferRegistry::new());
+
     // --- Content-addressed blob store (membership/file transfer) ---
     let blobs_dir = config::config_dir()?.join("blobs");
     std::fs::create_dir_all(&blobs_dir)?;
@@ -289,6 +294,7 @@ async fn build_daemon(
         registry.clone(),
         device_cert.clone(),
         device_user_map.clone(),
+        transfers.clone(),
     ));
     let connect = Arc::new(ConnectService::new(
         transport.clone(),
@@ -367,6 +373,7 @@ async fn build_daemon(
         _metrics_server: metrics_server,
         router,
         files,
+        transfers,
         connect,
         device_cert,
         contact_public,

--- a/src/daemon/mesh/bootstrap.rs
+++ b/src/daemon/mesh/bootstrap.rs
@@ -191,12 +191,21 @@ async fn build_daemon(
         .context("failed to open blob store")?;
     // Provider events tell us when a peer actually reads a blob out of our store,
     // which is the only signal a sender gets that its file arrived: `send_file`
-    // returns when the *offer* lands, not when the bytes move. `NotifyLog` gives us
-    // per-request transfer events with no interception, so a slow pump can never
-    // stall the provider. `connected: Notify` (also non-intercepting) is the only
-    // way to learn *who* is pulling: a `GetRequestReceivedNotify` carries a
-    // connection id, not a peer id, so without this we could only match on hash,
-    // which can't tell two recipients of the same file apart.
+    // returns when the *offer* lands, not when the bytes move. `NotifyLog` gives
+    // us per-request transfer events with no interception; `get` is the only
+    // request-mode field this crate version actually reads, so it gates
+    // notifications for all four request kinds (get, get_many, push, observe),
+    // not just get. What this actually guarantees: our pump body below never
+    // awaits anything except `recv` (each request's update stream is drained by
+    // a task spawned immediately), and transfer progress is sent with `try_send`
+    // and dropped rather than blocking, so a slow pump cannot itself stall the
+    // provider. It does not mean the provider can never block on us:
+    // `client_connected` and `notify_streaming` do await on this channel (64
+    // slots), so a wedged pump would still backpressure connection setup.
+    // `connected: Notify` (also non-intercepting) is the only way to learn *who*
+    // is pulling: a `GetRequestReceivedNotify` carries a connection id, not a
+    // peer id, so without this we could only match on hash, which can't tell two
+    // recipients of the same file apart.
     let (blob_events, mut blob_event_rx) = EventSender::channel(
         64,
         EventMask {
@@ -278,6 +287,28 @@ async fn build_daemon(
                                 }
                             }
                         });
+                    }
+                    // Not something we track (Rayfish only issues single-blob
+                    // Gets today), but `get: RequestMode::NotifyLog` above gates
+                    // all four request kinds in this crate version, not just
+                    // Get, so these three CAN arrive (e.g. from a future
+                    // get_many/HashSeq fetch). Each carries an `rx` update
+                    // channel the provider writes progress into; if we drop it
+                    // unread, the provider's `transfer_progress` gets
+                    // `SendError::ReceiverClosed` and aborts the request. Drain
+                    // it to completion and discard, same as the Get arm, but
+                    // without touching the registry.
+                    ProviderMessage::GetManyRequestReceivedNotify(msg) => {
+                        let mut updates = msg.rx;
+                        tokio::spawn(async move { while let Ok(Some(_)) = updates.recv().await {} });
+                    }
+                    ProviderMessage::PushRequestReceivedNotify(msg) => {
+                        let mut updates = msg.rx;
+                        tokio::spawn(async move { while let Ok(Some(_)) = updates.recv().await {} });
+                    }
+                    ProviderMessage::ObserveRequestReceivedNotify(msg) => {
+                        let mut updates = msg.rx;
+                        tokio::spawn(async move { while let Ok(Some(_)) = updates.recv().await {} });
                     }
                     _ => {}
                 }

--- a/src/daemon/mesh/bootstrap.rs
+++ b/src/daemon/mesh/bootstrap.rs
@@ -179,8 +179,8 @@ async fn build_daemon(
     .await?;
 
     // Built before the blob store below, because the provider event pump that
-    // feeds it (an upcoming send-side wiring) attaches to `BlobsProtocol` at
-    // construction and needs the same registry.
+    // feeds it (a bit further down, once `blobs_proto` exists) needs the
+    // registry to already be there to hand transfer updates to.
     let transfers = Arc::new(transfers::TransferRegistry::new());
 
     // --- Content-addressed blob store (membership/file transfer) ---

--- a/src/daemon/mesh/bootstrap.rs
+++ b/src/daemon/mesh/bootstrap.rs
@@ -10,6 +10,10 @@
 
 use std::sync::Mutex;
 
+use iroh_blobs::provider::events::{
+    EventMask, EventSender, ProviderMessage, RequestMode, RequestUpdate,
+};
+
 use super::super::*;
 
 pub async fn run_daemon(token: CancellationToken, stats: Arc<ForwardMetrics>) -> Result<()> {
@@ -185,7 +189,61 @@ async fn build_daemon(
     let blob_store = FsStore::load(&blobs_dir)
         .await
         .context("failed to open blob store")?;
-    let blobs_proto = BlobsProtocol::new(&blob_store, None);
+    // Provider events tell us when a peer actually reads a blob out of our store,
+    // which is the only signal a sender gets that its file arrived: `send_file`
+    // returns when the *offer* lands, not when the bytes move. `NotifyLog` gives us
+    // per-request transfer events with no interception, so a slow pump can never
+    // stall the provider.
+    let (blob_events, mut blob_event_rx) = EventSender::channel(
+        64,
+        EventMask {
+            get: RequestMode::NotifyLog,
+            ..EventMask::DEFAULT
+        },
+    );
+    let blobs_proto = BlobsProtocol::new(&blob_store, Some(blob_events));
+
+    // Pump provider events into the transfer registry. Roster (group blob) fetches
+    // ride the same blobs ALPN, so events for hashes we never registered as an
+    // outgoing file send are dropped by the registry.
+    {
+        let transfers = transfers.clone();
+        let token = token.clone();
+        tokio::spawn(async move {
+            loop {
+                let msg = tokio::select! {
+                    _ = token.cancelled() => break,
+                    msg = blob_event_rx.recv() => match msg {
+                        Some(msg) => msg,
+                        None => break,
+                    },
+                };
+                // Only the notify variant arrives under `NotifyLog`, and only for get
+                // requests: everything else in the mask is off.
+                if let ProviderMessage::GetRequestReceivedNotify(msg) = msg {
+                    let hash = msg.inner.request.hash;
+                    let transfers = transfers.clone();
+                    let mut updates = msg.rx;
+                    tokio::spawn(async move {
+                        while let Ok(Some(update)) = updates.recv().await {
+                            match update {
+                                RequestUpdate::Started(_) => transfers.provider_started(hash),
+                                RequestUpdate::Progress(p) => {
+                                    transfers.provider_progress(hash, p.end_offset)
+                                }
+                                RequestUpdate::Completed(_) => {
+                                    transfers.provider_finished(hash, true)
+                                }
+                                RequestUpdate::Aborted(_) => {
+                                    transfers.provider_finished(hash, false)
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        });
+    }
 
     // --- Packet interface: deferred to `attach_tun` ---
     // No OS TUN device or forwarding loop is created here. On desktop `run_daemon`

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -488,6 +488,9 @@ pub struct Daemon {
     /// File-transfer + pairing state and ALPN accept arms (see [`FileService`]).
     /// Shared with [`ProtocolRouter`], which runs the accept arms.
     files: Arc<FileService>,
+    /// In-flight file transfers, both directions, for progress reporting. Shared
+    /// with [`FileService`] (receive side) and the send-side provider event pump.
+    transfers: Arc<transfers::TransferRegistry>,
     /// `ray connect` state + ALPN accept arm (see [`ConnectService`]). Shared with
     /// [`ProtocolRouter`], which runs the accept arm.
     connect: Arc<ConnectService>,
@@ -562,6 +565,12 @@ impl Daemon {
             Ok(cert) => cert,
             Err(_) => self.device_cert.clone(),
         }
+    }
+
+    /// In-flight file transfers, both directions, for progress reporting. Cheap:
+    /// clones a small vec. Safe to poll.
+    pub fn list_transfers(&self) -> Vec<transfers::TransferInfo> {
+        self.transfers.list()
     }
 
     /// Gracefully take the whole node offline: cancel the daemon-wide shutdown

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -130,6 +130,9 @@ pub(crate) use dns_service::DnsService;
 mod file_service;
 pub(crate) use file_service::FileService;
 
+/// In-flight transfer state, for progress reporting on both sides of a send.
+pub mod transfers;
+
 mod connect_service;
 pub(crate) use connect_service::ConnectService;
 

--- a/src/daemon/transfers.rs
+++ b/src/daemon/transfers.rs
@@ -118,7 +118,7 @@ impl TransferRegistry {
 
     pub fn note_progress(&self, id: u64, transferred: u64) {
         if let Some(e) = self.entries.lock().unwrap().get_mut(&id) {
-            e.info.transferred = transferred;
+            e.info.transferred = transferred.min(e.info.size);
             e.info.state = TransferState::Transferring;
         }
     }
@@ -279,6 +279,27 @@ mod tests {
         let t = &reg.list()[0];
         assert_eq!(t.state, TransferState::Done);
         assert_eq!(t.transferred, 100);
+    }
+
+    #[test]
+    fn sending_the_same_file_again_after_it_finished_does_not_reopen_it() {
+        let reg = TransferRegistry::new();
+        let first = reg.register_send("laptop".into(), "photo.jpg".into(), 100, hash(1));
+        reg.provider_started(hash(1));
+        reg.provider_finished(hash(1), true);
+        assert_eq!(reg.list()[0].state, TransferState::Done);
+
+        // The user sends the same file again: a new entry for the same hash.
+        let second = reg.register_send("laptop".into(), "photo.jpg".into(), 100, hash(1));
+        reg.provider_started(hash(1));
+        reg.provider_finished(hash(1), true);
+
+        let list = reg.list();
+        assert_eq!(list.len(), 2, "the finished first send is still listed alongside the new one");
+        let a = list.iter().find(|t| t.id == first).unwrap();
+        let b = list.iter().find(|t| t.id == second).unwrap();
+        assert_eq!(a.state, TransferState::Done, "the first send must not be reopened");
+        assert_eq!(b.state, TransferState::Done);
     }
 
     #[test]

--- a/src/daemon/transfers.rs
+++ b/src/daemon/transfers.rs
@@ -10,16 +10,20 @@
 //!   iroh-blobs *provider* events, which fire when a peer actually reads the blob
 //!   out of our store. `TransferCompleted` is the authoritative "they got it".
 //!
-//! Provider events are keyed by blob hash, not by transfer, and the roster
-//! (group blob) fetches ride the same blobs ALPN. So hashes we never registered as
-//! an outgoing file send are ignored, and a hash registered more than once (the
-//! same file sent to two peers) resolves oldest-offer-first.
+//! Provider events are keyed by blob hash *and* the resolved peer endpoint id, not
+//! by transfer. The roster (group blob) fetches ride the same blobs ALPN, so a
+//! hash we never registered as an outgoing file send is ignored, and requiring the
+//! peer to match too means the same file offered to two different peers can only
+//! ever be completed by the peer it was actually sent to: a pull by one can never
+//! complete the other's entry, and a pull by an unrelated third party (anyone who
+//! learned the hash) can't complete anyone's entry at all.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use iroh::EndpointId;
 use iroh_blobs::Hash;
 
 /// How long a finished transfer stays listable, so a poller can observe the
@@ -53,6 +57,11 @@ struct Entry {
     info: TransferInfo,
     /// Outgoing only: the blob the peer will pull, used to match provider events.
     hash: Option<Hash>,
+    /// Outgoing only: the peer this offer was sent to. A provider event must match
+    /// both this and `hash` to complete the entry, so a pull by a different peer
+    /// (another recipient of the same file, or anyone else who learned the hash)
+    /// can never complete it.
+    peer_id: Option<EndpointId>,
     /// When the transfer reached a terminal state, for TTL expiry.
     finished_at: Option<Instant>,
 }
@@ -71,9 +80,16 @@ impl TransferRegistry {
         }
     }
 
-    /// An outgoing offer has been delivered. The bytes move later, when the peer
-    /// accepts and pulls them, which arrives as provider events keyed by `hash`.
-    pub fn register_send(&self, peer: String, filename: String, size: u64, hash: Hash) -> u64 {
+    /// An outgoing offer is about to be sent to `peer`. The bytes move later, when
+    /// the peer accepts and pulls them, which arrives as provider events keyed by
+    /// `hash` *and* `peer`. Must be called before the offer can possibly reach the
+    /// peer (i.e. before dialing), so that a peer who pulls immediately can never
+    /// race ahead of its own registration; the caller finishes the entry with
+    /// `finish(id, false)` if the send fails after this point.
+    ///
+    /// The display label is always the resolved peer id's short form, matching
+    /// `register_receive`, not whatever string the caller typed at the CLI.
+    pub fn register_send(&self, peer: EndpointId, filename: String, size: u64, hash: Hash) -> u64 {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         self.entries.lock().unwrap().insert(
             id,
@@ -81,13 +97,14 @@ impl TransferRegistry {
                 info: TransferInfo {
                     id,
                     outgoing: true,
-                    peer,
+                    peer: peer.fmt_short().to_string(),
                     filename,
                     size,
                     transferred: 0,
                     state: TransferState::Offered,
                 },
                 hash: Some(hash),
+                peer_id: Some(peer),
                 finished_at: None,
             },
         );
@@ -110,6 +127,7 @@ impl TransferRegistry {
                     state: TransferState::Transferring,
                 },
                 hash: None,
+                peer_id: None,
                 finished_at: None,
             },
         );
@@ -129,26 +147,36 @@ impl TransferRegistry {
         }
     }
 
-    pub fn provider_started(&self, hash: Hash) {
+    /// A peer started pulling a blob. If the only entry for this `(hash, peer)`
+    /// pair already finished as `Failed` (an earlier pull was aborted), a fresh
+    /// `Started` revives it rather than leaving the sender stuck showing a failure
+    /// for a file that is now actually arriving: a retried pull after an aborted
+    /// one still deserves to end up `Done`.
+    pub fn provider_started(&self, hash: Hash, peer: EndpointId) {
         let mut entries = self.entries.lock().unwrap();
-        if let Some(id) = oldest_live_outgoing(&entries, hash) {
+        if let Some(id) = oldest_live_outgoing(&entries, hash, peer) {
             let e = entries.get_mut(&id).expect("id came from this map");
+            e.info.state = TransferState::Transferring;
+        } else if let Some(id) = oldest_failed_outgoing(&entries, hash, peer) {
+            let e = entries.get_mut(&id).expect("id came from this map");
+            e.finished_at = None;
+            e.info.transferred = 0;
             e.info.state = TransferState::Transferring;
         }
     }
 
-    pub fn provider_progress(&self, hash: Hash, end_offset: u64) {
+    pub fn provider_progress(&self, hash: Hash, peer: EndpointId, end_offset: u64) {
         let mut entries = self.entries.lock().unwrap();
-        if let Some(id) = oldest_live_outgoing(&entries, hash) {
+        if let Some(id) = oldest_live_outgoing(&entries, hash, peer) {
             let e = entries.get_mut(&id).expect("id came from this map");
             e.info.transferred = end_offset.min(e.info.size);
             e.info.state = TransferState::Transferring;
         }
     }
 
-    pub fn provider_finished(&self, hash: Hash, ok: bool) {
+    pub fn provider_finished(&self, hash: Hash, peer: EndpointId, ok: bool) {
         let mut entries = self.entries.lock().unwrap();
-        if let Some(id) = oldest_live_outgoing(&entries, hash) {
+        if let Some(id) = oldest_live_outgoing(&entries, hash, peer) {
             let e = entries.get_mut(&id).expect("id came from this map");
             finish_entry(e, ok);
         }
@@ -220,13 +248,28 @@ fn finish_entry(e: &mut Entry, ok: bool) {
     e.finished_at = Some(Instant::now());
 }
 
-/// The transfer a provider event belongs to: the oldest outgoing entry for this
-/// hash that has not finished. Returns `None` for a hash we never registered as an
-/// outgoing file send (a roster blob fetch, say), which is how those get ignored.
-fn oldest_live_outgoing(entries: &HashMap<u64, Entry>, hash: Hash) -> Option<u64> {
+/// The transfer a provider event belongs to: the oldest outgoing, not-yet-finished
+/// entry for this `(hash, peer)` pair. Returns `None` for a hash we never
+/// registered as an outgoing file send (a roster blob fetch, say) or for a peer
+/// that never received this exact offer, which is how both get ignored: a hash
+/// alone is not enough to identify who a send actually went to.
+fn oldest_live_outgoing(entries: &HashMap<u64, Entry>, hash: Hash, peer: EndpointId) -> Option<u64> {
     entries
         .values()
-        .filter(|e| e.hash == Some(hash) && e.finished_at.is_none())
+        .filter(|e| e.hash == Some(hash) && e.peer_id == Some(peer) && e.finished_at.is_none())
+        .map(|e| e.info.id)
+        .min()
+}
+
+/// Like [`oldest_live_outgoing`] but for an entry that already finished as
+/// `Failed`, used only to revive a stuck `Failed` on a fresh `Started` event (see
+/// `provider_started`).
+fn oldest_failed_outgoing(entries: &HashMap<u64, Entry>, hash: Hash, peer: EndpointId) -> Option<u64> {
+    entries
+        .values()
+        .filter(|e| {
+            e.hash == Some(hash) && e.peer_id == Some(peer) && e.info.state == TransferState::Failed
+        })
         .map(|e| e.info.id)
         .min()
 }
@@ -234,30 +277,41 @@ fn oldest_live_outgoing(entries: &HashMap<u64, Entry>, hash: Hash) -> Option<u64
 #[cfg(test)]
 mod tests {
     use super::*;
+    use iroh::SecretKey;
 
     fn hash(byte: u8) -> Hash {
         Hash::from_bytes([byte; 32])
     }
 
+    fn peer(seed: u8) -> EndpointId {
+        let mut key_bytes = [0u8; 32];
+        key_bytes[0] = seed;
+        SecretKey::from(key_bytes).public()
+    }
+
     #[test]
     fn send_starts_offered_then_tracks_the_peer_pulling_it() {
         let reg = TransferRegistry::new();
-        let id = reg.register_send("laptop".into(), "photo.jpg".into(), 100, hash(1));
+        let a = peer(1);
+        let id = reg.register_send(a, "photo.jpg".into(), 100, hash(1));
 
         let t = &reg.list()[0];
         assert_eq!(t.id, id);
         assert!(t.outgoing);
         assert_eq!(t.state, TransferState::Offered);
         assert_eq!(t.transferred, 0);
+        // The display label is the resolved peer's short id, same format as a
+        // receive's, not whatever string the CLI caller typed.
+        assert_eq!(t.peer, a.fmt_short().to_string());
 
         // The peer accepts and starts reading the blob out of our store.
-        reg.provider_started(hash(1));
+        reg.provider_started(hash(1), a);
         assert_eq!(reg.list()[0].state, TransferState::Transferring);
 
-        reg.provider_progress(hash(1), 60);
+        reg.provider_progress(hash(1), a, 60);
         assert_eq!(reg.list()[0].transferred, 60);
 
-        reg.provider_finished(hash(1), true);
+        reg.provider_finished(hash(1), a, true);
         let t = &reg.list()[0];
         assert_eq!(t.state, TransferState::Done);
         // A completed transfer reads as 100%, whatever the last progress event said.
@@ -267,9 +321,10 @@ mod tests {
     #[test]
     fn an_aborted_send_fails() {
         let reg = TransferRegistry::new();
-        reg.register_send("laptop".into(), "photo.jpg".into(), 100, hash(1));
-        reg.provider_started(hash(1));
-        reg.provider_finished(hash(1), false);
+        let a = peer(1);
+        reg.register_send(a, "photo.jpg".into(), 100, hash(1));
+        reg.provider_started(hash(1), a);
+        reg.provider_finished(hash(1), a, false);
         assert_eq!(reg.list()[0].state, TransferState::Failed);
     }
 
@@ -278,26 +333,88 @@ mod tests {
         // The roster/group-blob fetches ride the same blobs ALPN. They must not
         // show up as file transfers.
         let reg = TransferRegistry::new();
-        reg.provider_started(hash(9));
-        reg.provider_progress(hash(9), 10);
-        reg.provider_finished(hash(9), true);
+        let a = peer(1);
+        reg.provider_started(hash(9), a);
+        reg.provider_progress(hash(9), a, 10);
+        reg.provider_finished(hash(9), a, true);
         assert!(reg.list().is_empty());
+    }
+
+    #[test]
+    fn a_pull_by_one_peer_cannot_complete_another_peers_entry() {
+        // The same file offered to two different peers: only the peer it was
+        // actually sent to can drive its own entry to Done. Matching on hash
+        // alone (the old behavior) would let B's pull complete A's entry and lie
+        // to the user about who actually received the file.
+        let reg = TransferRegistry::new();
+        let a = peer(1);
+        let b = peer(2);
+        let to_a = reg.register_send(a, "photo.jpg".into(), 100, hash(1));
+        let to_b = reg.register_send(b, "photo.jpg".into(), 100, hash(1));
+
+        // B accepts and pulls; A never does.
+        reg.provider_started(hash(1), b);
+        reg.provider_progress(hash(1), b, 100);
+        reg.provider_finished(hash(1), b, true);
+
+        let list = reg.list();
+        let entry_a = list.iter().find(|t| t.id == to_a).unwrap();
+        let entry_b = list.iter().find(|t| t.id == to_b).unwrap();
+        assert_eq!(entry_a.state, TransferState::Offered, "A's entry must be untouched by B's pull");
+        assert_eq!(entry_b.state, TransferState::Done);
+    }
+
+    #[test]
+    fn a_pull_from_an_unresolved_peer_completes_nothing() {
+        // A pull attributed to a peer id we never registered this hash for (a
+        // stranger who somehow learned the hash, or a connection whose
+        // ClientConnected event we missed) must not complete a registered send:
+        // falling back to hash-only matching here would reopen the false-Sent bug.
+        let reg = TransferRegistry::new();
+        let a = peer(1);
+        let stranger = peer(99);
+        let id = reg.register_send(a, "photo.jpg".into(), 100, hash(1));
+
+        reg.provider_started(hash(1), stranger);
+        reg.provider_finished(hash(1), stranger, true);
+
+        assert_eq!(reg.list()[0].state, TransferState::Offered, "id {id} must be unaffected");
+    }
+
+    #[test]
+    fn a_started_event_revives_a_failed_send_on_retry() {
+        // An aborted pull marks the send Failed; if the same peer later retries
+        // and actually completes the pull, the sender should end up Done, not
+        // stuck showing a failure for a file that did arrive.
+        let reg = TransferRegistry::new();
+        let a = peer(1);
+        reg.register_send(a, "photo.jpg".into(), 100, hash(1));
+        reg.provider_started(hash(1), a);
+        reg.provider_finished(hash(1), a, false);
+        assert_eq!(reg.list()[0].state, TransferState::Failed);
+
+        // The retry.
+        reg.provider_started(hash(1), a);
+        assert_eq!(reg.list()[0].state, TransferState::Transferring);
+        reg.provider_finished(hash(1), a, true);
+        assert_eq!(reg.list()[0].state, TransferState::Done);
     }
 
     #[test]
     fn the_same_blob_sent_twice_resolves_oldest_offer_first() {
         let reg = TransferRegistry::new();
-        let first = reg.register_send("laptop".into(), "photo.jpg".into(), 100, hash(1));
-        let second = reg.register_send("phone".into(), "photo.jpg".into(), 100, hash(1));
+        let a = peer(1);
+        let first = reg.register_send(a, "photo.jpg".into(), 100, hash(1));
+        let second = reg.register_send(a, "photo.jpg".into(), 100, hash(1));
 
-        reg.provider_started(hash(1));
-        reg.provider_finished(hash(1), true);
+        reg.provider_started(hash(1), a);
+        reg.provider_finished(hash(1), a, true);
 
         let list = reg.list();
-        let a = list.iter().find(|t| t.id == first).unwrap();
-        let b = list.iter().find(|t| t.id == second).unwrap();
-        assert_eq!(a.state, TransferState::Done);
-        assert_eq!(b.state, TransferState::Offered, "the second offer is untouched");
+        let a_entry = list.iter().find(|t| t.id == first).unwrap();
+        let b_entry = list.iter().find(|t| t.id == second).unwrap();
+        assert_eq!(a_entry.state, TransferState::Done);
+        assert_eq!(b_entry.state, TransferState::Offered, "the second offer is untouched");
     }
 
     #[test]
@@ -322,15 +439,16 @@ mod tests {
     #[test]
     fn sending_the_same_file_again_after_it_finished_does_not_reopen_it() {
         let reg = TransferRegistry::new();
-        let first = reg.register_send("laptop".into(), "photo.jpg".into(), 100, hash(1));
-        reg.provider_started(hash(1));
-        reg.provider_finished(hash(1), true);
+        let a = peer(1);
+        let first = reg.register_send(a, "photo.jpg".into(), 100, hash(1));
+        reg.provider_started(hash(1), a);
+        reg.provider_finished(hash(1), a, true);
         assert_eq!(reg.list()[0].state, TransferState::Done);
 
         // The user sends the same file again: a new entry for the same hash.
-        let second = reg.register_send("laptop".into(), "photo.jpg".into(), 100, hash(1));
-        reg.provider_started(hash(1));
-        reg.provider_finished(hash(1), true);
+        let second = reg.register_send(a, "photo.jpg".into(), 100, hash(1));
+        reg.provider_started(hash(1), a);
+        reg.provider_finished(hash(1), a, true);
 
         let list = reg.list();
         assert_eq!(list.len(), 2, "the finished first send is still listed alongside the new one");

--- a/src/daemon/transfers.rs
+++ b/src/daemon/transfers.rs
@@ -1,0 +1,307 @@
+//! In-flight file transfers, for progress reporting.
+//!
+//! Fed from both directions of a transfer:
+//!
+//! - **Receive:** `FileService::accept_file` consumes the `GetProgress` stream from
+//!   `blob_store.remote().fetch(..)` and reports bytes as they land.
+//! - **Send:** `send_file` returns as soon as the *offer* is delivered; the peer
+//!   pulls the bytes whenever it accepts (immediately on auto-accept, minutes or
+//!   never on a manual one). So the sender learns the real outcome only from
+//!   iroh-blobs *provider* events, which fire when a peer actually reads the blob
+//!   out of our store. `TransferCompleted` is the authoritative "they got it".
+//!
+//! Provider events are keyed by blob hash, not by transfer, and the roster
+//! (group blob) fetches ride the same blobs ALPN. So hashes we never registered as
+//! an outgoing file send are ignored, and a hash registered more than once (the
+//! same file sent to two peers) resolves oldest-offer-first.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use iroh_blobs::Hash;
+
+/// How long a finished transfer stays listable, so a poller can observe the
+/// terminal state before it disappears.
+const TERMINAL_TTL: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferState {
+    /// Outgoing: the offer is delivered, the peer has not started pulling yet.
+    Offered,
+    /// Bytes are moving.
+    Transferring,
+    /// Every byte transferred. For a send this means the peer actually pulled it.
+    Done,
+    /// The transfer failed or was aborted.
+    Failed,
+}
+
+#[derive(Debug, Clone)]
+pub struct TransferInfo {
+    pub id: u64,
+    pub outgoing: bool,
+    pub peer: String,
+    pub filename: String,
+    pub size: u64,
+    pub transferred: u64,
+    pub state: TransferState,
+}
+
+struct Entry {
+    info: TransferInfo,
+    /// Outgoing only: the blob the peer will pull, used to match provider events.
+    hash: Option<Hash>,
+    /// When the transfer reached a terminal state, for TTL expiry.
+    finished_at: Option<Instant>,
+}
+
+#[derive(Default)]
+pub struct TransferRegistry {
+    entries: Mutex<HashMap<u64, Entry>>,
+    next_id: AtomicU64,
+}
+
+impl TransferRegistry {
+    pub fn new() -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+        }
+    }
+
+    /// An outgoing offer has been delivered. The bytes move later, when the peer
+    /// accepts and pulls them, which arrives as provider events keyed by `hash`.
+    pub fn register_send(&self, peer: String, filename: String, size: u64, hash: Hash) -> u64 {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        self.entries.lock().unwrap().insert(
+            id,
+            Entry {
+                info: TransferInfo {
+                    id,
+                    outgoing: true,
+                    peer,
+                    filename,
+                    size,
+                    transferred: 0,
+                    state: TransferState::Offered,
+                },
+                hash: Some(hash),
+                finished_at: None,
+            },
+        );
+        id
+    }
+
+    /// An incoming transfer we drive ourselves, so it is moving from the start.
+    pub fn register_receive(&self, peer: String, filename: String, size: u64) -> u64 {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        self.entries.lock().unwrap().insert(
+            id,
+            Entry {
+                info: TransferInfo {
+                    id,
+                    outgoing: false,
+                    peer,
+                    filename,
+                    size,
+                    transferred: 0,
+                    state: TransferState::Transferring,
+                },
+                hash: None,
+                finished_at: None,
+            },
+        );
+        id
+    }
+
+    pub fn note_progress(&self, id: u64, transferred: u64) {
+        if let Some(e) = self.entries.lock().unwrap().get_mut(&id) {
+            e.info.transferred = transferred;
+            e.info.state = TransferState::Transferring;
+        }
+    }
+
+    pub fn finish(&self, id: u64, ok: bool) {
+        if let Some(e) = self.entries.lock().unwrap().get_mut(&id) {
+            finish_entry(e, ok);
+        }
+    }
+
+    pub fn provider_started(&self, hash: Hash) {
+        let mut entries = self.entries.lock().unwrap();
+        if let Some(id) = oldest_live_outgoing(&entries, hash) {
+            let e = entries.get_mut(&id).expect("id came from this map");
+            e.info.state = TransferState::Transferring;
+        }
+    }
+
+    pub fn provider_progress(&self, hash: Hash, end_offset: u64) {
+        let mut entries = self.entries.lock().unwrap();
+        if let Some(id) = oldest_live_outgoing(&entries, hash) {
+            let e = entries.get_mut(&id).expect("id came from this map");
+            e.info.transferred = end_offset.min(e.info.size);
+            e.info.state = TransferState::Transferring;
+        }
+    }
+
+    pub fn provider_finished(&self, hash: Hash, ok: bool) {
+        let mut entries = self.entries.lock().unwrap();
+        if let Some(id) = oldest_live_outgoing(&entries, hash) {
+            let e = entries.get_mut(&id).expect("id came from this map");
+            finish_entry(e, ok);
+        }
+    }
+
+    pub fn list(&self) -> Vec<TransferInfo> {
+        self.list_at(Instant::now())
+    }
+
+    fn list_at(&self, now: Instant) -> Vec<TransferInfo> {
+        let mut entries = self.entries.lock().unwrap();
+        entries.retain(|_, e| match e.finished_at {
+            Some(at) => now.duration_since(at) < TERMINAL_TTL,
+            None => true,
+        });
+        let mut out: Vec<TransferInfo> = entries.values().map(|e| e.info.clone()).collect();
+        out.sort_by_key(|t| t.id);
+        out
+    }
+}
+
+/// A finished transfer reads as complete: a Done that showed 60/100 because the
+/// last progress event was coarse would be a worse lie than rounding up.
+fn finish_entry(e: &mut Entry, ok: bool) {
+    e.info.state = if ok {
+        e.info.transferred = e.info.size;
+        TransferState::Done
+    } else {
+        TransferState::Failed
+    };
+    e.finished_at = Some(Instant::now());
+}
+
+/// The transfer a provider event belongs to: the oldest outgoing entry for this
+/// hash that has not finished. Returns `None` for a hash we never registered as an
+/// outgoing file send (a roster blob fetch, say), which is how those get ignored.
+fn oldest_live_outgoing(entries: &HashMap<u64, Entry>, hash: Hash) -> Option<u64> {
+    entries
+        .values()
+        .filter(|e| e.hash == Some(hash) && e.finished_at.is_none())
+        .map(|e| e.info.id)
+        .min()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(byte: u8) -> Hash {
+        Hash::from_bytes([byte; 32])
+    }
+
+    #[test]
+    fn send_starts_offered_then_tracks_the_peer_pulling_it() {
+        let reg = TransferRegistry::new();
+        let id = reg.register_send("laptop".into(), "photo.jpg".into(), 100, hash(1));
+
+        let t = &reg.list()[0];
+        assert_eq!(t.id, id);
+        assert!(t.outgoing);
+        assert_eq!(t.state, TransferState::Offered);
+        assert_eq!(t.transferred, 0);
+
+        // The peer accepts and starts reading the blob out of our store.
+        reg.provider_started(hash(1));
+        assert_eq!(reg.list()[0].state, TransferState::Transferring);
+
+        reg.provider_progress(hash(1), 60);
+        assert_eq!(reg.list()[0].transferred, 60);
+
+        reg.provider_finished(hash(1), true);
+        let t = &reg.list()[0];
+        assert_eq!(t.state, TransferState::Done);
+        // A completed transfer reads as 100%, whatever the last progress event said.
+        assert_eq!(t.transferred, 100);
+    }
+
+    #[test]
+    fn an_aborted_send_fails() {
+        let reg = TransferRegistry::new();
+        reg.register_send("laptop".into(), "photo.jpg".into(), 100, hash(1));
+        reg.provider_started(hash(1));
+        reg.provider_finished(hash(1), false);
+        assert_eq!(reg.list()[0].state, TransferState::Failed);
+    }
+
+    #[test]
+    fn provider_events_for_unregistered_hashes_are_ignored() {
+        // The roster/group-blob fetches ride the same blobs ALPN. They must not
+        // show up as file transfers.
+        let reg = TransferRegistry::new();
+        reg.provider_started(hash(9));
+        reg.provider_progress(hash(9), 10);
+        reg.provider_finished(hash(9), true);
+        assert!(reg.list().is_empty());
+    }
+
+    #[test]
+    fn the_same_blob_sent_twice_resolves_oldest_offer_first() {
+        let reg = TransferRegistry::new();
+        let first = reg.register_send("laptop".into(), "photo.jpg".into(), 100, hash(1));
+        let second = reg.register_send("phone".into(), "photo.jpg".into(), 100, hash(1));
+
+        reg.provider_started(hash(1));
+        reg.provider_finished(hash(1), true);
+
+        let list = reg.list();
+        let a = list.iter().find(|t| t.id == first).unwrap();
+        let b = list.iter().find(|t| t.id == second).unwrap();
+        assert_eq!(a.state, TransferState::Done);
+        assert_eq!(b.state, TransferState::Offered, "the second offer is untouched");
+    }
+
+    #[test]
+    fn receive_tracks_bytes_and_completes() {
+        let reg = TransferRegistry::new();
+        let id = reg.register_receive("laptop".into(), "photo.jpg".into(), 100);
+
+        let t = &reg.list()[0];
+        assert!(!t.outgoing);
+        // A receive we drive ourselves is moving from the moment it is registered.
+        assert_eq!(t.state, TransferState::Transferring);
+
+        reg.note_progress(id, 40);
+        assert_eq!(reg.list()[0].transferred, 40);
+
+        reg.finish(id, true);
+        let t = &reg.list()[0];
+        assert_eq!(t.state, TransferState::Done);
+        assert_eq!(t.transferred, 100);
+    }
+
+    #[test]
+    fn a_failed_receive_fails() {
+        let reg = TransferRegistry::new();
+        let id = reg.register_receive("laptop".into(), "photo.jpg".into(), 100);
+        reg.finish(id, false);
+        assert_eq!(reg.list()[0].state, TransferState::Failed);
+    }
+
+    #[test]
+    fn finished_transfers_expire_but_live_ones_do_not() {
+        let reg = TransferRegistry::new();
+        let done = reg.register_receive("laptop".into(), "a.jpg".into(), 10);
+        reg.finish(done, true);
+        reg.register_receive("laptop".into(), "b.jpg".into(), 10);
+
+        let now = Instant::now();
+        assert_eq!(reg.list_at(now).len(), 2, "both visible right away");
+
+        let later = now + TERMINAL_TTL + Duration::from_secs(1);
+        let list = reg.list_at(later);
+        assert_eq!(list.len(), 1, "the finished one expired");
+        assert_eq!(list[0].filename, "b.jpg");
+    }
+}

--- a/src/daemon/transfers.rs
+++ b/src/daemon/transfers.rs
@@ -64,6 +64,26 @@ struct Entry {
     peer_id: Option<EndpointId>,
     /// When the transfer reached a terminal state, for TTL expiry.
     finished_at: Option<Instant>,
+    /// Outgoing only: how a `Failed` entry got there. Only a pull that was
+    /// aborted partway through is worth reviving on a retried `Started`; an
+    /// offer that never reached the peer (the dial, `open_bi`, or the offer
+    /// message itself failed) has nothing to retry, because the peer never
+    /// even knew about it.
+    failure: Option<FailureKind>,
+}
+
+/// How an outgoing entry reached `Failed`. Only set on the send side: a
+/// receive's `finish(id, false)` never needs to distinguish these, since
+/// nothing ever revives a receive entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FailureKind {
+    /// The offer itself never reached the peer (dial, `open_bi`, or the offer
+    /// message failed). Not revivable: there is no pull to retry.
+    Offer,
+    /// The peer received the offer and started pulling, but the pull was
+    /// aborted. Revivable: a later `Started` for the same `(hash, peer)` is a
+    /// genuine retry.
+    Abort,
 }
 
 #[derive(Default)]
@@ -106,6 +126,7 @@ impl TransferRegistry {
                 hash: Some(hash),
                 peer_id: Some(peer),
                 finished_at: None,
+                failure: None,
             },
         );
         id
@@ -129,6 +150,7 @@ impl TransferRegistry {
                 hash: None,
                 peer_id: None,
                 finished_at: None,
+                failure: None,
             },
         );
         id
@@ -143,23 +165,42 @@ impl TransferRegistry {
 
     pub fn finish(&self, id: u64, ok: bool) {
         if let Some(e) = self.entries.lock().unwrap().get_mut(&id) {
-            finish_entry(e, ok);
+            finish_entry(e, ok, None);
+        }
+    }
+
+    /// An outgoing offer failed before the peer could ever pull it: the dial,
+    /// `open_bi`, or the offer message itself failed. Distinct from `finish`
+    /// so this can be tagged not-revivable (see [`FailureKind::Offer`]):
+    /// nothing the peer does can retry a pull of an offer it never received.
+    pub fn fail_offer(&self, id: u64) {
+        if let Some(e) = self.entries.lock().unwrap().get_mut(&id) {
+            finish_entry(e, false, Some(FailureKind::Offer));
         }
     }
 
     /// A peer started pulling a blob. If the only entry for this `(hash, peer)`
-    /// pair already finished as `Failed` (an earlier pull was aborted), a fresh
-    /// `Started` revives it rather than leaving the sender stuck showing a failure
-    /// for a file that is now actually arriving: a retried pull after an aborted
-    /// one still deserves to end up `Done`.
+    /// pair already finished as `Failed` from an aborted pull (not an offer that
+    /// never reached the peer, see [`FailureKind`]), and it failed recently
+    /// enough to still be live (within `TERMINAL_TTL`; terminal entries are only
+    /// evicted lazily in `list_at`, so an older one could otherwise sit around
+    /// forever waiting to be revived), a fresh `Started` revives it rather than
+    /// leaving the sender stuck showing a failure for a file that is now
+    /// actually arriving: a retried pull after an aborted one still deserves to
+    /// end up `Done`.
     pub fn provider_started(&self, hash: Hash, peer: EndpointId) {
+        self.provider_started_at(hash, peer, Instant::now());
+    }
+
+    fn provider_started_at(&self, hash: Hash, peer: EndpointId, now: Instant) {
         let mut entries = self.entries.lock().unwrap();
         if let Some(id) = oldest_live_outgoing(&entries, hash, peer) {
             let e = entries.get_mut(&id).expect("id came from this map");
             e.info.state = TransferState::Transferring;
-        } else if let Some(id) = oldest_failed_outgoing(&entries, hash, peer) {
+        } else if let Some(id) = oldest_revivable_outgoing(&entries, hash, peer, now) {
             let e = entries.get_mut(&id).expect("id came from this map");
             e.finished_at = None;
+            e.failure = None;
             e.info.transferred = 0;
             e.info.state = TransferState::Transferring;
         }
@@ -178,7 +219,7 @@ impl TransferRegistry {
         let mut entries = self.entries.lock().unwrap();
         if let Some(id) = oldest_live_outgoing(&entries, hash, peer) {
             let e = entries.get_mut(&id).expect("id came from this map");
-            finish_entry(e, ok);
+            finish_entry(e, ok, Some(FailureKind::Abort));
         }
     }
 
@@ -238,7 +279,10 @@ impl Drop for FinishGuard {
 
 /// A finished transfer reads as complete: a Done that showed 60/100 because the
 /// last progress event was coarse would be a worse lie than rounding up.
-fn finish_entry(e: &mut Entry, ok: bool) {
+///
+/// `failure` records why an outgoing entry failed (ignored when `ok` is true,
+/// and for receive entries, which never get revived): see [`FailureKind`].
+fn finish_entry(e: &mut Entry, ok: bool, failure: Option<FailureKind>) {
     e.info.state = if ok {
         e.info.transferred = e.info.size;
         TransferState::Done
@@ -246,6 +290,7 @@ fn finish_entry(e: &mut Entry, ok: bool) {
         TransferState::Failed
     };
     e.finished_at = Some(Instant::now());
+    e.failure = if ok { None } else { failure };
 }
 
 /// The transfer a provider event belongs to: the oldest outgoing, not-yet-finished
@@ -261,14 +306,27 @@ fn oldest_live_outgoing(entries: &HashMap<u64, Entry>, hash: Hash, peer: Endpoin
         .min()
 }
 
-/// Like [`oldest_live_outgoing`] but for an entry that already finished as
-/// `Failed`, used only to revive a stuck `Failed` on a fresh `Started` event (see
-/// `provider_started`).
-fn oldest_failed_outgoing(entries: &HashMap<u64, Entry>, hash: Hash, peer: EndpointId) -> Option<u64> {
+/// Like [`oldest_live_outgoing`] but for an entry worth reviving on a fresh
+/// `Started` event (see `provider_started`): it must have failed on the pull
+/// path (not the offer path, which the peer never even received), and recently
+/// enough that it has not already aged past `TERMINAL_TTL`. Terminal entries
+/// are only evicted lazily inside `list_at`, so without the TTL check an entry
+/// that is logically dead but hasn't been swept yet could be revived and then
+/// never expire at all.
+fn oldest_revivable_outgoing(
+    entries: &HashMap<u64, Entry>,
+    hash: Hash,
+    peer: EndpointId,
+    now: Instant,
+) -> Option<u64> {
     entries
         .values()
         .filter(|e| {
-            e.hash == Some(hash) && e.peer_id == Some(peer) && e.info.state == TransferState::Failed
+            e.hash == Some(hash)
+                && e.peer_id == Some(peer)
+                && e.info.state == TransferState::Failed
+                && e.failure == Some(FailureKind::Abort)
+                && e.finished_at.is_some_and(|at| now.duration_since(at) < TERMINAL_TTL)
         })
         .map(|e| e.info.id)
         .min()
@@ -398,6 +456,51 @@ mod tests {
         assert_eq!(reg.list()[0].state, TransferState::Transferring);
         reg.provider_finished(hash(1), a, true);
         assert_eq!(reg.list()[0].state, TransferState::Done);
+    }
+
+    #[test]
+    fn a_started_event_does_not_revive_a_failed_send_past_its_ttl() {
+        // An entry that failed long enough ago to be past TERMINAL_TTL is dead:
+        // it is only evicted lazily inside `list_at`, so one that hasn't been
+        // swept yet must still not be revived, or it would become permanently
+        // live again with no terminal event ever following.
+        let reg = TransferRegistry::new();
+        let a = peer(1);
+        reg.register_send(a, "photo.jpg".into(), 100, hash(1));
+        reg.provider_started(hash(1), a);
+        reg.provider_finished(hash(1), a, false);
+        assert_eq!(reg.list()[0].state, TransferState::Failed);
+
+        let later = Instant::now() + TERMINAL_TTL + Duration::from_secs(1);
+        reg.provider_started_at(hash(1), a, later);
+        assert!(
+            reg.list_at(later).is_empty(),
+            "a Started arriving after the entry aged out must not revive it: it is dead, \
+             so it is just evicted like any other expired terminal entry"
+        );
+    }
+
+    #[test]
+    fn a_started_event_does_not_revive_an_offer_path_failure() {
+        // `send_file` calls `fail_offer` (not `finish`) when the dial, `open_bi`,
+        // or the offer message itself fails: the peer never received the offer,
+        // so there is no pull to retry. A later Started for the same (hash, peer)
+        // must not revive it, or the sender would show a false Done for a send
+        // whose offer never got out.
+        let reg = TransferRegistry::new();
+        let a = peer(1);
+        let id = reg.register_send(a, "photo.jpg".into(), 100, hash(1));
+        reg.fail_offer(id);
+        assert_eq!(reg.list()[0].state, TransferState::Failed);
+
+        // Somehow (a coincidental resend under the same hash, say) a Started
+        // shows up for this (hash, peer) pair anyway.
+        reg.provider_started(hash(1), a);
+        assert_eq!(
+            reg.list()[0].state,
+            TransferState::Failed,
+            "an offer-path failure is not revivable"
+        );
     }
 
     #[test]

--- a/src/daemon/transfers.rs
+++ b/src/daemon/transfers.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use iroh_blobs::Hash;
@@ -167,6 +167,44 @@ impl TransferRegistry {
         let mut out: Vec<TransferInfo> = entries.values().map(|e| e.info.clone()).collect();
         out.sort_by_key(|t| t.id);
         out
+    }
+}
+
+/// Guards a registered transfer against a cancelled future leaving it stuck in
+/// `Transferring` forever. Held across every fallible step of a receive; its
+/// `Drop` marks the transfer failed unless [`FinishGuard::success`] disarmed
+/// it first. Cheap and unconditionally correct: the only way to reach `Done`
+/// is through `success`, so a dropped future (or an early `return`) can never
+/// leave a completion notification pointing at a file that was never written.
+pub struct FinishGuard {
+    registry: Arc<TransferRegistry>,
+    id: u64,
+    armed: bool,
+}
+
+impl FinishGuard {
+    pub fn new(registry: Arc<TransferRegistry>, id: u64) -> Self {
+        Self {
+            registry,
+            id,
+            armed: true,
+        }
+    }
+
+    /// Mark the transfer done and disarm the guard. Call this only once the
+    /// work the transfer represents (fetch + write to disk) has fully
+    /// succeeded.
+    pub fn success(mut self) {
+        self.armed = false;
+        self.registry.finish(self.id, true);
+    }
+}
+
+impl Drop for FinishGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.registry.finish(self.id, false);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #74.

## Why

Android allows exactly one active `VpnService` at a time, and Rayfish's tunnel claims `100.64.0.0/10`, the same CGNAT range Tailscale uses. So running Tailscale on the phone meant giving up Rayfish entirely: turning our VPN off (or turning Tailscale on, which makes Android revoke us) tore the whole node down.

Nothing about file transfer needs the tunnel. Transfers ride the iroh endpoint over `FILES_ALPN` on ordinary sockets. Only app traffic routing needs the TUN.

## Standby, now the default

Disabling Rayfish on the phone now drops the data plane and **releases the VPN slot**, but leaves the control plane connected, so you can still send and receive files and the device stays visible in the mesh. Mobile standby means exactly what desktop `ray down` means: no TUN, no Magic DNS, no mesh routing, control plane up.

There is a setting in You, **"Go fully offline when disabled"** (off by default), for anyone who wants the old behavior where disabling takes the device all the way offline.

This covers both ways the tunnel goes away:

- the in-app toggle, and
- **Android revoking our VPN when another VPN app takes the slot** (`onRevoke`), which is the path users will actually hit. The default implementation of `onRevoke` calls `stopSelf()`, so without overriding it the whole feature would be bypassed by the exact flow it exists to serve.

Bring-up and teardown are serialized on a process-wide single-threaded executor, since a fast VPN off/on toggle is now a common operation.

## Honest transfer notifications

`send_file` returns as soon as the *offer* is delivered. The recipient pulls the bytes whenever it accepts, which for a manual accept can be minutes later or never. So the app used to claim "Sent" when it only meant "offered", and receiving was completely silent.

The core now tracks in-flight transfers:

- **Receive:** `accept_file` consumes the `GetProgress` stream from the blob fetch instead of discarding it, so bytes are reported as they land.
- **Send:** `BlobsProtocol` gets a real `EventSender`, so iroh-blobs provider events fire when a peer actually reads the blob out of our store. `TransferCompleted` is the authoritative "they have it". Events are matched on `(blob hash, peer endpoint id)`, so a pull by one peer cannot complete another peer's transfer, and a stranger who learns a hash cannot complete anyone's.

Exposed as `Node.list_transfers()`; Kotlin polls it to drive a progress bar and a result notification. "Sent" now means the recipient has the file.

No wire format, control message, or ALPN version change.

## Known follow-up: polling

The app is pull-only across the FFI, so Kotlin polls (a 4s auto-accept poll in the service, a 2s poll in HomeScreen). That 4s wakeup now also runs in standby, which is battery spent on a timer rather than on an event.

This is worth fixing properly rather than papering over: the core already auto-accepts own-device files on push (`try_auto_accept_file`, from the `FILES_ALPN` accept arm) and only bails on Android because no download target is configured. A uniffi callback interface would let the core push offer and transfer events to Kotlin, delete all three poll loops, and make standby genuinely idle. That is its own PR, stacked on this one.

## Verification

`cargo build`, `cargo clippy --all-targets -D warnings`, and `cargo test` (362 + 24) are green, and `gradlew :app:compileDebugKotlin` builds.

**Not yet verified on hardware.** The daemon needs root for the TUN, and the Android app has no test source set, so the Kotlin side is verified by compilation and review only. Before merging, this wants a device pass:

1. Switch **Tailscale** on: the phone must stay online and a peer's `ray send` must still land in Downloads. This is the whole point of the change, and under the new default it needs no setup at all.
2. Send to a paired device with auto-accept on and confirm the **sender** reaches "Sent" rather than sticking at "Offered". This checks the one load-bearing assumption I could not test: that the `EndpointId` in the provider's `ClientConnected` equals the one `resolve_peer_flexible` returned when the offer was sent. If they ever differ, every send sits at "Offered" forever with no error.
3. Send to a peer with auto-accept off, leave the offer pending, then accept: the progress bar must complete only then.
4. Turn "Go fully offline when disabled" on, then disable Rayfish: the device must go fully offline, exactly as it does today.

## Out of scope

- Reboot survival (no `BOOT_COMPLETED` receiver). Standby resumes when the app is next opened.
- Files are still buffered whole in memory on both send and receive, which is an OOM risk for large videos on a phone. Pre-existing, its own issue.