### PR TITLE
feat(android): forward connectivity changes to the core so it rebinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`ray send` takes multiple files.** `ray send <peer> <file> <file> ...` sends
   each one; a failure on one file doesn't stop the rest.
 
+- **Android: the app now notices network changes.** Switching between Wi-Fi and
+  mobile data (or roaming access points) used to leave the app on dead sockets:
+  Android does not let apps observe route changes natively, so the core never
+  rebound and the device silently dropped off the mesh until the VPN was toggled
+  by hand. The app now forwards Android's connectivity callbacks to the core,
+  which rebinds and re-probes immediately.
+
 ### Changed
 
 - **`ray send` argument order flipped** to make room for multiple files: it is

--- a/android/app/src/main/java/uniffi/ray_mobile/ray_mobile.kt
+++ b/android/app/src/main/java/uniffi/ray_mobile/ray_mobile.kt
@@ -788,6 +788,8 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 
 
 
+
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -846,6 +848,8 @@ fun uniffi_ray_mobile_checksum_method_node_list_join_requests(
 fun uniffi_ray_mobile_checksum_method_node_list_transfers(
 ): Short
 fun uniffi_ray_mobile_checksum_method_node_log_snapshot(
+): Short
+fun uniffi_ray_mobile_checksum_method_node_network_changed(
 ): Short
 fun uniffi_ray_mobile_checksum_method_node_pair(
 ): Short
@@ -976,6 +980,8 @@ fun uniffi_ray_mobile_fn_method_node_list_transfers(`ptr`: Pointer,uniffi_out_er
 ): RustBuffer.ByValue
 fun uniffi_ray_mobile_fn_method_node_log_snapshot(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
+fun uniffi_ray_mobile_fn_method_node_network_changed(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
 fun uniffi_ray_mobile_fn_method_node_pair(`ptr`: Pointer,`ticket`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
 fun uniffi_ray_mobile_fn_method_node_reject_connect_request(`ptr`: Pointer,`shortId`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -1196,6 +1202,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_ray_mobile_checksum_method_node_log_snapshot() != 20955.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_ray_mobile_checksum_method_node_network_changed() != 41989.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_ray_mobile_checksum_method_node_pair() != 22172.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -1205,7 +1214,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_ray_mobile_checksum_method_node_reject_file_offer() != 10539.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_ray_mobile_checksum_method_node_send_file() != 31964.toShort()) {
+    if (lib.uniffi_ray_mobile_checksum_method_node_send_file() != 40644.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_ray_mobile_checksum_method_node_set_default_hostname() != 40200.toShort()) {
@@ -1762,6 +1771,25 @@ public interface NodeInterface {
     fun `logSnapshot`(): kotlin.String
     
     /**
+     * Send a file to a peer. `path` is a readable file path (the core reads its
+     * bytes and adds them to the blob store); `peer` is any identifier the core
+     * resolves — a hostname, mesh IPv4/IPv6, short id, or full endpoint id.
+     * Offers the file over `FILES_ALPN`; the recipient pulls the bytes on accept
+     * (or auto-accepts if it is one of the sender's own paired devices). Needs
+     * only the control plane ([`Node::start`]), not the tunnel, but the peer must
+     * be reachable. Runs to completion synchronously; callers drive it off the UI
+     * thread (Android's share flow runs it in a foreground service).
+     * The host OS reported a network change (Wi-Fi/cellular switch, roam,
+     * airplane-mode flip). Android blocks netlink route updates for apps, so
+     * the core cannot observe these itself (netwatch's Android monitor is a
+     * stub): the app must forward `ConnectivityManager` default-network
+     * callbacks here. The core rebinds its QUIC socket and re-probes paths.
+     * Cheap, idempotent, safe to call on every callback; a no-op before
+     * [`Node::start`].
+     */
+    fun `networkChanged`()
+    
+    /**
      * Pair this device with a primary device using a scanned/pasted pairing
      * ticket (`bs58(endpoint_id[32] || secret[32])`).
      */
@@ -1777,16 +1805,6 @@ public interface NodeInterface {
      */
     fun `rejectFileOffer`(`id`: kotlin.ULong)
     
-    /**
-     * Send a file to a peer. `path` is a readable file path (the core reads its
-     * bytes and adds them to the blob store); `peer` is any identifier the core
-     * resolves — a hostname, mesh IPv4/IPv6, short id, or full endpoint id.
-     * Offers the file over `FILES_ALPN`; the recipient pulls the bytes on accept
-     * (or auto-accepts if it is one of the sender's own paired devices). Needs
-     * only the control plane ([`Node::start`]), not the tunnel, but the peer must
-     * be reachable. Runs to completion synchronously; callers drive it off the UI
-     * thread (Android's share flow runs it in a foreground service).
-     */
     fun `sendFile`(`path`: kotlin.String, `peer`: kotlin.String)
     
     /**
@@ -2327,6 +2345,34 @@ open class Node: Disposable, AutoCloseable, NodeInterface
 
     
     /**
+     * Send a file to a peer. `path` is a readable file path (the core reads its
+     * bytes and adds them to the blob store); `peer` is any identifier the core
+     * resolves — a hostname, mesh IPv4/IPv6, short id, or full endpoint id.
+     * Offers the file over `FILES_ALPN`; the recipient pulls the bytes on accept
+     * (or auto-accepts if it is one of the sender's own paired devices). Needs
+     * only the control plane ([`Node::start`]), not the tunnel, but the peer must
+     * be reachable. Runs to completion synchronously; callers drive it off the UI
+     * thread (Android's share flow runs it in a foreground service).
+     * The host OS reported a network change (Wi-Fi/cellular switch, roam,
+     * airplane-mode flip). Android blocks netlink route updates for apps, so
+     * the core cannot observe these itself (netwatch's Android monitor is a
+     * stub): the app must forward `ConnectivityManager` default-network
+     * callbacks here. The core rebinds its QUIC socket and re-probes paths.
+     * Cheap, idempotent, safe to call on every callback; a no-op before
+     * [`Node::start`].
+     */override fun `networkChanged`()
+        = 
+    callWithPointer {
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_ray_mobile_fn_method_node_network_changed(
+        it, _status)
+}
+    }
+    
+    
+
+    
+    /**
      * Pair this device with a primary device using a scanned/pasted pairing
      * ticket (`bs58(endpoint_id[32] || secret[32])`).
      */
@@ -2372,16 +2418,6 @@ open class Node: Disposable, AutoCloseable, NodeInterface
     
 
     
-    /**
-     * Send a file to a peer. `path` is a readable file path (the core reads its
-     * bytes and adds them to the blob store); `peer` is any identifier the core
-     * resolves — a hostname, mesh IPv4/IPv6, short id, or full endpoint id.
-     * Offers the file over `FILES_ALPN`; the recipient pulls the bytes on accept
-     * (or auto-accepts if it is one of the sender's own paired devices). Needs
-     * only the control plane ([`Node::start`]), not the tunnel, but the peer must
-     * be reachable. Runs to completion synchronously; callers drive it off the UI
-     * thread (Android's share flow runs it in a foreground service).
-     */
     @Throws(RayException::class)override fun `sendFile`(`path`: kotlin.String, `peer`: kotlin.String)
         = 
     callWithPointer {

--- a/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
@@ -17,6 +17,8 @@ import uniffi.ray_mobile.Node
  * The node owns a tokio runtime, so we build exactly one per process.
  */
 object NodeHolder {
+    private const val TAG = "NodeHolder"
+
     @Volatile
     private var node: Node? = null
 
@@ -194,9 +196,10 @@ object NodeHolder {
         val cm = context.applicationContext.getSystemService(ConnectivityManager::class.java)
         if (cm == null) return
         val cb = object : ConnectivityManager.NetworkCallback() {
-            override fun onAvailable(network: Network) = notifyCore()
-            override fun onLost(network: Network) = notifyCore()
-            private fun notifyCore() {
+            override fun onAvailable(network: Network) = notifyCore("available", network)
+            override fun onLost(network: Network) = notifyCore("lost", network)
+            private fun notifyCore(event: String, network: Network) {
+                Log.i(TAG, "default network $event ($network); notifying core")
                 // The FFI call blocks briefly on the core runtime; keep it off
                 // Android's connectivity thread.
                 netScope.launch { runCatching { node?.networkChanged() } }
@@ -204,7 +207,7 @@ object NodeHolder {
         }
         runCatching { cm.registerDefaultNetworkCallback(cb) }
             .onSuccess { networkCallback = cb }
-            .onFailure { Log.w("NodeHolder", "network callback registration failed", it) }
+            .onFailure { Log.w(TAG, "network callback registration failed", it) }
     }
 
     private fun unregisterNetworkCallback(context: Context) {

--- a/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
+++ b/android/app/src/main/java/xyz/rayfish/android/NodeHolder.kt
@@ -1,7 +1,13 @@
 package xyz.rayfish.android
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import uniffi.ray_mobile.Node
 
@@ -161,10 +167,51 @@ object NodeHolder {
                     RustlsInit.ensureInitialized(context)
                     get(context).start()
                     seedDeviceName(context)
+                    registerNetworkCallback(context)
                     started = true
                 }
             }
         }
+    }
+
+    private val netScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Volatile
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+
+    /**
+     * Forward default-network changes to the core. Android blocks netlink route
+     * updates for apps, so the Rust side (netwatch) cannot see a Wi-Fi/cellular
+     * switch or roam on its own: without this the endpoint keeps using dead
+     * sockets until something rebuilds them (observed as hours of DNS resolve
+     * timeouts, no relay, no mDNS announce, device invisible to the mesh).
+     * Lives with the node's lifecycle, so it also covers standby, where the
+     * control plane is the only thing running and nothing else would notice.
+     * networkChanged() is idempotent and cheap, so the callback stays dumb.
+     */
+    private fun registerNetworkCallback(context: Context) {
+        if (networkCallback != null) return
+        val cm = context.applicationContext.getSystemService(ConnectivityManager::class.java)
+        if (cm == null) return
+        val cb = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) = notifyCore()
+            override fun onLost(network: Network) = notifyCore()
+            private fun notifyCore() {
+                // The FFI call blocks briefly on the core runtime; keep it off
+                // Android's connectivity thread.
+                netScope.launch { runCatching { node?.networkChanged() } }
+            }
+        }
+        runCatching { cm.registerDefaultNetworkCallback(cb) }
+            .onSuccess { networkCallback = cb }
+            .onFailure { Log.w("NodeHolder", "network callback registration failed", it) }
+    }
+
+    private fun unregisterNetworkCallback(context: Context) {
+        val cb = networkCallback ?: return
+        networkCallback = null
+        val cm = context.applicationContext.getSystemService(ConnectivityManager::class.java)
+        runCatching { cm?.unregisterNetworkCallback(cb) }
     }
 
     /**
@@ -179,6 +226,7 @@ object NodeHolder {
      */
     fun stopNode(context: Context) {
         synchronized(this) {
+            unregisterNetworkCallback(context)
             runCatching { node?.stop() }
             started = false
         }

--- a/ray-mobile/src/lib.rs
+++ b/ray-mobile/src/lib.rs
@@ -651,6 +651,19 @@ impl Node {
     /// only the control plane ([`Node::start`]), not the tunnel, but the peer must
     /// be reachable. Runs to completion synchronously; callers drive it off the UI
     /// thread (Android's share flow runs it in a foreground service).
+    /// The host OS reported a network change (Wi-Fi/cellular switch, roam,
+    /// airplane-mode flip). Android blocks netlink route updates for apps, so
+    /// the core cannot observe these itself (netwatch's Android monitor is a
+    /// stub): the app must forward `ConnectivityManager` default-network
+    /// callbacks here. The core rebinds its QUIC socket and re-probes paths.
+    /// Cheap, idempotent, safe to call on every callback; a no-op before
+    /// [`Node::start`].
+    pub fn network_changed(&self) {
+        if let Ok(state) = self.state() {
+            self.runtime.block_on(state.network_changed());
+        }
+    }
+
     pub fn send_file(&self, path: String, peer: String) -> Result<(), RayError> {
         let state = self.state()?;
         match self.runtime.block_on(state.send_file(&path, &peer)) {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -609,6 +609,7 @@ impl Daemon {
     /// forward the endpoint sits on dead sockets until something else rebuilds
     /// them. iroh rebinds and re-probes its paths in response.
     pub async fn network_changed(&self) {
+        tracing::info!("host reported a network change; rebinding endpoint");
         self.transport.endpoint.network_change().await;
     }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -602,6 +602,16 @@ impl Daemon {
         self.transport.clone()
     }
 
+    /// Part of the embedding API (used by `ray-mobile`): the host OS observed a
+    /// network change (Wi-Fi/cellular switch, roam, airplane mode). On desktop,
+    /// netwatch sees route changes itself; on Android its route monitor is a
+    /// stub (apps cannot subscribe to netlink route updates), so without this
+    /// forward the endpoint sits on dead sockets until something else rebuilds
+    /// them. iroh rebinds and re-probes its paths in response.
+    pub async fn network_changed(&self) {
+        self.transport.endpoint.network_change().await;
+    }
+
     /// Attach a packet interface to a headless [`DaemonState`] and start the data
     /// plane's forwarding tasks: the TUN writer (`spawn_tun_writer`) and the mesh
     /// forwarding loop (`run_mesh`, reading `reader` and using the state's


### PR DESCRIPTION
Fixes the 35-minute blackout debugged live today on sm-f966b: after a network flip while in standby, the app sat on dead sockets (116 consecutive failed pkarr publishes, DNS resolve timeouts on every relay dial, no mDNS announce) until the VPN was toggled by hand.

## Why the core can't see it itself

netwatch's Android route monitor is an empty stub ("Very sad monitor. Android doesn't allow us to do this"): Android blocks netlink route subscriptions for apps, so iroh never gets a network-changed signal on this platform. Desktop is unaffected (netlink/route sockets work there). The intended pattern, same as Tailscale's Android app, is that the app forwards OS connectivity callbacks down.

## Change

- `Daemon::network_changed()` (embedding API): delegates to iroh's `Endpoint::network_change()`, which rebinds the QUIC socket and re-runs net_report.
- ray-mobile: `Node::network_changed()` FFI, idempotent, no-op before start.
- `NodeHolder` registers a `ConnectivityManager` default-network callback for the node's lifetime, standby included (that's exactly when nothing else would notice), forwarding `onAvailable`/`onLost` off the connectivity thread. Unregistered on full stop.

Base is #107 only because the branches share ray-mobile edits; content here is independent. Retarget to master once that merges.

## Testing

- `just apk` builds; regenerated UniFFI bindings compile (`networkChanged()` present).
- Live test on the phone about to run: install the APK, flip airplane mode / Wi-Fi via adb, watch logcat for immediate rebind + pkarr publish instead of the stuck state.