### PR TITLE
feat(nix): Nix flake, NixOS module, and CI boot test

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,31 @@
+# Keeps the Nix packaging green. The most common failure mode is a stale
+# outputHashes entry in nix/package.nix after the iroh fork rev changes; the
+# error message prints the expected hash — copy it in (see CLAUDE.md, "Nix").
+name: Nix
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  flake-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - name: Enable KVM for the NixOS VM test
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      # Builds the package and runs the NixOS VM test (flake checks).
+      - run: nix flake check -L
+
+  build-darwin:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - run: nix build -L

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ secrets/
 # Android Studio / IntelliJ project settings
 android/.idea/
 *.iml
+
+# nix build output
+/result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **NixOS support.** The repo is now a Nix flake: `nix run github:rayfish/rayfish`
+  builds the `ray` CLI (Linux and macOS), and a NixOS module
+  (`nixosModules.default`) runs the daemon as a system service — operator,
+  relay/DNS/on-demand settings, and a `ray apply` provisioning spec all
+  declared straight from your system configuration. Joining a network stays a
+  one-time `ray join` (invites are secrets). A CI-run VM test boots the module
+  end to end.
 - **Android: disabling Rayfish no longer takes the phone offline.** Turning the VPN
   off (in the app, or because another VPN app took the slot) now drops the tunnel
   and releases the VPN slot but keeps Rayfish's control plane connected, so files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,3 +85,12 @@ The rules the code upholds. Read the code for the mechanics.
 - **Git:** conventional commit subjects (`feat`/`fix`/`docs`/…) so git-cliff can generate the changelog.
 - **CHANGELOG:** add a user-facing `[Unreleased]` entry (`Added`/`Changed`/`Fixed`/`Performance`), describing behavior from the user's view, for any user-visible change; skip pure-internal churn (refactors, CI, chores).
 - **Docs:** keep this file and README current when a feature or invariant changes: at the principle level, pointing to code rather than restating it.
+
+## Nix
+
+`flake.nix` + `nix/` package the daemon (`nix/package.nix`), ship a NixOS module (`nix/module.nix`), and boot-test it (`nix/vm-test.nix`); `.github/workflows/nix.yml` keeps them green. Rules:
+
+- Routine `cargo update` needs **no** nix changes — `Cargo.lock` is imported directly.
+- When the iroh fork rev/branch in `[patch.crates-io]` changes, all four `outputHashes` in `nix/package.nix` must change (they share one value). Set them to `lib.fakeHash`, run `nix build`, copy the `got: sha256-…` hash from the error; the CI nix job fails with the same message when stale.
+- New workspace member or moved cargo source path → add it to the `fileset` in `nix/package.nix`.
+- Daemon runtime-surface changes (socket path, TUN name, config keys, unit needs) → keep `nix/module.nix` and `nix/vm-test.nix` in sync; the VM test is what catches drift. The module never manages `/etc/rayfish` files (daemon-owned mutable state) — it configures only via the CLI/IPC surface.

--- a/README.md
+++ b/README.md
@@ -398,6 +398,40 @@ a peer's local rules. To seed a spec's `aliases:` from a machine you're on,
 `ray alias <net> set <host> <name>` saves the alias locally (it also shows inline
 in `ray status`) so you don't have to paste the identity by hand.
 
+### NixOS
+
+The repo is a Nix flake: `nix run github:rayfish/rayfish` builds and runs the
+`ray` CLI (Linux and macOS), and a NixOS module runs the daemon as a system
+service with the settings and apply spec above expressed directly in your
+system config:
+
+```nix
+{
+  inputs.rayfish.url = "github:rayfish/rayfish";
+
+  # in your NixOS configuration:
+  imports = [ rayfish.nixosModules.default ];
+
+  services.rayfish = {
+    enable = true;
+    operator = "alice";                    # ray set-operator, applied at boot
+    settings.dnsUpstreams = [ "9.9.9.9" ]; # ray config set, restarts on change
+    apply = {                              # ray apply, rerun when the spec changes
+      spec.networks.infra."*".allows.admins = "tcp:22";
+      prune = true;
+    };
+  };
+}
+```
+
+`services.resolved.enable = true` is strongly recommended so Magic DNS uses
+split-DNS via systemd-resolved instead of fighting NixOS over
+`/etc/resolv.conf`. Joining a network stays a one-time imperative step
+(`ray join <invite>`) — invites are secrets and don't belong in the
+world-readable Nix store. The daemon keeps owning `/etc/rayfish` as mutable
+state; the module configures it only through the same CLI surface documented
+above, so `nixos-rebuild switch` and hand-run `ray` commands never fight.
+
 ## Permissions
 
 Like Tailscale, the daemon authorizes each command by the **caller's UID**, not by file permissions:

--- a/build.rs
+++ b/build.rs
@@ -3,20 +3,29 @@
 //! `ray update --nightly` uses the running binary's checksum (not its version)
 //! to decide whether a swap is needed — but the SHA is what a tester quotes.
 //!
-//! Falls back to `unknown` when git is unavailable (e.g. a source tarball build
-//! outside a checkout), so the build never fails for lack of a `.git` dir.
+//! Packagers building from a checkout-less source tree (Nix, tarballs) can
+//! supply the SHA via the `RAY_GIT_SHA` env var, which takes precedence.
+//! Falls back to `unknown` when neither is available, so the build never
+//! fails for lack of a `.git` dir.
 
+use std::env;
 use std::process::Command;
 
 fn main() {
-    let sha = Command::new("git")
-        .args(["rev-parse", "--short=8", "HEAD"])
-        .output()
+    println!("cargo:rerun-if-env-changed=RAY_GIT_SHA");
+    let sha = env::var("RAY_GIT_SHA")
         .ok()
-        .filter(|o| o.status.success())
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
+        .or_else(|| {
+            Command::new("git")
+                .args(["rev-parse", "--short=8", "HEAD"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
         .unwrap_or_else(|| "unknown".to_string());
 
     println!("cargo:rustc-env=RAY_GIT_SHA={sha}");

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784210874,
+        "narHash": "sha256-x8i+HYAulduMlM63oxWJj5tAm+Sc/W756wUzcV5p24w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "59682e0069f0ed0a452e2179a7f4c1f247027b9e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "Rayfish — P2P mesh VPN powered by iroh";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      lib = nixpkgs.lib;
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      eachSystem = f: lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+      gitSha = self.shortRev or self.dirtyShortRev or "unknown";
+    in
+    {
+      overlays.default = final: _prev: {
+        rayfish = final.callPackage ./nix/package.nix { inherit gitSha; };
+      };
+
+      packages = eachSystem (pkgs: rec {
+        rayfish = pkgs.callPackage ./nix/package.nix { inherit gitSha; };
+        default = rayfish;
+      });
+
+      devShells = eachSystem (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            cargo
+            rustc
+            clippy
+            rustfmt
+            rust-analyzer
+            just
+          ];
+        };
+      });
+
+      # nix/module.nix is flake-free (nixpkgs-adoptable); this wrapper defaults
+      # services.rayfish.package to the flake's build so consumers don't need
+      # the overlay.
+      nixosModules.rayfish =
+        { pkgs, lib, ... }:
+        {
+          imports = [ ./nix/module.nix ];
+          services.rayfish.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.rayfish;
+        };
+      nixosModules.default = self.nixosModules.rayfish;
+
+      checks = eachSystem (
+        pkgs:
+        {
+          package = self.packages.${pkgs.stdenv.hostPlatform.system}.rayfish;
+        }
+        // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+          vm-test = pkgs.testers.runNixOSTest (
+            import ./nix/vm-test.nix { rayfishModule = self.nixosModules.rayfish; }
+          );
+        }
+      );
+    };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,323 @@
+# NixOS module for the rayfish daemon.
+#
+# The daemon owns /etc/rayfish as *mutable* state: settings.toml and
+# networks/<name>.toml mix operator config with runtime state (rosters,
+# pending joins, cert generation) and are rewritten atomically by the daemon.
+# Managing those files from the store would be silently clobbered on the
+# first daemon write, so this module never touches them; every declarative
+# knob is applied through the daemon's own idempotent CLI/IPC surface
+# (`ray set-operator`, `ray config set`, `ray mdns`, `ray apply`) after the
+# daemon is up.
+#
+# This file is flake-free on purpose (nixpkgs-adoptable); the flake wrapper
+# in flake.nix defaults services.rayfish.package to the flake's build.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.rayfish;
+  yamlFormat = pkgs.formats.yaml { };
+  ray = lib.getExe cfg.package;
+
+  # Effective apply spec file: an explicit specFile wins over rendered attrs.
+  applySpecFile =
+    if cfg.apply.specFile != null then
+      cfg.apply.specFile
+    else if cfg.apply.spec != null then
+      # `ray apply` rejects anything not named *.yaml/*.yml.
+      yamlFormat.generate "rayfish-apply.yaml" cfg.apply.spec
+    else
+      null;
+
+  onOff = b: if b then "on" else "off";
+
+  # Settings that the daemon only reads at startup; changing them requires a
+  # daemon restart to take effect. Keyed list of `ray config set` invocations.
+  restartRequiredSettings = lib.filterAttrs (_: v: v != null) {
+    "relay" = cfg.settings.relay;
+    "discovery-dns" = cfg.settings.discoveryDns;
+    "dns-upstreams" = cfg.settings.dnsUpstreams;
+    "on-demand" = cfg.settings.onDemand;
+  };
+
+  configSetLines = lib.mapAttrsToList (
+    key: value:
+    let
+      rendered = if lib.isList value then lib.concatStringsSep "," value else onOff value;
+    in
+    "${ray} config set ${key} ${lib.escapeShellArg rendered} --replace"
+  ) restartRequiredSettings;
+
+  # Restart exactly once per change to the restart-required desired state
+  # (not on package bumps — those already restart the unit via the normal
+  # NixOS unit-change path).
+  settingsGeneration = builtins.hashString "sha256" (builtins.toJSON restartRequiredSettings);
+
+  wantSettingsUnit =
+    cfg.operator != null || cfg.settings.mdns != null || restartRequiredSettings != { };
+in
+{
+  options.services.rayfish = {
+    enable = lib.mkEnableOption "rayfish P2P mesh VPN daemon";
+
+    package = lib.mkPackageOption pkgs "rayfish" { };
+
+    operator = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "alice";
+      description = ''
+        Unprivileged user authorized for mutating `ray` commands (the
+        Tailscale operator model). Applied at runtime via `ray set-operator`;
+        reads are open to any local user regardless.
+      '';
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "rayfish=trace";
+      description = ''
+        `RUST_LOG` filter for the daemon. When unset the daemon defaults to
+        console `info` and rolling file logs at `rayfish=debug`.
+      '';
+    };
+
+    extraFlags = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Extra command-line arguments passed to `ray daemon`.";
+    };
+
+    settings = {
+      relay = lib.mkOption {
+        type = lib.types.nullOr (lib.types.listOf lib.types.str);
+        default = null;
+        example = [
+          "n0"
+          "https://relay.example.com"
+        ];
+        description = ''
+          Relay servers (presets like `rayfish`/`n0`, or URLs), replacing the
+          default set. `null` leaves the daemon's own setting alone.
+        '';
+      };
+
+      discoveryDns = lib.mkOption {
+        type = lib.types.nullOr (lib.types.listOf lib.types.str);
+        default = null;
+        description = ''
+          Discovery DNS servers (presets or URLs), replacing the default set.
+          `null` leaves the daemon's own setting alone.
+        '';
+      };
+
+      dnsUpstreams = lib.mkOption {
+        type = lib.types.nullOr (lib.types.listOf lib.types.str);
+        default = null;
+        example = [ "9.9.9.9" ];
+        description = ''
+          Upstream resolvers for non-`.ray` names traversing Magic DNS,
+          replacing the default set. `null` leaves the daemon's own setting
+          alone.
+        '';
+      };
+
+      onDemand = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        description = ''
+          Dial peers lazily on first packet and drop idle connections
+          (daemon default: on). Set `false` on latency-sensitive nodes to
+          keep connections warm. `null` leaves the daemon's own setting alone.
+        '';
+      };
+
+      mdns = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        description = ''
+          Local-network peer discovery via mDNS (daemon default: on).
+          `null` leaves the daemon's own setting alone.
+        '';
+      };
+    };
+
+    apply = {
+      spec = lib.mkOption {
+        type = lib.types.nullOr yamlFormat.type;
+        default = null;
+        example = lib.literalExpression ''
+          {
+            networks.homelab = {
+              server.allows."*" = "tcp:22,tcp:443";
+            };
+          }
+        '';
+        description = ''
+          Declarative provisioning spec, rendered to YAML and reconciled with
+          `ray apply` after the daemon starts (see the "Declarative
+          provisioning" section of the README for the format). This is
+          coordinator-side: it creates missing networks and publishes
+          suggested firewalls, but never joins this node to a network —
+          joining stays a one-time `ray join <invite>`. The spec carries no
+          secrets, so it is safe in the world-readable Nix store.
+        '';
+      };
+
+      specFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          Path to a ready-made `ray apply` YAML spec (must end in `.yaml` or
+          `.yml`). Mutually exclusive with {option}`services.rayfish.apply.spec`.
+        '';
+      };
+
+      prune = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Pass `--prune` to `ray apply`: drop suggested-firewall subjects that
+          are no longer in the spec instead of merging over the live set.
+        '';
+      };
+
+      inviteMissing = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Pass `--invite-missing` to `ray apply`: mint one-time hostname-bound
+          invites for hosts the spec expects but that haven't joined yet. The
+          invites are printed to the unit's journal.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.apply.spec != null && cfg.apply.specFile != null);
+        message = "services.rayfish.apply: set either `spec` or `specFile`, not both.";
+      }
+    ];
+
+    warnings = lib.optional (!config.services.resolved.enable) ''
+      services.rayfish: systemd-resolved is not enabled. Rayfish will fall
+      back to NetworkManager/resolvconf or, as a last resort, take over
+      /etc/resolv.conf directly for Magic DNS — which fights NixOS's
+      declarative resolv.conf management. `services.resolved.enable = true`
+      is strongly recommended.
+    '';
+
+    # Non-secret config files are chowned root:rayfish for group read.
+    users.groups.rayfish = { };
+
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.rayfish = {
+      description = "rayfish P2P mesh VPN";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      # `ip` for TUN link management; systemd for the resolvectl DNS fallback
+      # (the preferred systemd-resolved path is D-Bus and needs no binary).
+      path = [
+        pkgs.iproute2
+        config.systemd.package
+      ];
+      environment = lib.optionalAttrs (cfg.logLevel != null) { RUST_LOG = cfg.logLevel; };
+      serviceConfig = {
+        # The daemon requires root (TUN creation, /etc/rayfish, OS DNS) and
+        # creates/owns /etc/rayfish, /var/log/rayfish and /var/run/rayfish
+        # itself — the module deliberately manages none of them.
+        ExecStart = "${ray} daemon ${lib.escapeShellArgs cfg.extraFlags}";
+        # The daemon's panic hook restores DNS then abort()s, expecting the
+        # supervisor to restart it from clean state; `ray stop`/`ray down`
+        # semantics rely on clean exits staying down.
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+    };
+
+    # Post-start convergence for operator + global settings. A oneshot whose
+    # script embeds the desired values, so `nixos-rebuild switch` reruns it
+    # exactly when they change.
+    systemd.services.rayfish-settings = lib.mkIf wantSettingsUnit {
+      description = "rayfish declarative settings";
+      wantedBy = [ "multi-user.target" ];
+      # Wants, not Requires: this unit restarts rayfish.service below, and a
+      # Requires dependency would take this unit down with it.
+      after = [ "rayfish.service" ];
+      wants = [ "rayfish.service" ];
+      # seq/sleep/cat for the script; systemctl for the settings-change restart.
+      path = [
+        pkgs.coreutils
+        config.systemd.package
+      ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        StateDirectory = "rayfish";
+      };
+      script = ''
+        # `ray config get` is a real IPC round-trip that fails while the daemon
+        # is down (`ray status` deliberately exits 0 then, showing saved config).
+        wait_ready() {
+          for _ in $(seq 60); do
+            ${ray} config get >/dev/null 2>&1 && return 0
+            sleep 1
+          done
+          echo "rayfish daemon did not become ready" >&2
+          exit 1
+        }
+        wait_ready
+
+        ${lib.optionalString (cfg.operator != null) "${ray} set-operator ${lib.escapeShellArg cfg.operator}"}
+        ${lib.optionalString (cfg.settings.mdns != null) "${ray} mdns ${onOff cfg.settings.mdns}"}
+
+        ${lib.concatStringsSep "\n" configSetLines}
+        ${lib.optionalString (restartRequiredSettings != { }) ''
+          # relay/discovery-dns/dns-upstreams/on-demand are read at daemon
+          # startup; restart once per change to this desired state. The stamp
+          # hashes the values (not the script path), so package bumps alone
+          # don't cause a redundant extra restart. First boot restarts once
+          # more than strictly needed (no stamp yet) — harmless.
+          stamp=/var/lib/rayfish/nixos-settings-generation
+          want=${settingsGeneration}
+          if [ "$(cat "$stamp" 2>/dev/null || true)" != "$want" ]; then
+            systemctl restart rayfish.service
+            wait_ready
+            echo "$want" > "$stamp"
+          fi
+        ''}
+      '';
+    };
+
+    # Declarative one-shot reconcile of networks + suggested firewalls.
+    systemd.services.rayfish-apply = lib.mkIf (applySpecFile != null) {
+      description = "rayfish declarative network reconcile (ray apply)";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "rayfish.service" ] ++ lib.optional wantSettingsUnit "rayfish-settings.service";
+      wants = [ "rayfish.service" ];
+      path = [ pkgs.coreutils ];
+      restartTriggers = [ applySpecFile ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      script = ''
+        for _ in $(seq 60); do
+          ${ray} config get >/dev/null 2>&1 && break
+          sleep 1
+        done
+        ${ray} apply ${applySpecFile} ${lib.optionalString cfg.apply.prune "--prune"} ${lib.optionalString cfg.apply.inviteMissing "--invite-missing"}
+      '';
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,69 @@
+# Nixpkgs-style derivation for the ray CLI/daemon. Kept callPackage-compatible
+# so it could move into nixpkgs unchanged; flake-specific wiring (gitSha) stays
+# an optional argument.
+{
+  lib,
+  rustPlatform,
+  gitSha ? "unknown",
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "rayfish";
+  version = (lib.importTOML ../Cargo.toml).package.version;
+
+  # Everything cargo needs and nothing else, so docs/CI edits don't rebuild.
+  # ray-mobile and benches are never built here but must be present: cargo
+  # resolves workspace members and [[bench]] target paths at manifest parse
+  # time. A new workspace member or moved source dir must be added here — the
+  # nix CI job fails loudly if it isn't.
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../build.rs
+      ../src
+      ../ray-proto
+      ../ray-mobile
+      ../benches
+      # include_str!'d service templates (src/cli/service.rs)
+      ../contrib
+    ];
+  };
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+    # The [patch.crates-io] iroh fork is the only non-crates.io source; all
+    # four crates come from the same repo+rev, so all four hashes are one
+    # value. When the fork branch/rev changes: replace all four with
+    # lib.fakeHash, `nix build`, copy the "got: sha256-…" hash from the error.
+    outputHashes = {
+      "iroh-1.0.2" = "sha256-oKDacCJxij/ydMVeqYXeUA8zkTYgnZTh/nt2Te4+WHE=";
+      "iroh-base-1.0.2" = "sha256-oKDacCJxij/ydMVeqYXeUA8zkTYgnZTh/nt2Te4+WHE=";
+      "iroh-dns-1.0.2" = "sha256-oKDacCJxij/ydMVeqYXeUA8zkTYgnZTh/nt2Te4+WHE=";
+      "iroh-relay-1.0.2" = "sha256-oKDacCJxij/ydMVeqYXeUA8zkTYgnZTh/nt2Te4+WHE=";
+    };
+  };
+
+  # Root package only; ray-mobile is Android-only and must not build here.
+  cargoBuildFlags = [
+    "--bin"
+    "ray"
+  ];
+
+  # Unit tests run in .github/workflows/ci.yml with network available. The nix
+  # sandbox has none; keeping checks off makes this derivation's failures mean
+  # exactly "packaging broke".
+  doCheck = false;
+
+  # Consumed by build.rs (env override; no .git in the sandbox).
+  env.RAY_GIT_SHA = gitSha;
+
+  meta = {
+    description = "P2P mesh VPN powered by iroh — connect peers by cryptographic identity, not IP address";
+    homepage = "https://github.com/rayfish/rayfish";
+    license = lib.licenses.mpl20;
+    mainProgram = "ray";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}

--- a/nix/vm-test.nix
+++ b/nix/vm-test.nix
@@ -1,0 +1,55 @@
+# Boot-tests the NixOS module in an offline VM: daemon up, IPC socket, TUN
+# device, declarative settings converged (including the one settings-triggered
+# restart), `ray apply` reconciled a network, and the operator model works.
+#
+# The VM has no internet, so everything asserted here must be offline-safe:
+# pkarr/relay publishes are best-effort background work, and network creation
+# is local-first.
+{ rayfishModule }:
+{
+  name = "rayfish";
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [ rayfishModule ];
+
+      services.resolved.enable = true;
+      users.users.alice = {
+        isNormalUser = true;
+        password = "";
+      };
+
+      services.rayfish = {
+        enable = true;
+        operator = "alice";
+        settings.dnsUpstreams = [ "9.9.9.9" ];
+        apply.spec.networks.ci-net = { };
+      };
+
+      virtualisation.cores = 2;
+      virtualisation.memorySize = 2048;
+    };
+
+  testScript = ''
+    machine.wait_for_unit("rayfish.service")
+    machine.wait_until_succeeds("test -S /var/run/rayfish/rayfish.sock", timeout=90)
+    # `ray config get` fails while the daemon is unreachable (`ray status`
+    # exits 0 even then, so it can't serve as a readiness probe).
+    machine.wait_until_succeeds("ray config get", timeout=90)
+    # The TUN device name is kernel-assigned (tun0, ...); assert on the mesh
+    # route the daemon installs through it instead.
+    machine.succeed("ip route show | grep -E '^100\\.64\\.0\\.0/10 dev tun'")
+
+    # Settings oneshot converged (includes the one settings-triggered restart).
+    machine.wait_for_unit("rayfish-settings.service")
+    machine.succeed("ray config get dns-upstreams | grep -F 9.9.9.9")
+
+    # Apply oneshot created the declared network.
+    machine.wait_for_unit("rayfish-apply.service")
+    machine.wait_until_succeeds("ray status | grep -F ci-net", timeout=60)
+
+    # Operator model: alice may run mutating commands without root.
+    machine.succeed("su - alice -c 'ray mdns off'")
+  '';
+}


### PR DESCRIPTION
## What

Packages rayfish as a Nix flake and adds a NixOS module that runs the daemon as a system service, with the declarative-provisioning story (`ray apply`) expressible straight from a NixOS config.

- **`flake.nix`** — one input (nixpkgs-unstable), no framework deps. Outputs: `packages` + `devShells` for x86_64/aarch64 Linux and macOS, `overlays.default`, `nixosModules.default`, and `checks` (package build + NixOS VM test).
- **`nix/package.nix`** — plain `rustPlatform.buildRustPackage`, kept callPackage-compatible so nixpkgs could adopt it later. `Cargo.lock` is imported directly, so **routine `cargo update` needs zero nix changes**; the only maintained hash is the `outputHashes` entry for the `[patch.crates-io]` iroh fork, and CI fails with the expected hash printed when it goes stale.
- **`nix/module.nix`** — `services.rayfish.{enable, package, operator, logLevel, extraFlags, settings.{relay,discoveryDns,dnsUpstreams,onDemand,mdns}, apply.{spec,specFile,prune,inviteMissing}}`. The daemon keeps owning `/etc/rayfish` as mutable state; the module never writes config files, it converges everything through the CLI/IPC surface after startup (`ray set-operator`, `ray config set --replace`, `ray mdns`, `ray apply`), so `nixos-rebuild switch` and hand-run `ray` commands never fight. Settings that are read at daemon startup trigger exactly one restart per desired-state change (stamp file). Joining stays imperative — invites are secrets and don't belong in the world-readable store.
- **`nix/vm-test.nix`** — a NixOS VM test that boots the module offline end to end: daemon up, IPC socket, mesh route through the TUN, systemd-resolved split-DNS via D-Bus, settings converged, `ray apply` creates the declared network (pkarr publish degrades to a WARN with no internet), and the operator user mutates without sudo.
- **`.github/workflows/nix.yml`** — `nix flake check` (package + VM test, KVM-enabled) on ubuntu, `nix build` on macos.
- **`build.rs`** (separate commit) — packagers can inject the git SHA via `RAY_GIT_SHA`; the flake passes `self.shortRev` so nix builds aren't stamped `unknown`. Existing behavior unchanged otherwise.
- **CLAUDE.md** gets a short principle-level Nix section: when the iroh fork rev changes → refresh the four `outputHashes` (procedure included); new workspace member → extend the `fileset`; daemon runtime-surface changes → keep module + VM test in sync.

## Why

`ray apply` already makes the network spec declarative; this extends the same idea to the host: a NixOS box can pin the daemon version, its settings, and its provisioning spec in one config. `auto_update` self-replace can't work on a read-only store anyway (updates come via the flake input), and systemd-resolved's D-Bus split-DNS path means no `/etc/resolv.conf` fights on NixOS.

## Testing

- VM test passes on NixOS (x86_64): full boot → converge → apply → operator flow, all offline.
- `nix build` on aarch64-darwin: `ray 0.2.0 (<rev>)` with the sha stamped through `RAY_GIT_SHA`.
- `cargo check` / `clippy --all-targets` / `test` all green.
- Docs: README gains a `### NixOS` subsection under Declarative provisioning; CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)