### PR TITLE
feat(files): pass the ray send file as an fd over IPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`ray send` now works from Documents, Desktop, and other protected folders on
+  macOS, and for files only your user can read.** The CLI used to hand the daemon
+  a path and the daemon (running as root) did the read, which failed with
+  `Operation not permitted` in TCC-protected folders (the daemon has no Full Disk
+  Access, and root does not bypass TCC) and quietly meant the daemon would read
+  anything root could. `ray send` now opens the file itself, with your own
+  permissions, and passes the open file descriptor to the daemon over the IPC
+  socket (SCM_RIGHTS), so the daemon never touches a path on your behalf. An
+  updated CLI still falls back to the old path-based request when talking to a
+  daemon that predates this.
+
 - **`ray send` now works with relative paths.** The path was resolved by the
   daemon, whose working directory is not the caller's, so `ray send ./file peer`
   failed with `No such file or directory` even though the file was right there.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4861,15 +4861,17 @@ dependencies = [
 
 [[package]]
 name = "ray-proto"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "bytes",
  "derive_more 2.1.1",
  "futures",
  "iroh",
+ "nix 0.30.1",
  "rmp-serde",
  "serde",
+ "tempfile",
  "tokio",
  "tokio-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ otel = [
 ]
 
 [dependencies]
-ray-proto = { path = "ray-proto", version = "0.1.6" }
+ray-proto = { path = "ray-proto", version = "0.1.7" }
 anyhow = "1"
 blake3 = { version = "1", features = ["serde"] }
 bytes = "1"

--- a/ray-proto/Cargo.toml
+++ b/ray-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ray-proto"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Dario <dario@rayfish.xyz>"]
@@ -19,7 +19,13 @@ bytes = "1"
 derive_more = { version = "2", features = ["is_variant", "display"] }
 futures = "0.3"
 iroh = { version = "1" }
+# SCM_RIGHTS fd passing for `SendFileFd` (sendmsg/recvmsg with ancillary data).
+nix = { version = "0.30", features = ["socket", "uio"] }
 rmp-serde = "1"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["net"] }
 tokio-util = { version = "0.7", features = ["codec"] }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["net", "rt", "macros"] }

--- a/ray-proto/src/ipc.rs
+++ b/ray-proto/src/ipc.rs
@@ -1,12 +1,15 @@
 use std::collections::BTreeMap;
+use std::io::{IoSlice, IoSliceMut};
 use std::marker::PhantomData;
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use bytes::{Bytes, BytesMut};
 use iroh::EndpointId;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use tokio::io::Interest;
 use tokio::net::UnixStream;
 use tokio_util::codec::{Decoder, Encoder, Framed, LengthDelimitedCodec};
 
@@ -211,6 +214,15 @@ pub enum IpcMessage {
     },
     SendFile {
         path: String,
+        peer: String,
+    },
+    /// Send a file to a peer, passing the already-open file as an SCM_RIGHTS
+    /// descriptor on the same connection (see [`send_with_fd`]). The client
+    /// opens the file with its own privileges, so filesystem permissions and
+    /// macOS TCC grants apply to the caller, not to the root daemon. `SendFile`
+    /// stays for frontends that cannot pass descriptors.
+    SendFileFd {
+        filename: String,
         peer: String,
     },
     ListFiles,
@@ -834,6 +846,104 @@ pub async fn recv(framed: &mut IpcFramed) -> Result<IpcMessage> {
     framed.next().await.context("connection closed")?
 }
 
+/// Cap on SCM_RIGHTS descriptors accepted per request. One is all any message
+/// uses today; the cap keeps a hostile client from stuffing the daemon's fd
+/// table through a single connection.
+pub const MAX_IPC_FDS: usize = 4;
+
+/// Send `msg` as a normal length-prefixed frame with `fd` attached to its
+/// first byte as SCM_RIGHTS ancillary data. The receiver must read with
+/// [`recv_with_fds`]: a plain `read()` consumes the bytes but silently drops
+/// the descriptor.
+pub async fn send_with_fd(stream: &UnixStream, msg: &IpcMessage, fd: BorrowedFd<'_>) -> Result<()> {
+    use nix::sys::socket::{ControlMessage, MsgFlags, sendmsg};
+
+    let body = rmp_serde::to_vec_named(msg).context("serialize IPC message")?;
+    let mut frame = Vec::with_capacity(4 + body.len());
+    frame.extend_from_slice(&u32::try_from(body.len())?.to_be_bytes());
+    frame.extend_from_slice(&body);
+
+    let mut sent = 0;
+    let mut fd_sent = false;
+    while sent < frame.len() {
+        let n = stream
+            .async_io(Interest::WRITABLE, || {
+                let iov = [IoSlice::new(&frame[sent..])];
+                let fds = [fd.as_raw_fd()];
+                // The descriptor rides the first sendmsg that accepts bytes;
+                // continuation writes after a partial send carry no ancillary.
+                let cmsgs: &[ControlMessage] = if fd_sent {
+                    &[]
+                } else {
+                    &[ControlMessage::ScmRights(&fds)]
+                };
+                sendmsg::<()>(stream.as_raw_fd(), &iov, cmsgs, MsgFlags::empty(), None)
+                    .map_err(std::io::Error::from)
+            })
+            .await?;
+        fd_sent = true;
+        sent += n;
+    }
+    Ok(())
+}
+
+/// Read one request frame, capturing any SCM_RIGHTS descriptors delivered
+/// with it. The daemon reads every request through this (not through the
+/// framed codec) because ancillary data is only surfaced by `recvmsg` with a
+/// control buffer; any other read on the socket would drop the descriptors.
+pub async fn recv_with_fds(stream: &UnixStream) -> Result<(IpcMessage, Vec<OwnedFd>)> {
+    use nix::sys::socket::{ControlMessageOwned, MsgFlags, recvmsg};
+
+    let mut buf: Vec<u8> = Vec::new();
+    let mut fds: Vec<OwnedFd> = Vec::new();
+    loop {
+        if buf.len() >= 4 {
+            let len = u32::from_be_bytes(buf[..4].try_into().unwrap()) as usize;
+            if len > MAX_FRAME_LEN {
+                anyhow::bail!("IPC frame too large ({len} bytes)");
+            }
+            if buf.len() >= 4 + len {
+                let msg = rmp_serde::from_slice(&buf[4..4 + len]).context("decode IPC message")?;
+                return Ok((msg, fds));
+            }
+        }
+
+        let mut chunk = [0u8; 8192];
+        let (n, mut got) = stream
+            .async_io(Interest::READABLE, || {
+                let mut iov = [IoSliceMut::new(&mut chunk)];
+                let mut cmsg_buf = nix::cmsg_space!([RawFd; MAX_IPC_FDS]);
+                // CLOEXEC on Linux/Android so a received fd never leaks into a
+                // spawned child; macOS has no MSG_CMSG_CLOEXEC.
+                #[cfg(any(target_os = "linux", target_os = "android"))]
+                let flags = MsgFlags::MSG_CMSG_CLOEXEC;
+                #[cfg(not(any(target_os = "linux", target_os = "android")))]
+                let flags = MsgFlags::empty();
+                let msg = recvmsg::<()>(stream.as_raw_fd(), &mut iov, Some(&mut cmsg_buf), flags)
+                    .map_err(std::io::Error::from)?;
+                let mut received = Vec::new();
+                for cmsg in msg.cmsgs().map_err(std::io::Error::from)? {
+                    if let ControlMessageOwned::ScmRights(raw) = cmsg {
+                        // SAFETY: the kernel just installed these descriptors in
+                        // our fd table for this process; we are their sole owner.
+                        received.extend(raw.iter().map(|&r| unsafe { OwnedFd::from_raw_fd(r) }));
+                    }
+                }
+                Ok((msg.bytes, received))
+            })
+            .await?;
+        if n == 0 {
+            anyhow::bail!("connection closed mid-frame");
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        fds.append(&mut got);
+        if fds.len() > MAX_IPC_FDS {
+            // Dropping the OwnedFds closes everything the client pushed.
+            anyhow::bail!("too many file descriptors in IPC request");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -854,6 +964,76 @@ mod tests {
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[tokio::test]
+    async fn send_file_fd_roundtrip() {
+        use std::io::{Read, Seek, SeekFrom, Write};
+        use std::os::fd::AsFd;
+
+        let (client, server) = UnixStream::pair().unwrap();
+        let mut file = tempfile::tempfile().unwrap();
+        file.write_all(b"payload bytes").unwrap();
+        file.seek(SeekFrom::Start(0)).unwrap();
+
+        let msg = IpcMessage::SendFileFd {
+            filename: "report.pdf".to_string(),
+            peer: "peer1".to_string(),
+        };
+        send_with_fd(&client, &msg, file.as_fd()).await.unwrap();
+
+        let (decoded, fds) = recv_with_fds(&server).await.unwrap();
+        match decoded {
+            IpcMessage::SendFileFd { filename, peer } => {
+                assert_eq!(filename, "report.pdf");
+                assert_eq!(peer, "peer1");
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+        assert_eq!(fds.len(), 1);
+
+        let mut received = std::fs::File::from(fds.into_iter().next().unwrap());
+        let mut contents = String::new();
+        received.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "payload bytes");
+    }
+
+    #[tokio::test]
+    async fn recv_with_fds_handles_plain_frames() {
+        use futures::SinkExt;
+
+        let (client, server) = UnixStream::pair().unwrap();
+        let mut framed = framed(client);
+        framed.send(IpcMessage::Status).await.unwrap();
+
+        let (decoded, fds) = recv_with_fds(&server).await.unwrap();
+        assert!(matches!(decoded, IpcMessage::Status));
+        assert!(fds.is_empty());
+    }
+
+    #[tokio::test]
+    async fn send_file_fd_survives_multi_chunk_frames() {
+        use std::os::fd::AsFd;
+
+        let (client, server) = UnixStream::pair().unwrap();
+        let file = tempfile::tempfile().unwrap();
+
+        // A frame much larger than the 8 KiB recv chunk, so the descriptor
+        // (attached to the first bytes) must survive a multi-read assembly.
+        let msg = IpcMessage::SendFileFd {
+            filename: "x".repeat(100 * 1024),
+            peer: "peer1".to_string(),
+        };
+        let send = send_with_fd(&client, &msg, file.as_fd());
+        let recv = recv_with_fds(&server);
+        let (sent, received) = tokio::join!(send, recv);
+        sent.unwrap();
+        let (decoded, fds) = received.unwrap();
+        match decoded {
+            IpcMessage::SendFileFd { filename, .. } => assert_eq!(filename.len(), 100 * 1024),
+            other => panic!("wrong variant: {other:?}"),
+        }
+        assert_eq!(fds.len(), 1);
     }
 
     #[test]

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -3,22 +3,51 @@
 use crate::*;
 
 pub(crate) async fn ipc_send_file(file: &str, peer: &str) -> Result<()> {
-    // The daemon does the read and its cwd is not the caller's: resolve the
-    // path against the client's cwd before it crosses the IPC boundary.
+    use std::fs::File;
+    use std::os::fd::AsFd;
+
     let path = std::path::absolute(file).with_context(|| format!("cannot resolve '{file}'"))?;
-    if !path.is_file() {
-        anyhow::bail!("cannot read '{}': no such file", path.display());
+    // Open here, in the caller's privilege domain, and pass the descriptor:
+    // the daemon never touches the path, so files the daemon can't read (TCC
+    // folders on macOS, user-only files) work as long as *we* can open them.
+    let opened = File::open(&path).with_context(|| format!("cannot read '{}'", path.display()))?;
+    if !opened.metadata()?.is_file() {
+        anyhow::bail!("cannot send '{}': not a regular file", path.display());
     }
+    let filename = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "file".to_string());
+
     let mut stream = ipc::connect().await?;
-    ipc::send(
-        &mut stream,
-        ipc::IpcMessage::SendFile {
-            path: path.to_string_lossy().to_string(),
+    ipc::send_with_fd(
+        stream.get_ref(),
+        &ipc::IpcMessage::SendFileFd {
+            filename,
             peer: peer.to_string(),
         },
+        opened.as_fd(),
     )
     .await?;
-    let resp = ipc::recv(&mut stream).await?;
+    let resp = match ipc::recv(&mut stream).await {
+        Ok(resp) => resp,
+        // A daemon predating `SendFileFd` fails to decode the request and
+        // drops the connection without a reply (never with an `Error`
+        // response). Retry once the old way, path over IPC, so an updated CLI
+        // keeps working until the daemon restarts onto the new binary.
+        Err(_) => {
+            let mut stream = ipc::connect().await?;
+            ipc::send(
+                &mut stream,
+                ipc::IpcMessage::SendFile {
+                    path: path.to_string_lossy().to_string(),
+                    peer: peer.to_string(),
+                },
+            )
+            .await?;
+            ipc::recv(&mut stream).await?
+        }
+    };
     match resp {
         ipc::IpcMessage::Ok { message } => println!("{}", message),
         ipc::IpcMessage::Error { message } => print_error("error", &message, None),

--- a/src/daemon/file_service.rs
+++ b/src/daemon/file_service.rs
@@ -11,6 +11,7 @@
 use super::transfers;
 use super::*;
 use std::ffi::CString;
+use std::io::Read;
 use std::path::PathBuf;
 
 use futures::StreamExt;
@@ -361,14 +362,10 @@ impl FileService {
     }
 
     /// Add a file to the blob store and offer it to a peer over `FILES_ALPN`.
+    /// The read happens daemon-side, so this only works for paths the daemon
+    /// itself can see; IPC clients use `send_file_fd`. Kept for in-process
+    /// callers (ray-mobile), where daemon and app share one privilege domain.
     pub(crate) async fn send_file(&self, path: &str, peer: &str) -> IpcMessage {
-        let peer_id = match self.registry.resolve_peer_flexible(peer).await {
-            Some(id) => id,
-            None => {
-                return ipc_err(format!("unknown peer '{peer}'"));
-            }
-        };
-
         let file_path = Path::new(path);
         let file_bytes = match std::fs::read(file_path) {
             Ok(b) => b,
@@ -376,11 +373,49 @@ impl FileService {
                 return ipc_err(format!("cannot read '{}': {e}", file_path.display()));
             }
         };
-
         let filename = file_path
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| "file".to_string());
+        self.send_bytes(file_bytes, filename, peer).await
+    }
+
+    /// `send_file` for a descriptor received over IPC (`SendFileFd`): the
+    /// client opened the file with its own privileges, the daemon never
+    /// resolves a path. This is what lets `ray send` reach TCC-protected
+    /// folders on macOS and files the daemon can't read but the caller can.
+    pub(crate) async fn send_file_fd(&self, fd: OwnedFd, filename: &str, peer: &str) -> IpcMessage {
+        let mut file = File::from(fd);
+        // fstat before reading: an fd is attacker-chosen input, and reading a
+        // FIFO or a device (/dev/zero) here would stall or balloon the daemon.
+        match file.metadata() {
+            Ok(m) if m.is_file() => {}
+            Ok(_) => return ipc_err("not a regular file"),
+            Err(e) => return ipc_err(format!("cannot stat file: {e}")),
+        }
+        let mut file_bytes = Vec::new();
+        if let Err(e) = file.read_to_end(&mut file_bytes) {
+            return ipc_err(format!("cannot read file: {e}"));
+        }
+        // The client names the file; keep only the basename so a hostile
+        // client can't smuggle path components into the offer.
+        let filename = Path::new(filename)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "file".to_string());
+        self.send_bytes(file_bytes, filename, peer).await
+    }
+
+    /// Shared tail of the send flow: blob-store the bytes and deliver the
+    /// offer to the peer over `FILES_ALPN`.
+    async fn send_bytes(&self, file_bytes: Vec<u8>, filename: String, peer: &str) -> IpcMessage {
+        let peer_id = match self.registry.resolve_peer_flexible(peer).await {
+            Some(id) => id,
+            None => {
+                return ipc_err(format!("unknown peer '{peer}'"));
+            }
+        };
+
         let size = file_bytes.len() as u64;
         let mime_type = guess_mime_type(&filename);
         let hash = blake3::hash(&file_bytes);

--- a/src/daemon/mesh/bootstrap.rs
+++ b/src/daemon/mesh/bootstrap.rs
@@ -661,9 +661,11 @@ fn set_socket_permissions(path: &std::path::Path) {
 
 async fn handle_ipc_client(stream: UnixStream, daemon: &Arc<Daemon>) -> Result<()> {
     let peer_cred = stream.peer_cred().ok().map(|c| (c.uid(), c.gid()));
+    // The request is read fd-aware: `SendFileFd` arrives with the file as
+    // SCM_RIGHTS ancillary data, which a plain framed read would drop.
+    let (req, fds) = ipc::recv_with_fds(&stream).await?;
+    let resp = daemon.handle_request(req, peer_cred, fds).await;
     let mut framed = ipc::framed(stream);
-    let req = ipc::recv(&mut framed).await?;
-    let resp = daemon.handle_request(req, peer_cred).await;
     ipc::send(&mut framed, resp).await?;
     Ok(())
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -41,6 +41,7 @@ use iroh_metrics::service::MetricsServer;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs::File;
 use std::net::{Ipv4Addr, SocketAddr};
+use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
@@ -917,6 +918,7 @@ impl Daemon {
         self: &Arc<Self>,
         req: IpcMessage,
         peer_cred: Option<(u32, u32)>,
+        mut fds: Vec<OwnedFd>,
     ) -> IpcMessage {
         if let Some(denied) = Self::check_authorized(&req, peer_cred) {
             return denied;
@@ -1036,6 +1038,10 @@ impl Daemon {
             }
             IpcMessage::AliasList { network } => self.registry.list_aliases(&network),
             IpcMessage::SendFile { path, peer } => self.send_file(&path, &peer).await,
+            IpcMessage::SendFileFd { filename, peer } => match fds.pop() {
+                Some(fd) => self.files.send_file_fd(fd, &filename, &peer).await,
+                None => ipc_err("SendFileFd request carried no file descriptor"),
+            },
             IpcMessage::ListFiles => self.list_files(),
             IpcMessage::AcceptFile { id, output } => {
                 self.files.accept_file(id, output, peer_cred).await


### PR DESCRIPTION
Closes #104.

## Problem

`ray send` shipped a path over IPC and the daemon, running as root, did the read. Two failures fall out of that:

- On macOS, sending from Documents/Desktop/Downloads fails with `Operation not permitted`: those folders are TCC-protected, the daemon has no Full Disk Access grant, and root does not bypass TCC. Hit in the wild today.
- The daemon reads with root's privileges, so any operator-authorized user could make it read files they cannot read themselves.

## Change

- New `IpcMessage::SendFileFd { filename, peer }`: the CLI opens the file with the caller's own privileges and attaches the descriptor as SCM_RIGHTS ancillary data on the same connection (`ipc::send_with_fd`). Permission checks (and TCC) happen at `open()` in the client; the daemon never resolves a client path.
- The daemon reads every IPC request through `ipc::recv_with_fds`, a recvmsg-based frame reader that captures ancillary descriptors. A plain `read()` would silently drop them, so the request read path had to move off the framed codec; responses still go through it. Received fds are CLOEXEC on Linux/Android, capped at 4 per request, and unclaimed ones are closed on drop.
- `FileService` splits into `send_file` (path, kept for in-process callers like ray-mobile, where app and daemon share one privilege domain), `send_file_fd` (fstat-rejects non-regular files so a client cannot hand the daemon a FIFO or /dev/zero, basename-sanitizes the client-supplied filename), and a shared `send_bytes` tail.
- Version skew: an old CLI against a new daemon works (plain frames read fine through `recv_with_fds`, covered by a test). A new CLI against an old daemon gets its connection dropped on the unknown variant and falls back to the legacy path-based `SendFile` once.
- ray-proto 0.1.6 to 0.1.7 (additive variant, new `nix` dependency for sendmsg/recvmsg).

## Testing

- Three new ray-proto tests: fd roundtrip over a socketpair (descriptor arrives and reads back the right bytes), plain frames through `recv_with_fds` (old-CLI compat), and a 100 KiB frame so the fd survives multi-chunk assembly.
- Fallback verified live against the currently installed (pre-`SendFileFd`) daemon: the new CLI's fd request is dropped, the retry lands, auth and peer resolution respond normally.
- Not yet verified live: new CLI against new daemon end-to-end (needs the daemon restarted onto this build; will do as part of rollout).
- `cargo clippy --all-targets` clean, full workspace check, 362 + 24 + 14 tests pass.