### PR TITLE
feat(files): queue ray send offers and deliver when the peer comes online

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Linux (glibc and musl) and macOS on every change. rayfish.xyz serves a copy of
   this file, and its CI fails if the two drift apart.
 
+- **`ray send` no longer blocks, and sending to an offline device just works.**
+  The command returns as soon as the daemon has the file: if the peer is
+  connected the offer goes out immediately, otherwise it is queued and delivered
+  automatically the moment the device comes back online (sends survive a daemon
+  restart). Queued sends show up in `ray files` and can be dropped with
+  `ray files cancel <id>`. Previously `ray send` sat silent for as long as the
+  dial took and failed outright if the peer was offline.
+- **`ray send` takes multiple files.** `ray send <peer> <file> <file> ...` sends
+  each one; a failure on one file doesn't stop the rest.
+
+### Changed
+
+- **`ray send` argument order flipped** to make room for multiple files: it is
+  now `ray send <peer> <files...>` (was `ray send <file> <peer>`). The `--json`
+  output of `ray files` is now an object with `pending` (inbound offers) and
+  `queued` (outbound sends) arrays instead of a bare array.
+
 ### Fixed
 
 - **`ray send` now works from Documents, Desktop, and other protected folders on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "ray-proto"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ otel = [
 ]
 
 [dependencies]
-ray-proto = { path = "ray-proto", version = "0.1.7" }
+ray-proto = { path = "ray-proto", version = "0.1.8" }
 anyhow = "1"
 blake3 = { version = "1", features = ["serde"] }
 bytes = "1"

--- a/ray-mobile/src/lib.rs
+++ b/ray-mobile/src/lib.rs
@@ -666,7 +666,7 @@ impl Node {
     pub fn list_file_offers(&self) -> Result<Vec<FileOffer>, RayError> {
         let state = self.state()?;
         match state.list_files() {
-            IpcMessage::FileList { files } => Ok(files
+            IpcMessage::FileList { files, .. } => Ok(files
                 .into_iter()
                 .map(|f| FileOffer {
                     id: f.id,

--- a/ray-proto/Cargo.toml
+++ b/ray-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ray-proto"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Dario <dario@rayfish.xyz>"]

--- a/ray-proto/src/ipc.rs
+++ b/ray-proto/src/ipc.rs
@@ -226,6 +226,11 @@ pub enum IpcMessage {
         peer: String,
     },
     ListFiles,
+    /// Cancel a queued outbound send (`ray files cancel <id>`). Only reaches
+    /// sends still waiting in the outbox; a delivered offer is the peer's now.
+    CancelSend {
+        id: u64,
+    },
     AcceptFile {
         id: u64,
         output: Option<String>,
@@ -500,6 +505,10 @@ pub enum IpcMessage {
     },
     FileList {
         files: Vec<PendingFileInfo>,
+        /// Outbound sends queued for delivery (peer offline). Absent on daemons
+        /// that predate queued sends.
+        #[serde(default)]
+        outbox: Vec<OutboxFileInfo>,
     },
     PairingTicket {
         ticket: String,
@@ -628,6 +637,16 @@ pub struct PendingRequestInfo {
     pub waiting_secs: u64,
 }
 
+/// An outbound send waiting in the daemon's outbox for its peer to come online.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OutboxFileInfo {
+    pub id: u64,
+    /// The peer name as given to `ray send` (hostname or short id).
+    pub peer: String,
+    pub filename: String,
+    pub size: u64,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PendingFileInfo {
     pub id: u64,
@@ -714,7 +733,9 @@ pub struct PeerStatus {
 }
 
 /// Three-state peer liveness for `ray status`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, derive_more::IsVariant)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, derive_more::IsVariant,
+)]
 pub enum PeerState {
     /// A live mesh connection to the peer exists right now.
     Active,

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -2,7 +2,24 @@
 
 use crate::*;
 
-pub(crate) async fn ipc_send_file(file: &str, peer: &str) -> Result<()> {
+/// `ray send <peer> <files...>`: one `SendFileFd` request per file. Each file
+/// gets its own IPC connection (the protocol is one request per connection);
+/// a failure on one file still sends the rest.
+pub(crate) async fn ipc_send_files(files: &[String], peer: &str) -> Result<()> {
+    let mut failed = false;
+    for file in files {
+        if let Err(e) = ipc_send_file(file, peer).await {
+            print_error("error", &format!("{file}: {e:#}"), None);
+            failed = true;
+        }
+    }
+    if failed {
+        anyhow::bail!("some files were not sent");
+    }
+    Ok(())
+}
+
+async fn ipc_send_file(file: &str, peer: &str) -> Result<()> {
     use std::fs::File;
     use std::os::fd::AsFd;
 
@@ -91,7 +108,8 @@ pub(crate) async fn ipc_files(action: Option<FilesAction>) -> Result<()> {
                 let uid = crate::uid_for_user(u).ok_or_else(|| {
                     anyhow::anyhow!("unknown user '{u}' (pass a valid username or uid)")
                 })?;
-                return crate::ipc_mutate(ipc::IpcMessage::SetDownloadUser { uid: Some(uid) }).await;
+                return crate::ipc_mutate(ipc::IpcMessage::SetDownloadUser { uid: Some(uid) })
+                    .await;
             }
             let mut stream = ipc::connect().await?;
             ipc::send(&mut stream, ipc::IpcMessage::GetDownloadSettings).await?;
@@ -114,9 +132,9 @@ pub(crate) async fn ipc_files(action: Option<FilesAction>) -> Result<()> {
             ipc::send(&mut stream, ipc::IpcMessage::ListFiles).await?;
             let resp = ipc::recv(&mut stream).await?;
             match resp {
-                ipc::IpcMessage::FileList { files } => {
+                ipc::IpcMessage::FileList { files, outbox } => {
                     if json_enabled() {
-                        let arr: Vec<_> = files
+                        let inbound: Vec<_> = files
                             .iter()
                             .map(|f| {
                                 serde_json::json!({
@@ -125,34 +143,75 @@ pub(crate) async fn ipc_files(action: Option<FilesAction>) -> Result<()> {
                                 })
                             })
                             .collect();
-                        print_json(&serde_json::json!(arr));
-                    } else if files.is_empty() {
-                        println!("\n  {}\n", style::faint("no pending file transfers"));
-                    } else {
-                        let rows = files
+                        let queued: Vec<_> = outbox
                             .iter()
                             .map(|f| {
-                                let accept = format!("ray files accept {}", f.id);
-                                vec![
-                                    layout::Cell::new(
-                                        f.id.to_string(),
-                                        style::rose(&f.id.to_string()),
-                                    ),
-                                    layout::Cell::new(f.from.clone(), style::value(&f.from)),
-                                    layout::Cell::right(
-                                        format_size(f.size),
-                                        style::faint(&format_size(f.size)),
-                                    ),
-                                    layout::Cell::new(
-                                        f.filename.clone(),
-                                        style::value(&f.filename),
-                                    ),
-                                    layout::Cell::new(accept.clone(), style::faint(&accept)),
-                                ]
+                                serde_json::json!({
+                                    "id": f.id, "to": f.peer, "filename": f.filename,
+                                    "size": f.size,
+                                })
                             })
                             .collect();
-                        println!();
-                        print!("{}", table(&["id", "from", "size", "file", ""], rows, 2));
+                        print_json(&serde_json::json!({"pending": inbound, "queued": queued}));
+                    } else if files.is_empty() && outbox.is_empty() {
+                        println!("\n  {}\n", style::faint("no pending file transfers"));
+                    } else {
+                        if !files.is_empty() {
+                            let rows = files
+                                .iter()
+                                .map(|f| {
+                                    let accept = format!("ray files accept {}", f.id);
+                                    vec![
+                                        layout::Cell::new(
+                                            f.id.to_string(),
+                                            style::rose(&f.id.to_string()),
+                                        ),
+                                        layout::Cell::new(f.from.clone(), style::value(&f.from)),
+                                        layout::Cell::right(
+                                            format_size(f.size),
+                                            style::faint(&format_size(f.size)),
+                                        ),
+                                        layout::Cell::new(
+                                            f.filename.clone(),
+                                            style::value(&f.filename),
+                                        ),
+                                        layout::Cell::new(accept.clone(), style::faint(&accept)),
+                                    ]
+                                })
+                                .collect();
+                            println!();
+                            print!("{}", table(&["id", "from", "size", "file", ""], rows, 2));
+                        }
+                        if !outbox.is_empty() {
+                            let rows = outbox
+                                .iter()
+                                .map(|f| {
+                                    let cancel = format!("ray files cancel {}", f.id);
+                                    vec![
+                                        layout::Cell::new(
+                                            f.id.to_string(),
+                                            style::rose(&f.id.to_string()),
+                                        ),
+                                        layout::Cell::new(f.peer.clone(), style::value(&f.peer)),
+                                        layout::Cell::right(
+                                            format_size(f.size),
+                                            style::faint(&format_size(f.size)),
+                                        ),
+                                        layout::Cell::new(
+                                            f.filename.clone(),
+                                            style::value(&f.filename),
+                                        ),
+                                        layout::Cell::new(cancel.clone(), style::faint(&cancel)),
+                                    ]
+                                })
+                                .collect();
+                            println!();
+                            println!(
+                                "  {}",
+                                style::faint("queued sends (deliver when the peer comes online)")
+                            );
+                            print!("{}", table(&["id", "to", "size", "file", ""], rows, 2));
+                        }
                         println!();
                     }
                 }
@@ -173,6 +232,16 @@ pub(crate) async fn ipc_files(action: Option<FilesAction>) -> Result<()> {
             let resp = ipc::recv(&mut stream).await?;
             spinner.finish_and_clear();
             match resp {
+                ipc::IpcMessage::Ok { message } => {
+                    println!("  {} {}", style::check(), style::value(&message));
+                }
+                ipc::IpcMessage::Error { message } => print_error("error", &message, None),
+                other => eprintln!("Unexpected response: {:?}", other),
+            }
+        }
+        Some(FilesAction::Cancel { id }) => {
+            ipc::send(&mut stream, ipc::IpcMessage::CancelSend { id }).await?;
+            match ipc::recv(&mut stream).await? {
                 ipc::IpcMessage::Ok { message } => {
                     println!("  {} {}", style::check(), style::value(&message));
                 }

--- a/src/daemon/connection_manager.rs
+++ b/src/daemon/connection_manager.rs
@@ -24,6 +24,11 @@ use super::*;
 pub(crate) struct MeshDispatch {
     pub(crate) ctx: MeshCtx,
     pub(crate) token: CancellationToken,
+    /// Fired once per mesh connection as it starts (dialed or accepted), with
+    /// the peer's id. Wired by the composition root to the file-service send
+    /// outbox, which delivers queued offers the moment their peer reappears;
+    /// the manager stays ignorant of who listens.
+    pub(crate) on_peer_connected: Arc<dyn Fn(EndpointId) + Send + Sync>,
 }
 
 pub(crate) struct ConnectionManager {
@@ -50,6 +55,14 @@ impl ConnectionManager {
 
     /// Install the daemon-wide mesh dispatch context. Called once by
     /// `Daemon` right after it is built.
+    /// Invoke the composition-root peer-connected hook (no-op before dispatch
+    /// is installed). Called by each `MeshConnection` as its run loop starts.
+    pub(crate) fn notify_peer_connected(&self, peer: EndpointId) {
+        if let Some(mesh) = self.mesh.get() {
+            (mesh.on_peer_connected)(peer);
+        }
+    }
+
     pub(crate) fn set_mesh_dispatch(&self, dispatch: MeshDispatch) {
         let _ = self.mesh.set(dispatch);
     }

--- a/src/daemon/file_service.rs
+++ b/src/daemon/file_service.rs
@@ -16,6 +16,48 @@ use std::path::PathBuf;
 
 use futures::StreamExt;
 use iroh_blobs::api::remote::GetProgressItem;
+use serde::{Deserialize, Serialize};
+
+/// Upper bound on one background offer dial. `Endpoint::connect` retries
+/// discovery with no timeout of its own; the outbox retries on the next
+/// peer-connected event anyway, so a stuck dial must not pin the flush task.
+const OFFER_CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How often the outbox re-attempts delivery to peers that currently hold a
+/// live mesh connection. The peer-connected hook is the primary trigger; this
+/// sweep only catches offers whose delivery failed transiently while the
+/// connection stayed up.
+pub(crate) const OUTBOX_SWEEP_INTERVAL: Duration = Duration::from_secs(120);
+
+fn outbox_path() -> Option<PathBuf> {
+    config::config_dir().ok().map(|d| d.join("outbox.json"))
+}
+
+fn load_outbox() -> Vec<OutboxEntry> {
+    let Some(path) = outbox_path() else {
+        return Vec::new();
+    };
+    match std::fs::read(&path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "unreadable send outbox; starting empty");
+            Vec::new()
+        }),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// An outbound send waiting for its peer. Persisted (JSON, in the config dir)
+/// so a queued send survives a daemon restart; the bytes themselves already
+/// live in the persistent blob store. `id` is session-local, reassigned on load.
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct OutboxEntry {
+    #[serde(skip)]
+    pub(crate) id: u64,
+    pub(crate) peer: EndpointId,
+    pub(crate) filename: String,
+    pub(crate) size: u64,
+    pub(crate) blob_hash: blake3::Hash,
+}
 
 /// A received file offer awaiting `ray files accept`.
 pub(crate) struct PendingFile {
@@ -46,6 +88,13 @@ pub(crate) struct FileService {
     device_user_map: peers::DeviceUserMap,
     /// In-flight transfers, for progress reporting.
     pub(crate) transfers: Arc<transfers::TransferRegistry>,
+    /// Outbound sends awaiting delivery (peer offline, or the offer dial
+    /// failed). Flushed on every peer-connected event and by a slow sweep.
+    /// Ids come from `file_id_counter`, shared with inbound pending offers.
+    outbox: Arc<std::sync::Mutex<Vec<OutboxEntry>>>,
+    /// Peers with a flush in flight, so a burst of connect events (or the
+    /// sweep racing a connect) can't deliver the same offer twice.
+    flushing: Arc<DashSet<EndpointId>>,
 }
 
 impl FileService {
@@ -57,9 +106,23 @@ impl FileService {
         device_user_map: peers::DeviceUserMap,
         transfers: Arc<transfers::TransferRegistry>,
     ) -> Self {
+        // Reload queued sends from the previous run. Ids and transfer entries
+        // are session-local: reassign fresh ones (the transfer re-registers as
+        // Offered so provider events find it by hash+peer when the peer pulls).
+        let mut queued = load_outbox();
+        let ids = AtomicU64::new(1);
+        for entry in &mut queued {
+            entry.id = ids.fetch_add(1, Ordering::Relaxed);
+            transfers.register_send(
+                entry.peer,
+                entry.filename.clone(),
+                entry.size,
+                iroh_blobs::Hash::from_bytes(*entry.blob_hash.as_bytes()),
+            );
+        }
         Self {
             pending_files: Arc::new(std::sync::Mutex::new(Vec::new())),
-            file_id_counter: Arc::new(AtomicU64::new(1)),
+            file_id_counter: Arc::new(ids),
             pairing_secret: Arc::new(std::sync::Mutex::new(None)),
             secret_key,
             transport,
@@ -67,6 +130,8 @@ impl FileService {
             device_cert,
             device_user_map,
             transfers,
+            outbox: Arc::new(std::sync::Mutex::new(queued)),
+            flushing: Arc::new(DashSet::new()),
         }
     }
 
@@ -365,7 +430,7 @@ impl FileService {
     /// The read happens daemon-side, so this only works for paths the daemon
     /// itself can see; IPC clients use `send_file_fd`. Kept for in-process
     /// callers (ray-mobile), where daemon and app share one privilege domain.
-    pub(crate) async fn send_file(&self, path: &str, peer: &str) -> IpcMessage {
+    pub(crate) async fn send_file(self: &Arc<Self>, path: &str, peer: &str) -> IpcMessage {
         let file_path = Path::new(path);
         let file_bytes = match std::fs::read(file_path) {
             Ok(b) => b,
@@ -384,7 +449,12 @@ impl FileService {
     /// client opened the file with its own privileges, the daemon never
     /// resolves a path. This is what lets `ray send` reach TCC-protected
     /// folders on macOS and files the daemon can't read but the caller can.
-    pub(crate) async fn send_file_fd(&self, fd: OwnedFd, filename: &str, peer: &str) -> IpcMessage {
+    pub(crate) async fn send_file_fd(
+        self: &Arc<Self>,
+        fd: OwnedFd,
+        filename: &str,
+        peer: &str,
+    ) -> IpcMessage {
         let mut file = File::from(fd);
         // fstat before reading: an fd is attacker-chosen input, and reading a
         // FIFO or a device (/dev/zero) here would stall or balloon the daemon.
@@ -406,9 +476,17 @@ impl FileService {
         self.send_bytes(file_bytes, filename, peer).await
     }
 
-    /// Shared tail of the send flow: blob-store the bytes and deliver the
-    /// offer to the peer over `FILES_ALPN`.
-    async fn send_bytes(&self, file_bytes: Vec<u8>, filename: String, peer: &str) -> IpcMessage {
+    /// Shared tail of the send flow: blob-store the bytes, queue the offer,
+    /// and reply immediately. Delivery is asynchronous: a background flush
+    /// attempts it right away, and the outbox re-flushes whenever a mesh
+    /// connection to the peer comes up, so a send to an offline peer parks
+    /// here instead of making the caller wait on an unbounded dial.
+    async fn send_bytes(
+        self: &Arc<Self>,
+        file_bytes: Vec<u8>,
+        filename: String,
+        peer: &str,
+    ) -> IpcMessage {
         let peer_id = match self.registry.resolve_peer_flexible(peer).await {
             Some(id) => id,
             None => {
@@ -417,7 +495,6 @@ impl FileService {
         };
 
         let size = file_bytes.len() as u64;
-        let mime_type = guess_mime_type(&filename);
         let hash = blake3::hash(&file_bytes);
 
         if let Err(e) = self
@@ -431,62 +508,188 @@ impl FileService {
         }
 
         // Register the transfer now, before the peer can possibly learn the hash:
-        // it is only after `add_slice` above that the blob exists to be pulled, and
-        // the offer that tells the peer about it hasn't even been dialed yet. On
-        // auto-accept, the receiver can fetch the entire blob and close its
-        // connection before this function's own `conn.closed()` await below
-        // returns, so every provider event (Started/Progress/Completed) can arrive
-        // before an entry registered "at the end" would have existed; registering
-        // here instead means the entry always exists first.
-        let blob_hash = iroh_blobs::Hash::from_bytes(*hash.as_bytes());
-        let transfer_id = self
-            .transfers
-            .register_send(peer_id, filename.clone(), size, blob_hash);
+        // it is only after `add_slice` above that the blob exists to be pulled,
+        // and on auto-accept the receiver can fetch the entire blob the moment
+        // the offer lands, so every provider event (Started/Progress/Completed)
+        // must find the entry already registered.
+        self.transfers.register_send(
+            peer_id,
+            filename.clone(),
+            size,
+            iroh_blobs::Hash::from_bytes(*hash.as_bytes()),
+        );
 
-        let msg = control::ControlMsg::FileOffer {
-            from: self.transport.endpoint.id(),
+        let entry = OutboxEntry {
+            id: self.file_id_counter.fetch_add(1, Ordering::Relaxed),
+            peer: peer_id,
             filename: filename.clone(),
             size,
-            mime_type: mime_type.clone(),
             blob_hash: hash,
         };
+        self.outbox.lock().unwrap().push(entry);
+        self.save_outbox();
 
-        match transport::connect_to_peer_with_alpn(
-            &self.transport.endpoint,
-            peer_id,
-            transport::FILES_ALPN,
-        )
-        .await
-        {
-            Ok(conn) => match conn.open_bi().await {
-                Ok((mut send, _)) => {
-                    // File offers ride the separate FILES_ALPN, not the mesh demux,
-                    // so they carry no network scope.
-                    if let Err(e) = control::send_msg(&mut send, None, &msg).await {
-                        self.transfers.fail_offer(transfer_id);
-                        return ipc_err(format!("failed to send offer: {e}"));
-                    }
-                    // send_msg already finished the stream; wait for the peer to
-                    // read the offer so it flushes before this `conn` is dropped.
-                    let _ = tokio::time::timeout(Duration::from_secs(5), conn.closed()).await;
+        // Kick delivery in the background either way: even a peer with no live
+        // mesh connection may be dialable (fresh mDNS discovery, say), and the
+        // attempt is bounded by OFFER_CONNECT_TIMEOUT.
+        let svc = Arc::clone(self);
+        tokio::spawn(async move { svc.flush_outbox_for(peer_id).await });
+
+        let message = if self.peer_connected(peer_id) {
+            format!("sending {} ({}) to {}", filename, format_size(size), peer)
+        } else {
+            format!(
+                "queued {} ({}) for {}; it delivers when the peer comes online (see `ray files`)",
+                filename,
+                format_size(size),
+                peer
+            )
+        };
+        IpcMessage::Ok { message }
+    }
+
+    /// Distinct peers with queued sends that hold a live mesh connection right
+    /// now: the periodic sweep's work list (it never dials offline peers).
+    pub(crate) fn outbox_peers(&self) -> Vec<EndpointId> {
+        let mut peers: Vec<EndpointId> =
+            self.outbox.lock().unwrap().iter().map(|e| e.peer).collect();
+        peers.sort();
+        peers.dedup();
+        peers.retain(|p| self.peer_connected(*p));
+        peers
+    }
+
+    /// True when any shared network holds a live mesh connection to `peer`.
+    fn peer_connected(&self, peer: EndpointId) -> bool {
+        self.registry.networks.iter().any(|entry| {
+            self.registry
+                .peers
+                .peers_for_network_with_conn(entry.key())
+                .iter()
+                .any(|(pid, _, _)| *pid == peer)
+        })
+    }
+
+    /// Deliver every queued offer for `peer`, stopping at the first failure
+    /// (the next peer-connected event or sweep retries). Called from the
+    /// mesh-connection hook, the enqueue path, and the periodic sweep; the
+    /// `flushing` guard collapses concurrent triggers so an offer can't be
+    /// delivered twice.
+    pub(crate) async fn flush_outbox_for(self: Arc<Self>, peer: EndpointId) {
+        if !self.flushing.insert(peer) {
+            return;
+        }
+        loop {
+            let Some(entry) = self
+                .outbox
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|e| e.peer == peer)
+                .cloned()
+            else {
+                break;
+            };
+            match self.deliver_offer(&entry).await {
+                Ok(()) => {
+                    tracing::info!(
+                        peer = %peer.fmt_short(),
+                        filename = %entry.filename,
+                        "queued file offer delivered"
+                    );
+                    self.outbox.lock().unwrap().retain(|e| e.id != entry.id);
+                    self.save_outbox();
                 }
                 Err(e) => {
-                    self.transfers.fail_offer(transfer_id);
-                    return ipc_err(format!("failed to open stream: {e}"));
+                    tracing::debug!(
+                        peer = %peer.fmt_short(),
+                        filename = %entry.filename,
+                        error = %e,
+                        "outbox delivery attempt failed; will retry"
+                    );
+                    break;
                 }
-            },
-            Err(e) => {
-                self.transfers.fail_offer(transfer_id);
-                return ipc_err(format!("cannot reach peer '{peer}': {e}"));
             }
         }
+        self.flushing.remove(&peer);
+    }
 
-        // The bytes have not moved yet: the offer has only just been delivered.
-        // The peer pulls the blob out of our store when it accepts, and that is
-        // what the provider events (wired up in bootstrap) report against this
-        // hash and peer. The entry stays Offered until then.
-        IpcMessage::Ok {
-            message: format!("offered {} ({}) to {}", filename, format_size(size), peer),
+    /// One bounded delivery attempt: dial `FILES_ALPN`, send the offer, wait
+    /// for the peer to read it. The transfer entry stays Offered afterwards;
+    /// the peer pulling the blob is what moves it (provider events).
+    async fn deliver_offer(&self, entry: &OutboxEntry) -> Result<(), String> {
+        let msg = control::ControlMsg::FileOffer {
+            from: self.transport.endpoint.id(),
+            filename: entry.filename.clone(),
+            size: entry.size,
+            mime_type: guess_mime_type(&entry.filename),
+            blob_hash: entry.blob_hash,
+        };
+        let conn = tokio::time::timeout(
+            OFFER_CONNECT_TIMEOUT,
+            transport::connect_to_peer_with_alpn(
+                &self.transport.endpoint,
+                entry.peer,
+                transport::FILES_ALPN,
+            ),
+        )
+        .await
+        .map_err(|_| "connect timed out".to_string())?
+        .map_err(|e| format!("connect failed: {e}"))?;
+        let (mut send, _recv) = conn
+            .open_bi()
+            .await
+            .map_err(|e| format!("failed to open stream: {e}"))?;
+        // File offers ride the separate FILES_ALPN, not the mesh demux, so they
+        // carry no network scope.
+        control::send_msg(&mut send, None, &msg)
+            .await
+            .map_err(|e| format!("failed to send offer: {e}"))?;
+        // send_msg already finished the stream; wait for the peer to read the
+        // offer so it flushes before this `conn` is dropped.
+        let _ = tokio::time::timeout(Duration::from_secs(5), conn.closed()).await;
+        Ok(())
+    }
+
+    /// `ray files cancel <id>`: drop a queued send that hasn't been delivered.
+    pub(crate) fn cancel_send(&self, id: u64) -> IpcMessage {
+        let removed = {
+            let mut outbox = self.outbox.lock().unwrap();
+            let i = outbox.iter().position(|e| e.id == id);
+            i.map(|i| outbox.remove(i))
+        };
+        match removed {
+            Some(entry) => {
+                self.transfers.fail_offer_by(
+                    iroh_blobs::Hash::from_bytes(*entry.blob_hash.as_bytes()),
+                    entry.peer,
+                );
+                self.save_outbox();
+                IpcMessage::Ok {
+                    message: format!(
+                        "canceled queued send of {} to {}",
+                        entry.filename,
+                        entry.peer.fmt_short()
+                    ),
+                }
+            }
+            None => ipc_err(format!("no queued send with id {id}")),
+        }
+    }
+
+    /// Persist the outbox (atomic write via `config::write_file`). Filenames
+    /// and peers are not secrets in the config-dir threat model, but keep the
+    /// file root-only like the rest of the daemon state.
+    fn save_outbox(&self) {
+        let Some(path) = outbox_path() else { return };
+        let entries = self.outbox.lock().unwrap().clone();
+        match serde_json::to_vec_pretty(&entries) {
+            Ok(bytes) => {
+                if let Err(e) = config::write_file(&path, &bytes, true) {
+                    tracing::warn!(error = %e, "failed to persist send outbox");
+                }
+            }
+            Err(e) => tracing::warn!(error = %e, "failed to serialize send outbox"),
         }
     }
 
@@ -505,7 +708,19 @@ impl FileService {
                 own_device: self.is_own_device_sender(f.from),
             })
             .collect();
-        IpcMessage::FileList { files }
+        let outbox = self
+            .outbox
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|e| ipc::OutboxFileInfo {
+                id: e.id,
+                peer: e.peer.fmt_short().to_string(),
+                filename: e.filename.clone(),
+                size: e.size,
+            })
+            .collect();
+        IpcMessage::FileList { files, outbox }
     }
 
     /// Decline a pending file offer: drop it from the queue without fetching the
@@ -682,5 +897,34 @@ impl FileService {
                 tracing::warn!(error = %e, peer = %remote_id.fmt_short(), "failed to accept bi stream for pairing");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the outbox persistence format: `EndpointId` and `blake3::Hash`
+    /// must survive a JSON round trip (the file is reloaded across daemon
+    /// restarts, so a serde-shape regression would silently drop the queue).
+    #[test]
+    fn outbox_entry_roundtrips_through_json() {
+        let peer = SecretKey::from([7u8; 32]).public();
+        let entry = OutboxEntry {
+            id: 3,
+            peer,
+            filename: "report.pdf".to_string(),
+            size: 42,
+            blob_hash: blake3::hash(b"payload"),
+        };
+        let bytes = serde_json::to_vec(&vec![entry.clone()]).unwrap();
+        let loaded: Vec<OutboxEntry> = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(loaded.len(), 1);
+        // `id` is #[serde(skip)]: session-local, reassigned on load.
+        assert_eq!(loaded[0].id, 0);
+        assert_eq!(loaded[0].peer, entry.peer);
+        assert_eq!(loaded[0].filename, entry.filename);
+        assert_eq!(loaded[0].size, entry.size);
+        assert_eq!(loaded[0].blob_hash, entry.blob_hash);
     }
 }

--- a/src/daemon/mesh/bootstrap.rs
+++ b/src/daemon/mesh/bootstrap.rs
@@ -300,15 +300,21 @@ async fn build_daemon(
                     // without touching the registry.
                     ProviderMessage::GetManyRequestReceivedNotify(msg) => {
                         let mut updates = msg.rx;
-                        tokio::spawn(async move { while let Ok(Some(_)) = updates.recv().await {} });
+                        tokio::spawn(
+                            async move { while let Ok(Some(_)) = updates.recv().await {} },
+                        );
                     }
                     ProviderMessage::PushRequestReceivedNotify(msg) => {
                         let mut updates = msg.rx;
-                        tokio::spawn(async move { while let Ok(Some(_)) = updates.recv().await {} });
+                        tokio::spawn(
+                            async move { while let Ok(Some(_)) = updates.recv().await {} },
+                        );
                     }
                     ProviderMessage::ObserveRequestReceivedNotify(msg) => {
                         let mut updates = msg.rx;
-                        tokio::spawn(async move { while let Ok(Some(_)) = updates.recv().await {} });
+                        tokio::spawn(
+                            async move { while let Ok(Some(_)) = updates.recv().await {} },
+                        );
                     }
                     _ => {}
                 }
@@ -469,6 +475,34 @@ async fn build_daemon(
     protocol_router.set_mesh_dispatch(MeshDispatch {
         ctx: registry.mesh_ctx(),
         token: token.clone(),
+        on_peer_connected: {
+            // Deliver queued `ray send` offers the moment their peer connects.
+            let files = files.clone();
+            Arc::new(move |peer| {
+                let files = files.clone();
+                tokio::spawn(async move { files.flush_outbox_for(peer).await });
+            })
+        },
+    });
+    // Slow safety net for offers whose delivery failed transiently while the
+    // peer connection stayed up (the connect hook won't refire until the peer
+    // reconnects). `outbox_peers` only yields currently connected peers, so
+    // this never dials into the void.
+    tokio::spawn({
+        let files = files.clone();
+        let token = token.clone();
+        async move {
+            loop {
+                tokio::select! {
+                    _ = token.cancelled() => return,
+                    _ = tokio::time::sleep(file_service::OUTBOX_SWEEP_INTERVAL) => {}
+                }
+                for peer in files.outbox_peers() {
+                    let files = files.clone();
+                    tokio::spawn(async move { files.flush_outbox_for(peer).await });
+                }
+            }
+        }
     });
     // The Router owns the endpoint accept loop and dispatches by ALPN. It aborts on
     // drop, so the Daemon owns it for the process lifetime and shuts it down on exit.

--- a/src/daemon/mesh_connection.rs
+++ b/src/daemon/mesh_connection.rs
@@ -62,6 +62,9 @@ impl MeshConnection {
     /// exit that isn't daemon shutdown, stop the reader and, if this connection was
     /// ever a registered member, report the drop to the supervisor.
     pub(crate) async fn run(mut self) {
+        // A connection to this peer now exists (either side dialed): let the
+        // composition-root hook flush anything queued for it (send outbox).
+        self.manager.notify_peer_connected(self.peer_id);
         // The connection's single data reader. One reader serves every network the
         // connection carries; `MeshConnection` owns it for the connection's
         // lifetime and aborts it when the loop below ends.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -218,8 +218,7 @@ impl MeshCtx {
         // Keep the roster route map current with every peer we connect to, so a
         // later idle teardown can re-dial it on demand (reconverge covers the
         // roster-wide sync + removals; this is the incremental add).
-        self.route_map
-            .sync_add(network, ip, ipv6, peer_id);
+        self.route_map.sync_add(network, ip, ipv6, peer_id);
         self.peers.add(ip, ipv6, conn.clone(), peer_id, network)
     }
 }
@@ -1042,6 +1041,7 @@ impl Daemon {
                 Some(fd) => self.files.send_file_fd(fd, &filename, &peer).await,
                 None => ipc_err("SendFileFd request carried no file descriptor"),
             },
+            IpcMessage::CancelSend { id } => self.files.cancel_send(id),
             IpcMessage::ListFiles => self.list_files(),
             IpcMessage::AcceptFile { id, output } => {
                 self.files.accept_file(id, output, peer_cred).await
@@ -1834,10 +1834,11 @@ mod headless_tests {
         // on panic, so this can't poison later tests.
         let _env_guard = EnvVarGuard::set("RAYFISH_CONFIG_DIR", tmp.path());
 
-        let daemon = tokio::time::timeout(std::time::Duration::from_secs(30), build_headless(false))
-            .await
-            .expect("build_headless should not hang")
-            .expect("build_headless should succeed");
+        let daemon =
+            tokio::time::timeout(std::time::Duration::from_secs(30), build_headless(false))
+                .await
+                .expect("build_headless should not hang")
+                .expect("build_headless should succeed");
 
         // It returns a shared `Arc<DaemonState>`.
         assert!(Arc::strong_count(&daemon) >= 1);
@@ -1904,10 +1905,11 @@ mod headless_tests {
         let tmp = tempfile::tempdir().unwrap();
         let _env_guard = EnvVarGuard::set("RAYFISH_CONFIG_DIR", tmp.path());
 
-        let daemon = tokio::time::timeout(std::time::Duration::from_secs(30), build_headless(false))
-            .await
-            .expect("build_headless should not hang")
-            .expect("build_headless should succeed");
+        let daemon =
+            tokio::time::timeout(std::time::Duration::from_secs(30), build_headless(false))
+                .await
+                .expect("build_headless should not hang")
+                .expect("build_headless should succeed");
 
         use std::sync::atomic::Ordering;
 

--- a/src/daemon/transfers.rs
+++ b/src/daemon/transfers.rs
@@ -179,6 +179,21 @@ impl TransferRegistry {
         }
     }
 
+    /// `fail_offer` addressed by `(hash, peer)` instead of registry id, for the
+    /// send outbox: a canceled queued send registered its transfer at enqueue
+    /// (see `register_send`'s ordering contract) and only knows the blob and
+    /// peer. Touches only the still-`Offered` entry, never a moving transfer.
+    pub fn fail_offer_by(&self, hash: Hash, peer: EndpointId) {
+        if let Some(e) = self.entries.lock().unwrap().values_mut().find(|e| {
+            e.info.outgoing
+                && e.hash == Some(hash)
+                && e.peer_id == Some(peer)
+                && e.info.state == TransferState::Offered
+        }) {
+            finish_entry(e, false, Some(FailureKind::Offer));
+        }
+    }
+
     /// A peer started pulling a blob. If the only entry for this `(hash, peer)`
     /// pair already finished as `Failed` from an aborted pull (not an offer that
     /// never reached the peer, see [`FailureKind`]), and it failed recently
@@ -298,7 +313,11 @@ fn finish_entry(e: &mut Entry, ok: bool, failure: Option<FailureKind>) {
 /// registered as an outgoing file send (a roster blob fetch, say) or for a peer
 /// that never received this exact offer, which is how both get ignored: a hash
 /// alone is not enough to identify who a send actually went to.
-fn oldest_live_outgoing(entries: &HashMap<u64, Entry>, hash: Hash, peer: EndpointId) -> Option<u64> {
+fn oldest_live_outgoing(
+    entries: &HashMap<u64, Entry>,
+    hash: Hash,
+    peer: EndpointId,
+) -> Option<u64> {
     entries
         .values()
         .filter(|e| e.hash == Some(hash) && e.peer_id == Some(peer) && e.finished_at.is_none())
@@ -326,7 +345,8 @@ fn oldest_revivable_outgoing(
                 && e.peer_id == Some(peer)
                 && e.info.state == TransferState::Failed
                 && e.failure == Some(FailureKind::Abort)
-                && e.finished_at.is_some_and(|at| now.duration_since(at) < TERMINAL_TTL)
+                && e.finished_at
+                    .is_some_and(|at| now.duration_since(at) < TERMINAL_TTL)
         })
         .map(|e| e.info.id)
         .min()
@@ -418,7 +438,11 @@ mod tests {
         let list = reg.list();
         let entry_a = list.iter().find(|t| t.id == to_a).unwrap();
         let entry_b = list.iter().find(|t| t.id == to_b).unwrap();
-        assert_eq!(entry_a.state, TransferState::Offered, "A's entry must be untouched by B's pull");
+        assert_eq!(
+            entry_a.state,
+            TransferState::Offered,
+            "A's entry must be untouched by B's pull"
+        );
         assert_eq!(entry_b.state, TransferState::Done);
     }
 
@@ -436,7 +460,11 @@ mod tests {
         reg.provider_started(hash(1), stranger);
         reg.provider_finished(hash(1), stranger, true);
 
-        assert_eq!(reg.list()[0].state, TransferState::Offered, "id {id} must be unaffected");
+        assert_eq!(
+            reg.list()[0].state,
+            TransferState::Offered,
+            "id {id} must be unaffected"
+        );
     }
 
     #[test]
@@ -517,7 +545,11 @@ mod tests {
         let a_entry = list.iter().find(|t| t.id == first).unwrap();
         let b_entry = list.iter().find(|t| t.id == second).unwrap();
         assert_eq!(a_entry.state, TransferState::Done);
-        assert_eq!(b_entry.state, TransferState::Offered, "the second offer is untouched");
+        assert_eq!(
+            b_entry.state,
+            TransferState::Offered,
+            "the second offer is untouched"
+        );
     }
 
     #[test]
@@ -554,10 +586,18 @@ mod tests {
         reg.provider_finished(hash(1), a, true);
 
         let list = reg.list();
-        assert_eq!(list.len(), 2, "the finished first send is still listed alongside the new one");
+        assert_eq!(
+            list.len(),
+            2,
+            "the finished first send is still listed alongside the new one"
+        );
         let a = list.iter().find(|t| t.id == first).unwrap();
         let b = list.iter().find(|t| t.id == second).unwrap();
-        assert_eq!(a.state, TransferState::Done, "the first send must not be reopened");
+        assert_eq!(
+            a.state,
+            TransferState::Done,
+            "the first send must not be reopened"
+        );
         assert_eq!(b.state, TransferState::Done);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,12 +317,13 @@ pub(crate) enum Command {
         /// Username or numeric UID to grant operator access
         user: String,
     },
-    /// Send a file to a peer
+    /// Send one or more files to a peer (queued if the peer is offline)
     Send {
-        /// File path to send
-        file: String,
-        /// Peer hostname or short ID
+        /// Peer hostname, mesh IP, or short ID
         peer: String,
+        /// File paths to send
+        #[arg(required = true)]
+        files: Vec<String>,
     },
     /// Manage incoming file transfers
     Files {
@@ -690,6 +691,11 @@ pub(crate) enum FilesAction {
         /// Output directory (default: ~/Downloads)
         #[arg(long, short)]
         output: Option<String>,
+    },
+    /// Cancel a queued send that hasn't reached its peer yet
+    Cancel {
+        /// Queued-send ID (from 'ray files')
+        id: u64,
     },
     /// Toggle auto-accepting file transfers from your own paired devices on a
     /// network (`on` also drains any already-queued offers from your devices;
@@ -1060,7 +1066,7 @@ async fn main() -> Result<()> {
         Command::AutoUpdate { state } => cmd_auto_update(&state).await,
         Command::Config { action } => cmd_config(action, cli.json).await,
         Command::SetOperator { user } => cmd_set_operator(&user).await,
-        Command::Send { file, peer } => ipc_send_file(&file, &peer).await,
+        Command::Send { peer, files } => ipc_send_files(&files, &peer).await,
         Command::Files { action } => ipc_files(action).await,
         Command::Pair { action, ticket } => cmd_pair(action, ticket).await,
         Command::Unpair { device } => ipc_unpair(&device).await,


### PR DESCRIPTION
Closes #106.

## Change

- **`ray send` resolves immediately.** Peer resolution and the blob-store write stay synchronous (so `unknown peer` still errors on the spot); the offer itself is queued and delivered in the background. Reply says "sending" when the peer has a live mesh connection, "queued ... delivers when the peer comes online" otherwise.
- **Persistent outbox.** Queued offers live in `outbox.json` in the config dir (root-only, atomic writes); the bytes are already in the persistent FsStore, so queued sends survive a daemon restart (ids are session-local and reassigned on load, transfers re-register as Offered so provider events still resolve by hash+peer).
- **Delivery triggers.** Every new mesh connection (dialed or accepted) fires a composition-root hook from `MeshConnection::run` through `ConnectionManager::notify_peer_connected` into `FileService::flush_outbox_for`, so a peer coming online gets its queued offers pushed at once. A 120s sweep retries transiently failed deliveries, and only for peers that are connected right now. Each attempt is bounded (20s connect timeout), and a per-peer in-flight guard stops a connect burst from double-delivering.
- **Visibility and control.** `ray files` lists queued sends next to inbound offers; `ray files cancel <id>` drops one (and fails its transfer entry via a new `(hash, peer)`-addressed registry lookup, since the outbox entry is deliberately minimal: id, peer, filename, size, blob hash).
- **Multiple files.** `ray send <peer> <files...>`, one request per file, a failure on one file doesn't stop the rest. This flips the argument order (was `ray send <file> <peer>`); a network qualifier was considered and skipped since devices are identity-addressed across networks (`resolve_peer_flexible` takes hostname, mesh IP, short/full id).
- ray-proto 0.1.8: additive `CancelSend` variant and `FileList.outbox` field (`serde(default)`, so both directions of version skew decode). `ray files --json` output is now `{pending, queued}` instead of a bare array.

## Not changed

- `FileService::send_file` (path-based, used in-process by ray-mobile) gains the same queued behavior via the shared `send_bytes` tail; its signature is untouched.
- Mobile note: a queued send registers its transfer as Offered at enqueue, so the Android transfer notification shows an in-progress send while the offer waits for the peer. Acceptable for now; flagged for the notification rework in #101.

## Testing

- New test pinning the outbox JSON persistence shape (EndpointId + blake3::Hash round trip, `id` skipped and reassigned).
- Full suite green: 362 + 24 + 14, clippy clean, workspace check (ray-mobile included).
- Live check against the running older daemon: `ray send <peer> a.txt b.txt` sends per-file requests and surfaces per-file results (fd fallback path).
- Not yet verified live: queue-then-deliver against a real offline peer; needs this build deployed on two hosts, will exercise during rollout (send to the phone while offline, watch it deliver on reconnect).