### PR TITLE
fix(mesh): never publish stale roster on restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,7 +254,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `using: <peer>` either way, while every packet left directly. It now says the
   selection is not in effect and why (the routing rules would not install, the
   data plane is down, the peer is not in the roster yet, or the gateway cannot
-  carry the family this node tunnels).
+  carry the family this node tunnels).- **A coordinator restart can no longer erase a healthy network roster.** If
+  the signed membership blob was temporarily unavailable at startup, a
+  coordinator fell back to its stale config copy and immediately published it
+  as authoritative; that copy could contain only the coordinator, making every
+  member disappear. Coordinator restore now stays inactive and retries until it
+  has the signed blob.
 - **`.ray` names now resolve alongside another VPN that manages
   `/etc/resolv.conf`.** On a host with no DNS manager (no systemd-resolved in
   the resolution path), Rayfish and a VPN like Tailscale both want that file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,12 +254,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `using: <peer>` either way, while every packet left directly. It now says the
   selection is not in effect and why (the routing rules would not install, the
   data plane is down, the peer is not in the roster yet, or the gateway cannot
-  carry the family this node tunnels).- **A coordinator restart can no longer erase a healthy network roster.** If
+  carry the family this node tunnels).
+- **A coordinator restart can no longer erase a healthy network roster.** If
   the signed membership blob was temporarily unavailable at startup, a
   coordinator fell back to its stale config copy and immediately published it
   as authoritative; that copy could contain only the coordinator, making every
-  member disappear. Coordinator restore now stays inactive and retries until it
-  has the signed blob.
+  member disappear. Coordinator restore now republishes only a complete blob
+  selected by the current signed record or its last cached content hash.
 - **`.ray` names now resolve alongside another VPN that manages
   `/etc/resolv.conf`.** On a host with no DNS manager (no systemd-resolved in
   the resolution path), Rayfish and a VPN like Tailscale both want that file.

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use std::fs::Permissions;
 use std::net::Ipv4Addr;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 // Only the test-only `CONFIG_ENV_LOCK` holds one.
 #[cfg(test)]
 use std::sync::Mutex;
@@ -113,6 +114,12 @@ pub struct NetworkConfig {
     pub network_secret_key: Option<SecretKey>,
     #[serde(default)]
     pub network_public_key: Option<EndpointId>,
+    /// Hash of the last complete GroupBlob this node verified or authored.
+    /// Coordinator restore uses it only when the signed pkarr record is
+    /// unreachable, so an expired record can be republished without rebuilding
+    /// the roster from the deliberately lossy `members` config projection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_group_hash: Option<blake3::Hash>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transport: Option<TransportMode>,
     /// This node auto-installs coordinator-suggested firewall rules without a
@@ -346,6 +353,7 @@ pub(crate) fn empty_network_config(name: &str) -> NetworkConfig {
         approved: vec![],
         network_secret_key: None,
         network_public_key: None,
+        last_group_hash: None,
         transport: None,
         auto_accept_firewall: false,
         auto_accept_files: true,
@@ -579,6 +587,12 @@ pub fn rotate_contact_secret(config: &mut AppConfig) -> SecretKey {
 const LEGACY_FILE: &str = "networks.toml";
 const SETTINGS_FILE: &str = "settings.toml";
 const NETWORKS_SUBDIR: &str = "networks";
+
+/// Process-wide transaction boundary for network shards. Public per-network
+/// reads take a shared guard; save, update, migration, and delete take an
+/// exclusive guard so a stale whole-file write cannot overwrite another task's
+/// fields or resurrect a deleted network.
+static NETWORK_CONFIG_LOCK: RwLock<()> = RwLock::new(());
 
 /// Globals persisted to `settings.toml` (everything in [`AppConfig`] except the
 /// per-network entries, which live in their own files).
@@ -884,7 +898,7 @@ fn migrate_legacy(dir: &Path) -> Result<()> {
 
     save_settings_in(dir, &old)?;
     for net in &old.networks {
-        save_network_in(dir, net)?;
+        save_network_unlocked(dir, net)?;
     }
 
     let bak = dir.join("networks.toml.bak");
@@ -899,7 +913,15 @@ fn migrate_legacy(dir: &Path) -> Result<()> {
 /// on first call after an upgrade.
 pub fn load() -> Result<AppConfig> {
     let dir = config_dir()?;
-    migrate_legacy(&dir)?;
+    {
+        let _guard = NETWORK_CONFIG_LOCK
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        migrate_legacy(&dir)?;
+    }
+    let _guard = NETWORK_CONFIG_LOCK
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     load_in(&dir)
 }
 
@@ -907,6 +929,9 @@ pub fn load() -> Result<AppConfig> {
 /// daemon is down). Creates nothing and runs no migration; a config tree that
 /// isn't there, or isn't readable by this user, reads as an empty config.
 pub fn load_for_read() -> Result<AppConfig> {
+    let _guard = NETWORK_CONFIG_LOCK
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     load_in(&config_dir_for_read()?)
 }
 
@@ -1039,13 +1064,18 @@ fn remove_pending_join_in(dir: &Path, network_key: &str) -> Result<()> {
     Ok(())
 }
 
-/// Persist a single network to `networks/<name>.toml`. Touches only that file,
-/// so concurrent saves of distinct networks can never clobber one another.
+/// Persist a single network to `networks/<name>.toml`. Direct full-record
+/// writes share the same transaction boundary as updates and deletes.
 pub fn save_network(net: &NetworkConfig) -> Result<()> {
-    save_network_in(&config_dir()?, net)
+    let dir = config_dir()?;
+    let _guard = NETWORK_CONFIG_LOCK
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    save_network_unlocked(&dir, net)
 }
 
-fn save_network_in(dir: &Path, net: &NetworkConfig) -> Result<()> {
+/// Caller holds [`NETWORK_CONFIG_LOCK`] when this runs in production.
+fn save_network_unlocked(dir: &Path, net: &NetworkConfig) -> Result<()> {
     validate_net_name(&net.name)?;
     let ndir = dir.join(NETWORKS_SUBDIR);
     let path = ndir.join(format!("{}.toml", net.name));
@@ -1056,10 +1086,15 @@ fn save_network_in(dir: &Path, net: &NetworkConfig) -> Result<()> {
 
 /// Load a single network's config, if present.
 pub fn load_network(name: &str) -> Result<Option<NetworkConfig>> {
-    load_network_in(&config_dir()?, name)
+    let dir = config_dir()?;
+    let _guard = NETWORK_CONFIG_LOCK
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    load_network_unlocked(&dir, name)
 }
 
-fn load_network_in(dir: &Path, name: &str) -> Result<Option<NetworkConfig>> {
+/// Caller holds [`NETWORK_CONFIG_LOCK`] when this runs in production.
+fn load_network_unlocked(dir: &Path, name: &str) -> Result<Option<NetworkConfig>> {
     validate_net_name(name)?;
     let path = dir.join(NETWORKS_SUBDIR).join(format!("{name}.toml"));
     if !path.exists() {
@@ -1072,12 +1107,100 @@ fn load_network_in(dir: &Path, name: &str) -> Result<Option<NetworkConfig>> {
     ))
 }
 
-/// Delete a single network's config file. Returns true if it existed.
-pub fn delete_network(name: &str) -> Result<bool> {
-    delete_network_in(&config_dir()?, name)
+/// Atomically load, synchronously mutate, and save an existing network's latest
+/// config. The callback must not call another network-config API; the lock is
+/// deliberately never held across an await. Returns `None` when the network was
+/// deleted or never existed.
+pub fn update_network(
+    name: &str,
+    update: impl FnOnce(&mut NetworkConfig) -> Result<()>,
+) -> Result<Option<NetworkConfig>> {
+    update_network_in(&config_dir()?, name, update)
 }
 
-fn delete_network_in(dir: &Path, name: &str) -> Result<bool> {
+fn update_network_in(
+    dir: &Path,
+    name: &str,
+    update: impl FnOnce(&mut NetworkConfig) -> Result<()>,
+) -> Result<Option<NetworkConfig>> {
+    let _guard = NETWORK_CONFIG_LOCK
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(mut net) = load_network_unlocked(dir, name)? else {
+        return Ok(None);
+    };
+    anyhow::ensure!(
+        net.name == name,
+        "network config {name:?} contains mismatched name {:?}",
+        net.name
+    );
+    let before = toml::to_string(&net).context("serializing network config")?;
+    update(&mut net)?;
+    anyhow::ensure!(
+        net.name == name,
+        "network update cannot rename {name:?} to {:?}",
+        net.name
+    );
+    let after = toml::to_string(&net).context("serializing network config")?;
+    if after != before {
+        save_network_unlocked(dir, &net)?;
+    }
+    Ok(Some(net))
+}
+
+/// Atomically update the latest network config, inserting `initial` only when
+/// the network is absent. This is the fresh-join counterpart to
+/// [`update_network`]; existing node-local fields remain available to `update`.
+pub fn update_network_or_insert(
+    name: &str,
+    initial: NetworkConfig,
+    update: impl FnOnce(&mut NetworkConfig) -> Result<()>,
+) -> Result<NetworkConfig> {
+    update_network_or_insert_in(&config_dir()?, name, initial, update)
+}
+
+fn update_network_or_insert_in(
+    dir: &Path,
+    name: &str,
+    initial: NetworkConfig,
+    update: impl FnOnce(&mut NetworkConfig) -> Result<()>,
+) -> Result<NetworkConfig> {
+    let _guard = NETWORK_CONFIG_LOCK
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let existing = load_network_unlocked(dir, name)?;
+    let inserting = existing.is_none();
+    let mut net = existing.unwrap_or(initial);
+    anyhow::ensure!(
+        net.name == name,
+        "network config {name:?} contains mismatched name {:?}",
+        net.name
+    );
+    let before = toml::to_string(&net).context("serializing network config")?;
+    update(&mut net)?;
+    anyhow::ensure!(
+        net.name == name,
+        "network update cannot rename {name:?} to {:?}",
+        net.name
+    );
+    let after = toml::to_string(&net).context("serializing network config")?;
+    if inserting || after != before {
+        save_network_unlocked(dir, &net)?;
+    }
+    Ok(net)
+}
+
+/// Delete a single network's config file. Returns true if it existed.
+pub fn delete_network(name: &str) -> Result<bool> {
+    let dir = config_dir()?;
+    let _guard = NETWORK_CONFIG_LOCK
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    delete_network_unlocked(&dir, name)
+}
+
+/// Caller holds [`NETWORK_CONFIG_LOCK`] when this runs in production.
+fn delete_network_unlocked(dir: &Path, name: &str) -> Result<bool> {
     validate_net_name(name)?;
     let path = dir.join(NETWORKS_SUBDIR).join(format!("{name}.toml"));
     match std::fs::remove_file(&path) {
@@ -1170,6 +1293,7 @@ mod tests {
                     approved: vec![],
                     network_secret_key: None,
                     network_public_key: None,
+                    last_group_hash: None,
                     my_hostname: None,
                     pending_hostname: None,
                     transport: None,
@@ -1191,6 +1315,7 @@ mod tests {
                     approved: vec![],
                     network_secret_key: None,
                     network_public_key: None,
+                    last_group_hash: None,
                     my_hostname: None,
                     pending_hostname: None,
                     transport: None,
@@ -1233,6 +1358,7 @@ mod tests {
             approved: vec![],
             network_secret_key: None,
             network_public_key: None,
+            last_group_hash: None,
             my_hostname: None,
             pending_hostname: None,
             transport: None,
@@ -1263,6 +1389,7 @@ mod tests {
                 approved: vec![],
                 network_secret_key: None,
                 network_public_key: None,
+                last_group_hash: None,
                 my_hostname: None,
                 pending_hostname: None,
                 transport: None,
@@ -1286,6 +1413,7 @@ mod tests {
             approved: vec![],
             network_secret_key: None,
             network_public_key: None,
+            last_group_hash: None,
             my_hostname: None,
             pending_hostname: None,
             transport: None,
@@ -1316,6 +1444,7 @@ mod tests {
                     approved: vec![],
                     network_secret_key: None,
                     network_public_key: None,
+                    last_group_hash: None,
                     my_hostname: None,
                     pending_hostname: None,
                     transport: None,
@@ -1337,6 +1466,7 @@ mod tests {
                     approved: vec![],
                     network_secret_key: None,
                     network_public_key: None,
+                    last_group_hash: None,
                     my_hostname: None,
                     pending_hostname: None,
                     transport: None,
@@ -1384,6 +1514,7 @@ mod tests {
                 }],
                 network_secret_key: None,
                 network_public_key: None,
+                last_group_hash: None,
                 my_hostname: None,
                 pending_hostname: None,
                 transport: None,
@@ -1418,6 +1549,7 @@ mod tests {
                 approved: vec![],
                 network_secret_key: Some(secret.clone()),
                 network_public_key: Some(public),
+                last_group_hash: None,
                 my_hostname: None,
                 pending_hostname: None,
                 transport: None,
@@ -1498,6 +1630,19 @@ name = "test"
         assert_eq!(minimal.ephemeral_ttl_secs, None);
     }
 
+    #[test]
+    fn last_group_hash_roundtrips_and_defaults_none() {
+        let hash = blake3::hash(b"complete signed roster");
+        let mut n = net("cached");
+        n.last_group_hash = Some(hash);
+        let text = toml::to_string(&n).unwrap();
+        let back: NetworkConfig = toml::from_str(&text).unwrap();
+        assert_eq!(back.last_group_hash, Some(hash));
+
+        let minimal: NetworkConfig = toml::from_str("name = \"x\"").unwrap();
+        assert_eq!(minimal.last_group_hash, None);
+    }
+
     fn net(name: &str) -> NetworkConfig {
         NetworkConfig {
             name: name.to_string(),
@@ -1508,6 +1653,7 @@ name = "test"
             approved: vec![],
             network_secret_key: Some(SecretKey::generate()),
             network_public_key: None,
+            last_group_hash: None,
             transport: None,
             auto_accept_firewall: false,
             auto_accept_files: false,
@@ -1527,8 +1673,8 @@ name = "test"
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
 
-        save_network_in(dir, &net("homelab")).unwrap();
-        save_network_in(dir, &net("genesis")).unwrap();
+        save_network_unlocked(dir, &net("homelab")).unwrap();
+        save_network_unlocked(dir, &net("genesis")).unwrap();
         save_settings_in(
             dir,
             &AppConfig {
@@ -1543,12 +1689,12 @@ name = "test"
         assert_eq!(loaded.default_hostname.as_deref(), Some("laptop"));
 
         // Single-network load.
-        assert!(load_network_in(dir, "homelab").unwrap().is_some());
-        assert!(load_network_in(dir, "absent").unwrap().is_none());
+        assert!(load_network_unlocked(dir, "homelab").unwrap().is_some());
+        assert!(load_network_unlocked(dir, "absent").unwrap().is_none());
 
         // Deleting one leaves the other untouched.
-        assert!(delete_network_in(dir, "homelab").unwrap());
-        assert!(!delete_network_in(dir, "homelab").unwrap());
+        assert!(delete_network_unlocked(dir, "homelab").unwrap());
+        assert!(!delete_network_unlocked(dir, "homelab").unwrap());
         let after = load_in(dir).unwrap();
         assert_eq!(after.networks.len(), 1);
         assert_eq!(after.networks[0].name, "genesis");
@@ -1605,8 +1751,8 @@ name = "test"
         let mut n = net("homelab");
         n.aliases.insert("alice".into(), "id-alice".into());
         n.aliases.insert("bob".into(), "id-bob".into());
-        save_network_in(dir, &n).unwrap();
-        let loaded = load_network_in(dir, "homelab").unwrap().unwrap();
+        save_network_unlocked(dir, &n).unwrap();
+        let loaded = load_network_unlocked(dir, "homelab").unwrap().unwrap();
         assert_eq!(
             loaded.aliases.get("alice").map(String::as_str),
             Some("id-alice")
@@ -1848,7 +1994,7 @@ name = "test"
             for i in 0..N {
                 let dir = dir.clone();
                 s.spawn(move || {
-                    save_network_in(&dir, &net(&format!("net-{i}"))).unwrap();
+                    save_network_unlocked(&dir, &net(&format!("net-{i}"))).unwrap();
                 });
             }
         });
@@ -1858,6 +2004,92 @@ name = "test"
             loaded.networks.len(),
             N,
             "all concurrent saves must survive"
+        );
+    }
+
+    #[test]
+    fn concurrent_same_network_updates_preserve_unrelated_fields() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        save_network_unlocked(&dir, &net("homelab")).unwrap();
+        let barrier = std::sync::Barrier::new(3);
+
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                barrier.wait();
+                update_network_in(&dir, "homelab", |net| {
+                    net.aliases.insert("alice".into(), "id-alice".into());
+                    Ok(())
+                })
+                .unwrap();
+            });
+            scope.spawn(|| {
+                barrier.wait();
+                update_network_in(&dir, "homelab", |net| {
+                    net.last_group_hash = Some(blake3::hash(b"latest group"));
+                    Ok(())
+                })
+                .unwrap();
+            });
+            barrier.wait();
+        });
+
+        let loaded = load_network_unlocked(&dir, "homelab").unwrap().unwrap();
+        assert_eq!(
+            loaded.aliases.get("alice").map(String::as_str),
+            Some("id-alice")
+        );
+        assert_eq!(loaded.last_group_hash, Some(blake3::hash(b"latest group")));
+    }
+
+    #[test]
+    fn update_or_insert_uses_initial_only_when_network_is_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let mut initial = net("homelab");
+        initial.aliases.insert("local".into(), "first".into());
+
+        update_network_or_insert_in(dir, "homelab", initial, |net| {
+            net.last_group_hash = Some(blake3::hash(b"first group"));
+            Ok(())
+        })
+        .unwrap();
+
+        let mut stale_initial = net("homelab");
+        stale_initial.aliases.insert("local".into(), "stale".into());
+        update_network_or_insert_in(dir, "homelab", stale_initial, |net| {
+            net.my_hostname = Some("latest".into());
+            Ok(())
+        })
+        .unwrap();
+
+        let loaded = load_network_unlocked(dir, "homelab").unwrap().unwrap();
+        assert_eq!(
+            loaded.aliases.get("local").map(String::as_str),
+            Some("first")
+        );
+        assert_eq!(loaded.last_group_hash, Some(blake3::hash(b"first group")));
+        assert_eq!(loaded.my_hostname.as_deref(), Some("latest"));
+    }
+
+    #[test]
+    fn failed_network_update_does_not_persist_partial_mutation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        save_network_unlocked(dir, &net("homelab")).unwrap();
+
+        let result = update_network_in(dir, "homelab", |net| {
+            net.aliases.insert("alice".into(), "id-alice".into());
+            anyhow::bail!("reject update")
+        });
+
+        assert!(result.is_err());
+        assert!(
+            load_network_unlocked(dir, "homelab")
+                .unwrap()
+                .unwrap()
+                .aliases
+                .is_empty()
         );
     }
 
@@ -1898,8 +2130,8 @@ name = "test"
     fn rejects_unsafe_network_names() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
-        assert!(save_network_in(dir, &net("../escape")).is_err());
-        assert!(load_network_in(dir, "a/b").is_err());
+        assert!(save_network_unlocked(dir, &net("../escape")).is_err());
+        assert!(load_network_unlocked(dir, "a/b").is_err());
     }
 
     #[test]

--- a/src/daemon/connect_service.rs
+++ b/src/daemon/connect_service.rs
@@ -295,11 +295,11 @@ impl ConnectService {
                 false,
             )
             .await;
-        if let IpcMessage::Joined { name, .. } = &resp
-            && let Ok(Some(mut n)) = config::load_network(name)
-        {
-            n.direct = true;
-            let _ = config::save_network(&n);
+        if let IpcMessage::Joined { name, .. } = &resp {
+            let _ = config::update_network(name, |net| {
+                net.direct = true;
+                Ok(())
+            });
         }
         resp
     }

--- a/src/daemon/mesh/accept.rs
+++ b/src/daemon/mesh/accept.rs
@@ -703,13 +703,17 @@ impl CoordinatorAcceptState {
                 .flatten()
                 .is_some_and(|n| grants_direct_key(&n, remote_id, &self.state));
 
+        let snapshot_commit = self.state.read().unwrap().snapshot_commit.clone();
+        let commit_guard = snapshot_commit.lock().await;
         let user_id_opt = device_cert.as_ref().map(|c| c.user_identity);
-        let snap_bytes = {
+        let (removed_approved, removed_pending) = {
             let mut s = self.state.write().unwrap();
-            if was_approved {
-                s.approved.remove(&remote_id);
-            }
-            s.pending.remove(&remote_id);
+            let removed_approved = if was_approved {
+                s.approved.remove(&remote_id)
+            } else {
+                None
+            };
+            let removed_pending = s.pending.remove(&remote_id);
             s.members.add(Member {
                 identity: remote_id,
                 is_coordinator: grant_direct,
@@ -720,12 +724,30 @@ impl CoordinatorAcceptState {
                 exit_node: false,
                 exit_families: ExitFamilies::Unknown,
             });
-            s.refresh_snapshot();
-            s.snapshot.as_ref().map(|snap| snap.msgpack_bytes.clone())
+            (removed_approved, removed_pending)
         };
-        if let Some(bytes) = snap_bytes {
-            let _ = self.ctx.blob_store.blobs().add_slice(&bytes).await;
+        if !commit_current_snapshot(&self.state, &self.ctx.blob_store, &self.dht_notify).await {
+            {
+                let mut s = self.state.write().unwrap();
+                s.members.remove(&remote_id);
+                if let Some(approved) = removed_approved {
+                    s.approved.approve(approved);
+                }
+                if let Some(pending) = removed_pending {
+                    s.pending.insert(remote_id, pending);
+                }
+                s.refresh_snapshot();
+            }
+            drop(commit_guard);
+            self.deny(
+                conn,
+                send,
+                "failed to durably store the updated network roster".to_string(),
+            )
+            .await;
+            return None;
         }
+        drop(commit_guard);
 
         if let Some(ref h) = final_hostname {
             dns::update_hostname(
@@ -775,10 +797,6 @@ impl CoordinatorAcceptState {
         )
         .await;
 
-        if let Some(notify) = &self.dht_notify {
-            notify.notify_one();
-        }
-
         // Register the peer's route + start its single data reader (the accept-side
         // demux already owns this connection's control loop).
         crate::spawn_path_logger(conn.clone(), remote_id.fmt_short().to_string());
@@ -796,12 +814,13 @@ impl CoordinatorAcceptState {
         // The key rode the Welcome above (see `direct_key`). Record the grant
         // locally (mirrors `admin_add`) so our own `ray admin list` shows the peer
         // as a co-coordinator too.
-        if grant_direct
-            && let Ok(Some(mut net)) = config::load_network(&self.network_name)
-            && !net.admins.contains(&remote_id)
-        {
-            net.admins.push(remote_id);
-            let _ = config::save_network(&net);
+        if grant_direct {
+            let _ = config::update_network(&self.network_name, |net| {
+                if !net.admins.contains(&remote_id) {
+                    net.admins.push(remote_id);
+                }
+                Ok(())
+            });
         }
         Some(peer_ip)
     }
@@ -1245,9 +1264,19 @@ impl MemberAcceptState {
             return;
         }
         let key = SecretKey::from(secret_key);
-        if let Ok(Some(mut net)) = config::load_network(&self.network_name) {
+        match config::update_network(&self.network_name, |net| {
             net.network_secret_key = Some(key.clone());
-            let _ = config::save_network(&net);
+            Ok(())
+        }) {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                tracing::warn!(network = %self.network_name, "admin grant arrived after network config was deleted");
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(network = %self.network_name, error = %e, "failed to persist admin grant");
+                return;
+            }
         }
         {
             let mut s = self.state.write().unwrap();
@@ -1255,13 +1284,13 @@ impl MemberAcceptState {
             if let Some(m) = s.members.get_mut(&self.my_identity) {
                 m.is_coordinator = true;
             }
-            s.refresh_snapshot();
         }
         if let Ok(client) = dht::create_pkarr_client(&self.endpoint) {
             spawn_lazy_publisher(
                 client,
                 key,
                 self.state.clone(),
+                self.ctx.blob_store.clone(),
                 self.endpoint.id(),
                 self.ctx.peers.clone(),
                 self.network_name.clone(),
@@ -1666,6 +1695,7 @@ mod direct_grant_tests {
             members: list,
             approved: ApprovedList::new(),
             snapshot: None,
+            snapshot_commit: Arc::new(AsyncMutex::new(())),
             converged_hash: None,
             network_secret_key: None,
             network_public_key: eid(200),

--- a/src/daemon/mesh/admin.rs
+++ b/src/daemon/mesh/admin.rs
@@ -90,12 +90,12 @@ impl NetworkRegistry {
         self.store_and_publish_group(network).await;
 
         // Record the grant locally (coordinator's record; not verifiable).
-        if let Ok(Some(mut net)) = config::load_network(network)
-            && !net.admins.contains(&identity)
-        {
-            net.admins.push(identity);
-            let _ = config::save_network(&net);
-        }
+        let _ = config::update_network(network, |net| {
+            if !net.admins.contains(&identity) {
+                net.admins.push(identity);
+            }
+            Ok(())
+        });
         IpcMessage::Ok {
             message: format!("granted network key to {}", identity.fmt_short()),
         }

--- a/src/daemon/mesh/alias.rs
+++ b/src/daemon/mesh/alias.rs
@@ -10,18 +10,13 @@ impl NetworkRegistry {
     /// canonicalized CLI-side (the string `ray identityof` prints); this just
     /// persists the mapping. Overwrites any existing alias of the same name.
     pub(crate) fn set_alias(&self, network: &str, identity: &str, alias: &str) -> IpcMessage {
-        let mut net = match config::load_network(network) {
-            Ok(Some(n)) => n,
-            Ok(None) => {
-                return ipc_err(format!("network '{network}' not found"));
-            }
-            Err(e) => {
-                return ipc_err(format!("failed to load network config: {e}"));
-            }
-        };
-        net.aliases.insert(alias.to_string(), identity.to_string());
-        if let Err(e) = config::save_network(&net) {
-            return ipc_err(format!("failed to save config: {e}"));
+        match config::update_network(network, |net| {
+            net.aliases.insert(alias.to_string(), identity.to_string());
+            Ok(())
+        }) {
+            Ok(Some(_)) => {}
+            Ok(None) => return ipc_err(format!("network '{network}' not found")),
+            Err(e) => return ipc_err(format!("failed to save config: {e}")),
         }
         IpcMessage::Ok {
             message: format!("alias '{alias}' -> {identity} on '{network}'"),
@@ -31,20 +26,15 @@ impl NetworkRegistry {
     /// Remove a local alias by name. Reports an error if no such alias exists so
     /// a typo is visible rather than silently succeeding.
     pub(crate) fn remove_alias(&self, network: &str, alias: &str) -> IpcMessage {
-        let mut net = match config::load_network(network) {
-            Ok(Some(n)) => n,
-            Ok(None) => {
-                return ipc_err(format!("network '{network}' not found"));
-            }
-            Err(e) => {
-                return ipc_err(format!("failed to load network config: {e}"));
-            }
-        };
-        if net.aliases.remove(alias).is_none() {
-            return ipc_err(format!("no alias '{alias}' on '{network}'"));
-        }
-        if let Err(e) = config::save_network(&net) {
-            return ipc_err(format!("failed to save config: {e}"));
+        let mut removed = false;
+        match config::update_network(network, |net| {
+            removed = net.aliases.remove(alias).is_some();
+            Ok(())
+        }) {
+            Ok(Some(_)) if removed => {}
+            Ok(Some(_)) => return ipc_err(format!("no alias '{alias}' on '{network}'")),
+            Ok(None) => return ipc_err(format!("network '{network}' not found")),
+            Err(e) => return ipc_err(format!("failed to save config: {e}")),
         }
         IpcMessage::Ok {
             message: format!("removed alias '{alias}' from '{network}'"),

--- a/src/daemon/mesh/coordinator.rs
+++ b/src/daemon/mesh/coordinator.rs
@@ -788,6 +788,7 @@ mod sender_authority_tests {
             members: list,
             approved: ApprovedList::new(),
             snapshot: None,
+            snapshot_commit: Arc::new(AsyncMutex::new(())),
             converged_hash: None,
             network_secret_key: None,
             network_public_key: eid(200),

--- a/src/daemon/mesh/create_join.rs
+++ b/src/daemon/mesh/create_join.rs
@@ -20,6 +20,8 @@ struct JoinContext<'a> {
     my_hostname: &'a str,
     alpn: &'a [u8],
     net_pubkey: EndpointId,
+    /// Exact GroupBlob hash committed by the signed record used for this join.
+    group_hash: blake3::Hash,
     /// Single-use invite secret to redeem at admission, if any. Cloned per dial
     /// attempt (a fresh join may try several coordinators).
     invite: Option<Vec<u8>>,
@@ -54,9 +56,58 @@ enum VersionGate {
 /// mesh protocol version.
 struct ResolvedNetwork {
     blob: crate::membership::GroupBlob,
+    /// Exact content hash committed by the verified network record.
+    hash: blake3::Hash,
     /// `Some` when the record advertises a version this build does not speak and
     /// the caller asked to record that rather than refuse.
     mismatch: Option<MeshVersionMismatch>,
+}
+
+/// Where coordinator restore learned the complete blob hash it is allowed to
+/// apply. A live signed record always wins; the cached hash exists only to let a
+/// sole coordinator republish after that record expires while it is offline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RestoreHashSource {
+    Published,
+    Cached,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RestoreTarget {
+    hash: blake3::Hash,
+    peers: Vec<EndpointId>,
+    source: RestoreHashSource,
+}
+
+/// Select the exact content-addressed blob a coordinator may restore. Persisted
+/// members are transport hints only: they can supply bytes for `hash`, but can
+/// neither choose the hash nor become roster data themselves.
+fn select_restore_target(
+    published: Option<(blake3::Hash, Vec<EndpointId>)>,
+    cached: Option<blake3::Hash>,
+    persisted_peers: &[EndpointId],
+) -> Option<RestoreTarget> {
+    let (hash, mut peers, source) = match published {
+        Some((hash, peers)) => (hash, peers, RestoreHashSource::Published),
+        None => (cached?, Vec::new(), RestoreHashSource::Cached),
+    };
+    peers.extend_from_slice(persisted_peers);
+    peers.sort_by_key(|id| *id.as_bytes());
+    peers.dedup();
+    Some(RestoreTarget {
+        hash,
+        peers,
+        source,
+    })
+}
+
+fn apply_join_record_pointer(
+    net: &mut config::NetworkConfig,
+    net_pubkey: EndpointId,
+    group_hash: blake3::Hash,
+) {
+    net.network_public_key = Some(net_pubkey);
+    net.last_group_hash = Some(group_hash);
 }
 
 /// Whether the mesh version a network's record advertises is one this build can
@@ -295,6 +346,7 @@ impl NetworkRegistry {
         };
         let ResolvedNetwork {
             blob: data,
+            hash: group_hash,
             mismatch,
         } = self.resolve_and_fetch_blob(net_pubkey, gate).await?;
 
@@ -355,6 +407,7 @@ impl NetworkRegistry {
             my_hostname: &my_hostname,
             alpn: &alpn,
             net_pubkey,
+            group_hash,
             invite,
             auto_accept_firewall,
             auto_accept_files,
@@ -419,7 +472,13 @@ impl NetworkRegistry {
 
         for peer_id in &peer_ids {
             match self.try_fetch_group_blob(*peer_id, blob_hash).await {
-                Ok(blob) => return Ok(ResolvedNetwork { blob, mismatch }),
+                Ok(blob) => {
+                    return Ok(ResolvedNetwork {
+                        blob,
+                        hash: expected_hash,
+                        mismatch,
+                    });
+                }
                 Err(e) => {
                     tracing::warn!(peer = %peer_id.fmt_short(), error = %e, "failed to fetch blob");
                 }
@@ -548,6 +607,7 @@ impl NetworkRegistry {
                 members: MemberList::from_members(data.members.clone()),
                 approved: ApprovedList::from_entries(data.approved.clone()),
                 snapshot: None,
+                snapshot_commit: Arc::new(AsyncMutex::new(())),
                 converged_hash: None,
                 network_secret_key: None,
                 network_public_key: ctx.net_pubkey,
@@ -720,6 +780,7 @@ impl NetworkRegistry {
             display_name,
             my_hostname,
             net_pubkey,
+            group_hash,
             invite_lock,
             mismatch,
             ..
@@ -776,21 +837,29 @@ impl NetworkRegistry {
             s.network_public_key = net_pubkey;
             s.refresh_snapshot();
         }
-        let snap_bytes = state
+        let snapshot = state
             .read()
             .unwrap()
             .snapshot
             .as_ref()
-            .map(|s| s.msgpack_bytes.clone());
-        if let Some(bytes) = snap_bytes {
-            let _ = self.transport.blob_store.blobs().add_slice(&bytes).await;
+            .map(|s| (s.hash, s.msgpack_bytes.clone()));
+        if let Some((_hash, bytes)) = snapshot
+            && let Err(e) = self.transport.blob_store.blobs().add_slice(&bytes).await
+        {
+            tracing::warn!(error = %e, "failed to store local group snapshot");
         }
 
-        // Save config with network public key (use display_name for config)
-        if let Ok(Some(mut net)) = config::load_network(display_name) {
-            net.network_public_key = Some(net_pubkey);
-            let _ = config::save_network(&net);
-        }
+        // Persist the network key and the exact hash committed by the signed
+        // record in one transaction. The local state above may be a deliberate
+        // partial projection during admission.
+        let updated = config::update_network(display_name, |net| {
+            apply_join_record_pointer(net, net_pubkey, group_hash);
+            Ok(())
+        })?;
+        anyhow::ensure!(
+            updated.is_some(),
+            "network config was deleted while joining"
+        );
 
         // Membership poller
         if let Ok(poller_client) = dht::create_pkarr_client(&self.transport.endpoint) {
@@ -849,34 +918,66 @@ impl NetworkRegistry {
         })))
     }
 
-    /// Fetch the authoritative GroupBlob for a network we coordinate, used to
-    /// restore the roster across a daemon restart. Resolves the pkarr record to
-    /// get the blob hash, reads the bytes back from the local blob store (where
-    /// we stored them before publishing, no network round-trip), and verifies +
-    /// decodes. Falls back to fetching from a seed peer if the local store
-    /// doesn't have them (e.g. blobs dir was wiped). Returns an error if the
-    /// authoritative record or blob is unavailable, so the caller retries
-    /// without publishing stale local state.
+    /// Fetch the complete GroupBlob used to restore a coordinated network. A
+    /// currently signed pkarr record chooses the hash whenever it is reachable.
+    /// If that record has expired, the last complete hash persisted alongside
+    /// the network config lets a sole coordinator read the same content-addressed
+    /// bytes back and republish the record. Persisted member identities are only
+    /// fetch hints for that exact hash; their lossy config roster is never applied.
     pub(crate) async fn restore_roster_from_blob(
         &self,
         net_pubkey: EndpointId,
+        cached_hash: Option<blake3::Hash>,
+        persisted_peers: &[EndpointId],
     ) -> Result<crate::membership::GroupBlob> {
-        let pkarr_client = dht::create_pkarr_client(&self.transport.endpoint)?;
-        let (expected_hash, seed_peers) = dht::resolve_network(&pkarr_client, net_pubkey)
-            .await
-            .context("resolve pkarr record for roster restore")?;
+        let resolved = match dht::create_pkarr_client(&self.transport.endpoint) {
+            Ok(client) => match dht::resolve_network_packet(&client, net_pubkey).await {
+                Ok(packet) => Some(
+                    dht::decode_network_record(&packet)
+                        .context("decode signed pkarr record for roster restore")?,
+                ),
+                Err(e) => {
+                    tracing::debug!(error = %e, "network record unavailable during roster restore");
+                    None
+                }
+            },
+            Err(e) => {
+                tracing::debug!(error = %e, "pkarr client unavailable during roster restore");
+                None
+            }
+        };
+        let resolution_error = resolved
+            .is_none()
+            .then(|| "signed network record was unavailable".to_string());
+        let target =
+            select_restore_target(resolved, cached_hash, persisted_peers).with_context(|| {
+                resolution_error
+                    .clone()
+                    .unwrap_or_else(|| "no roster hash available".into())
+            })?;
+        if target.source == RestoreHashSource::Cached {
+            tracing::warn!(
+                network = %net_pubkey.fmt_short(),
+                error = resolution_error.as_deref().unwrap_or("record unavailable"),
+                hash = %target.hash,
+                "network record unavailable; restoring its last complete local snapshot"
+            );
+        }
+
+        let expected_hash = target.hash;
         let blob_hash = iroh_blobs::Hash::from_bytes(*expected_hash.as_bytes());
 
-        // Local blob store first: the coordinator stored these bytes before
-        // publishing, so they're on disk.
+        // Local blob store first: snapshots are permanently retained when they
+        // are authored or fetched, so the normal restart has no network trip.
         if let Ok(bytes) = self.transport.blob_store.blobs().get_bytes(blob_hash).await
             && let Ok(data) = verify_group_blob(&bytes, &expected_hash)
         {
             return Ok(data);
         }
 
-        // Fall back to fetching from a seed peer.
-        for peer_id in &seed_peers {
+        // A current record's seeds and the saved roster are only transport hints:
+        // every peer must provide bytes matching the selected hash.
+        for peer_id in &target.peers {
             if *peer_id == self.transport.endpoint.id() {
                 continue;
             }
@@ -906,7 +1007,7 @@ impl NetworkRegistry {
                 return Ok(data);
             }
         }
-        anyhow::bail!("group blob not found locally or at any seed peer");
+        anyhow::bail!("group blob {expected_hash} not found locally or at any known peer");
     }
 
     pub(crate) async fn try_fetch_group_blob(
@@ -1116,5 +1217,73 @@ mod tests {
     fn a_republished_matching_version_is_speakable_again() {
         assert!(!mesh_version_is_speakable(Some(2), 4));
         assert!(mesh_version_is_speakable(Some(4), 4));
+    }
+
+    fn id(seed: u8) -> EndpointId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed;
+        SecretKey::from(bytes).public()
+    }
+
+    #[test]
+    fn join_caches_the_signed_record_hash_not_a_local_projection() {
+        let net_pubkey = id(1);
+        let signed_hash = blake3::hash(b"signed complete roster");
+        let local_partial_hash = blake3::hash(b"local partial roster");
+        let mut net = config::empty_network_config("joined");
+        net.last_group_hash = Some(local_partial_hash);
+
+        apply_join_record_pointer(&mut net, net_pubkey, signed_hash);
+
+        assert_eq!(net.network_public_key, Some(net_pubkey));
+        assert_eq!(net.last_group_hash, Some(signed_hash));
+        assert_ne!(net.last_group_hash, Some(local_partial_hash));
+    }
+
+    #[test]
+    fn a_published_restore_hash_wins_over_the_cached_hash() {
+        let published = blake3::hash(b"published");
+        let cached = blake3::hash(b"cached");
+        let record_seed = id(1);
+        let saved_member = id(2);
+
+        let target = select_restore_target(
+            Some((published, vec![record_seed])),
+            Some(cached),
+            &[saved_member],
+        )
+        .expect("published record is a restore target");
+
+        assert_eq!(target.hash, published);
+        assert_eq!(target.source, RestoreHashSource::Published);
+        let mut expected = vec![record_seed, saved_member];
+        expected.sort_by_key(|id| *id.as_bytes());
+        assert_eq!(target.peers, expected);
+    }
+
+    #[test]
+    fn an_unreachable_record_uses_the_last_complete_snapshot_hash() {
+        let cached = blake3::hash(b"cached");
+        let saved_member = id(2);
+
+        let target = select_restore_target(None, Some(cached), &[saved_member])
+            .expect("cached complete snapshot is a restore target");
+
+        assert_eq!(target.hash, cached);
+        assert_eq!(target.source, RestoreHashSource::Cached);
+        assert_eq!(target.peers, vec![saved_member]);
+    }
+
+    #[test]
+    fn restore_has_no_target_without_a_record_or_cached_snapshot() {
+        assert!(select_restore_target(None, None, &[id(2)]).is_none());
+    }
+
+    #[test]
+    fn restore_fetch_hints_are_deduplicated() {
+        let hash = blake3::hash(b"published");
+        let peer = id(1);
+        let target = select_restore_target(Some((hash, vec![peer])), None, &[peer]).unwrap();
+        assert_eq!(target.peers, vec![peer]);
     }
 }

--- a/src/daemon/mesh/create_join.rs
+++ b/src/daemon/mesh/create_join.rs
@@ -854,9 +854,9 @@ impl NetworkRegistry {
     /// get the blob hash, reads the bytes back from the local blob store (where
     /// we stored them before publishing, no network round-trip), and verifies +
     /// decodes. Falls back to fetching from a seed peer if the local store
-    /// doesn't have them (e.g. blobs dir was wiped). Returns an error if the DHT
-    /// is unreachable, so the caller can fall back to the (possibly stale)
-    /// config roster rather than booting empty.
+    /// doesn't have them (e.g. blobs dir was wiped). Returns an error if the
+    /// authoritative record or blob is unavailable, so the caller retries
+    /// without publishing stale local state.
     pub(crate) async fn restore_roster_from_blob(
         &self,
         net_pubkey: EndpointId,

--- a/src/daemon/mesh/exit_node.rs
+++ b/src/daemon/mesh/exit_node.rs
@@ -238,10 +238,6 @@ impl NetworkRegistry {
         peer: &str,
         allow: bool,
     ) -> IpcMessage {
-        let mut app_config = match config::load() {
-            Ok(c) => c,
-            Err(e) => return ipc_err(format!("failed to load config: {e}")),
-        };
         // Resolve to a stored allow-entry: `*` stays literal, otherwise the peer's
         // **user identity** hex, so a paired multi-device peer matches on any of
         // its devices (same normalization the SSH allow-list uses).
@@ -253,21 +249,21 @@ impl NetworkRegistry {
                 None => return ipc_err(format!("could not resolve peer: {peer}")),
             }
         };
-        let Some(net) = app_config.networks.iter_mut().find(|n| n.name == network) else {
-            return ipc_err(format!("no such network: {network}"));
-        };
-        if allow {
-            if !net.exit_allow.iter().any(|p| p == &entry) {
-                net.exit_allow.push(entry.clone());
+        let net = match config::update_network(network, |net| {
+            if allow {
+                if !net.exit_allow.iter().any(|p| p == &entry) {
+                    net.exit_allow.push(entry.clone());
+                }
+            } else {
+                net.exit_allow.retain(|p| p != &entry);
             }
-        } else {
-            net.exit_allow.retain(|p| p != &entry);
-        }
+            Ok(())
+        }) {
+            Ok(Some(net)) => net,
+            Ok(None) => return ipc_err(format!("no such network: {network}")),
+            Err(e) => return ipc_err(format!("failed to persist network config: {e}")),
+        };
         let offering = !net.exit_allow.is_empty();
-        let net = net.clone();
-        if let Err(e) = config::save_network(&net) {
-            return ipc_err(format!("failed to persist network config: {e}"));
-        }
         // Not advertised from here: the roster flag must reflect a gateway that
         // actually forwards, so [`Self::sync_exit_offers`] publishes it only once
         // the reconcile has the kernel state in place (now if the daemon is up,
@@ -292,10 +288,6 @@ impl NetworkRegistry {
     /// over IPv4 alone would receive this node's traffic and have no uplink to
     /// masquerade it onto. Refusing here turns a silent black hole into a sentence.
     pub(crate) async fn exit_node_use(&self, network: &str, peer: Option<String>) -> IpcMessage {
-        let mut app_config = match config::load() {
-            Ok(c) => c,
-            Err(e) => return ipc_err(format!("failed to load config: {e}")),
-        };
         // Validate the selection against the live roster before persisting.
         // Set when the gateway is allowed on an absent IPv6 claim rather than a
         // positive one, so the reply can say so: a log line is not where someone
@@ -329,13 +321,13 @@ impl NetworkRegistry {
             }
             None => None,
         };
-        let Some(net) = app_config.networks.iter_mut().find(|n| n.name == network) else {
-            return ipc_err(format!("no such network: {network}"));
-        };
-        net.exit_node_use = selection;
-        let net = net.clone();
-        if let Err(e) = config::save_network(&net) {
-            return ipc_err(format!("failed to persist network config: {e}"));
+        match config::update_network(network, |net| {
+            net.exit_node_use = selection;
+            Ok(())
+        }) {
+            Ok(Some(_)) => {}
+            Ok(None) => return ipc_err(format!("no such network: {network}")),
+            Err(e) => return ipc_err(format!("failed to persist network config: {e}")),
         }
         // "All traffic" would be a lie: the mesh carries no IPv4, so the tunnel
         // takes IPv6 and leaves the host's IPv4 egress where it already was. Say

--- a/src/daemon/mesh/firewall.rs
+++ b/src/daemon/mesh/firewall.rs
@@ -514,15 +514,12 @@ impl Daemon {
         users: Vec<String>,
         allow: bool,
     ) -> IpcMessage {
-        let mut app_config = match config::load() {
-            Ok(c) => c,
+        let ssh_enabled = match config::load() {
+            Ok(c) => c.ssh_enabled,
             Err(e) => {
                 return ipc_err(format!("failed to load config: {e}"));
             }
         };
-        if !app_config.networks.iter().any(|n| n.name == network) {
-            return ipc_err(format!("no such network: {network}"));
-        }
         // Resolve the peer to a stored allow-entry: `*` stays literal, otherwise
         // resolve to the peer's **user identity** hex. `resolve_peer_name` may
         // return a transport endpoint id (for a connected peer) which differs
@@ -539,29 +536,27 @@ impl Daemon {
                 }
             }
         };
-        let net = app_config
-            .networks
-            .iter_mut()
-            .find(|n| n.name == network)
-            .expect("network presence checked above");
-        if allow {
-            // Normalize: a `*` collapses the list to just `*` (any incl. root);
-            // otherwise dedupe. Empty = the non-root default.
-            let users = normalize_ssh_users(users);
-            match net.ssh_allow.iter_mut().find(|r| r.peer == entry) {
-                Some(r) => r.users = users,
-                None => net.ssh_allow.push(config::SshRule {
-                    peer: entry.clone(),
-                    users,
-                }),
+        let net = match config::update_network(network, |net| {
+            if allow {
+                // Normalize: a `*` collapses the list to just `*` (any incl. root);
+                // otherwise dedupe. Empty = the non-root default.
+                let users = normalize_ssh_users(users);
+                match net.ssh_allow.iter_mut().find(|r| r.peer == entry) {
+                    Some(r) => r.users = users,
+                    None => net.ssh_allow.push(config::SshRule {
+                        peer: entry.clone(),
+                        users,
+                    }),
+                }
+            } else {
+                net.ssh_allow.retain(|r| r.peer != entry);
             }
-        } else {
-            net.ssh_allow.retain(|r| r.peer != entry);
-        }
-        let net = net.clone();
-        if let Err(e) = config::save_network(&net) {
-            return ipc_err(format!("failed to persist network config: {e}"));
-        }
+            Ok(())
+        }) {
+            Ok(Some(net)) => net,
+            Ok(None) => return ipc_err(format!("no such network: {network}")),
+            Err(e) => return ipc_err(format!("failed to persist network config: {e}")),
+        };
         // Push the change to any live listener.
         #[cfg(feature = "desktop")]
         self.rebuild_ssh_authz();
@@ -579,7 +574,7 @@ impl Daemon {
         // Mirror of the `ssh on` nudge: a rule with the server off looks like it
         // took effect, but `:22` still falls through to the host sshd (which
         // asks for a password), so the failure doesn't point back here.
-        if allow && !app_config.ssh_enabled {
+        if allow && !ssh_enabled {
             detail.push_str(
                 "\n\nmesh SSH is off, so this rule is not in effect yet. \
                  Start the server with `ray firewall ssh on`.",

--- a/src/daemon/mesh/join.rs
+++ b/src/daemon/mesh/join.rs
@@ -155,6 +155,7 @@ pub(crate) async fn join_mesh_shared(
         auto_accept_firewall,
         auto_accept_files,
         direct_key.as_ref(),
+        initial,
     )?;
 
     let remote_id = initial_conn.remote_id();
@@ -277,59 +278,57 @@ fn persist_join_config(
     // network key so we survive a restart as a key-holder (a plain member persists
     // `None`).
     direct_key: Option<&SecretKey>,
+    initial: bool,
 ) -> Result<()> {
     let persisted_hostname = members
         .iter()
         .find(|m| m.identity == my_identity)
         .and_then(|m| m.hostname.clone())
         .or(my_hostname.clone());
-    // Preserve across reconnects/restores state the just-fetched blob doesn't
-    // carry: the direct-connection flag, a queued rename intent, the SSH allow
-    // list, node-local aliases, and the local exit-node policy (server
-    // allow-list + selected exit peer). Anything node-local left out of this
-    // list is silently erased on every member daemon restart.
-    let prev = config::load_network(network_name)?;
-    let (direct, direct_peer, pending_hostname, ssh_allow, aliases, prev_auto_accept_files) = prev
-        .as_ref()
-        .map(|n| {
-            (
-                n.direct,
-                n.direct_peer,
-                n.pending_hostname.clone(),
-                n.ssh_allow.clone(),
-                n.aliases.clone(),
-                n.auto_accept_files,
-            )
-        })
-        .unwrap_or((false, None, None, vec![], BTreeMap::new(), false));
-    let (exit_allow, exit_node_use) = prev
-        .map(|n| (n.exit_allow, n.exit_node_use))
-        .unwrap_or((vec![], None));
-    // The toggle command (`ray files auto-accept`) is authoritative, so preserve
-    // a previously-persisted value; the join-time `--auto-accept-files` seed only
-    // needs to take effect on the first join (no prior config).
-    let auto_accept_files = prev_auto_accept_files || auto_accept_files;
-    config::save_network(&config::NetworkConfig {
+    // Reconnects replace only data learned from the join. Node-local policy is
+    // updated against the latest saved config so an unrelated concurrent write
+    // cannot be lost; a fresh join inserts these defaults atomically.
+    let member_entries = to_member_entries(members.iter());
+    let approved_entries = to_approved_entries(approved.iter());
+    let initial_config = config::NetworkConfig {
         name: network_name.to_string(),
         group_mode: GroupMode::Restricted,
-        my_hostname: persisted_hostname,
-        pending_hostname,
-        members: to_member_entries(members.iter()),
-        approved: to_approved_entries(approved.iter()),
+        my_hostname: persisted_hostname.clone(),
+        members: member_entries.clone(),
+        approved: approved_entries.clone(),
         network_secret_key: direct_key.cloned(),
         network_public_key: Some(net_pubkey),
-        transport: None,
         auto_accept_firewall,
         auto_accept_files,
-        admins: vec![],
-        direct,
-        direct_peer,
-        ssh_allow,
-        aliases,
-        ephemeral_ttl_secs: None,
-        exit_allow,
-        exit_node_use,
-    })
+        ..Default::default()
+    };
+    let update = |net: &mut config::NetworkConfig| {
+        net.group_mode = GroupMode::Restricted;
+        // A rename requested while the handshake was in flight is newer than
+        // the roster projection we just received.
+        if net.pending_hostname.is_none() {
+            net.my_hostname = persisted_hostname;
+        }
+        net.members = member_entries;
+        net.approved = approved_entries;
+        net.network_secret_key = direct_key.cloned();
+        net.network_public_key = Some(net_pubkey);
+        if initial {
+            net.auto_accept_firewall = auto_accept_firewall;
+            net.auto_accept_files |= auto_accept_files;
+        }
+        Ok(())
+    };
+    if initial {
+        config::update_network_or_insert(network_name, initial_config, update)?;
+    } else {
+        let updated = config::update_network(network_name, update)?;
+        anyhow::ensure!(
+            updated.is_some(),
+            "network config was deleted while reconnecting"
+        );
+    }
+    Ok(())
 }
 
 /// Build the in-memory `NetworkState` cell for a joined member from the admitted
@@ -355,6 +354,7 @@ async fn build_member_state(
         members: MemberList::from_members(members.to_vec()),
         approved: ApprovedList::from_entries(approved),
         snapshot: None,
+        snapshot_commit: Arc::new(AsyncMutex::new(())),
         converged_hash: None,
         network_secret_key: direct_key.cloned(),
         network_public_key: net_pubkey,
@@ -654,11 +654,12 @@ mod persist_config_tests {
         // Pre-existing config: this node offers an exit (`*`) and routes its own
         // traffic through a chosen peer. This is the state a restart must keep.
         let exit_peer = id(3).to_string();
+        let cached_hash = blake3::hash(b"complete signed roster");
         config::save_network(&NetworkConfig {
             name: "homelab".to_string(),
             group_mode: GroupMode::Restricted,
-            my_hostname: Some("umbrel".to_string()),
-            pending_hostname: None,
+            my_hostname: Some("new-name".to_string()),
+            pending_hostname: Some("new-name".to_string()),
             members: vec![MemberEntry {
                 identity: me,
                 is_coordinator: false,
@@ -667,9 +668,10 @@ mod persist_config_tests {
             approved: vec![],
             network_secret_key: None,
             network_public_key: Some(net_pubkey),
+            last_group_hash: Some(cached_hash),
             transport: None,
-            auto_accept_firewall: false,
-            auto_accept_files: false,
+            auto_accept_firewall: true,
+            auto_accept_files: true,
             admins: vec![],
             direct: false,
             direct_peer: None,
@@ -693,6 +695,7 @@ mod persist_config_tests {
             false,
             false,
             None,
+            false,
         )
         .unwrap();
 
@@ -707,6 +710,71 @@ mod persist_config_tests {
             Some(exit_peer),
             "selected exit peer must survive a reconnect"
         );
+        assert_eq!(
+            after.last_group_hash,
+            Some(cached_hash),
+            "the last complete roster hash must survive a partial reconnect write"
+        );
+        assert!(after.auto_accept_firewall);
+        assert!(after.auto_accept_files);
+        assert_eq!(after.my_hostname.as_deref(), Some("new-name"));
+        assert_eq!(after.pending_hostname.as_deref(), Some("new-name"));
+
+        persist_join_config(
+            "homelab",
+            &[member(2, false), member(4, true)],
+            &[],
+            me,
+            net_pubkey,
+            &Some("umbrel".to_string()),
+            false,
+            false,
+            None,
+            true,
+        )
+        .unwrap();
+        let after_fresh_join = config::load_network("homelab").unwrap().unwrap();
+        assert!(
+            !after_fresh_join.auto_accept_firewall,
+            "a fresh join's firewall-consent flag must replace a saved value"
+        );
+        assert!(
+            after_fresh_join.auto_accept_files,
+            "a fresh join must not turn off an existing file-auto-accept opt-in"
+        );
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("RAYFISH_CONFIG_DIR", v),
+                None => std::env::remove_var("RAYFISH_CONFIG_DIR"),
+            }
+        }
+    }
+
+    #[test]
+    fn reconnect_does_not_recreate_a_deleted_network_config() {
+        let _lock = CONFIG_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var_os("RAYFISH_CONFIG_DIR");
+        unsafe { std::env::set_var("RAYFISH_CONFIG_DIR", tmp.path()) };
+
+        let net_pubkey = id(1);
+        let me = id(2);
+        let result = persist_join_config(
+            "homelab",
+            &[member(2, false), member(4, true)],
+            &[],
+            me,
+            net_pubkey,
+            &Some("umbrel".to_string()),
+            false,
+            false,
+            None,
+            false,
+        );
+
+        assert!(result.is_err());
+        assert!(config::load_network("homelab").unwrap().is_none());
 
         unsafe {
             match prev {

--- a/src/daemon/mesh/publish.rs
+++ b/src/daemon/mesh/publish.rs
@@ -6,11 +6,33 @@
 
 use super::super::*;
 
+/// Renew records with enough margin for scheduler/network delay that a healthy
+/// coordinator never lets its five-minute pkarr lease expire.
+const RECORD_REPUBLISH_INTERVAL: Duration = Duration::from_secs((dht::RECORD_TTL / 2) as u64);
+
+async fn snapshot_is_publishable(blob_store: &FsStore, network: &str, hash: blake3::Hash) -> bool {
+    let hash_is_persisted = config::load_network(network)
+        .ok()
+        .flatten()
+        .is_some_and(|net| net.last_group_hash == Some(hash));
+    if !hash_is_persisted {
+        tracing::warn!(network, %hash, "not publishing a group snapshot without a recovery pointer");
+        return false;
+    }
+    let blob_hash = iroh_blobs::Hash::from_bytes(*hash.as_bytes());
+    if blob_store.blobs().get_bytes(blob_hash).await.is_err() {
+        tracing::warn!(network, %hash, "not publishing a group snapshot absent from local storage");
+        return false;
+    }
+    true
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn spawn_network_publisher(
     client: PkarrRelayClient,
     net_secret_key: SecretKey,
     state: SharedNetworkState,
+    blob_store: FsStore,
     endpoint_id: EndpointId,
     peers: PeerTable,
     network_name: String,
@@ -19,39 +41,36 @@ pub(crate) fn spawn_network_publisher(
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         loop {
-            let hash = {
-                let s = state.read().unwrap();
-                s.snapshot
-                    .as_ref()
-                    .map(|snap| snap.hash)
-                    .unwrap_or_else(|| {
-                        group_blob_hash(
-                            &s.members,
-                            &s.approved,
-                            &s.suggested_firewall,
-                            s.network_name.as_deref(),
-                            &s.reusable_keys,
-                            &s.nullifiers,
-                        )
-                    })
-            };
-            let mut seed_peers: Vec<EndpointId> = peers
-                .peers_for_network(&network_name)
-                .into_iter()
-                .map(|(id, _)| id)
-                .collect();
-            seed_peers.push(endpoint_id);
-            seed_peers.sort_by_key(|id| id.to_string());
-            seed_peers.dedup();
+            {
+                let commit = state.read().unwrap().snapshot_commit.clone();
+                let _commit = commit.lock().await;
+                if let Some(hash) = config::load_network(&network_name)
+                    .ok()
+                    .flatten()
+                    .and_then(|net| net.last_group_hash)
+                    && snapshot_is_publishable(&blob_store, &network_name, hash).await
+                {
+                    let mut seed_peers: Vec<EndpointId> = peers
+                        .peers_for_network(&network_name)
+                        .into_iter()
+                        .map(|(id, _)| id)
+                        .collect();
+                    seed_peers.push(endpoint_id);
+                    seed_peers.sort_by_key(|id| id.to_string());
+                    seed_peers.dedup();
 
-            match dht::publish_network(&client, &net_secret_key, &hash, &seed_peers).await {
-                Ok(()) => tracing::info!(peers = seed_peers.len(), "published network record"),
-                Err(e) => tracing::warn!(error = %e, "failed to publish network record"),
+                    match dht::publish_network(&client, &net_secret_key, &hash, &seed_peers).await {
+                        Ok(()) => {
+                            tracing::info!(peers = seed_peers.len(), "published network record")
+                        }
+                        Err(e) => tracing::warn!(error = %e, "failed to publish network record"),
+                    }
+                }
             }
             tokio::select! {
                 _ = token.cancelled() => break,
                 _ = notify.notified() => {},
-                _ = tokio::time::sleep(Duration::from_secs(300)) => {},
+                _ = tokio::time::sleep(RECORD_REPUBLISH_INTERVAL) => {},
             }
         }
     })
@@ -81,7 +100,7 @@ pub(crate) fn spawn_contact_publisher(
             }
             tokio::select! {
                 _ = token.cancelled() => break,
-                _ = tokio::time::sleep(Duration::from_secs(150)) => {},
+                _ = tokio::time::sleep(RECORD_REPUBLISH_INTERVAL) => {},
             }
         }
     })
@@ -99,6 +118,7 @@ pub(crate) fn spawn_lazy_publisher(
     client: PkarrRelayClient,
     net_secret_key: SecretKey,
     state: SharedNetworkState,
+    blob_store: FsStore,
     endpoint_id: EndpointId,
     peers: PeerTable,
     network_name: String,
@@ -106,42 +126,41 @@ pub(crate) fn spawn_lazy_publisher(
 ) -> JoinHandle<()> {
     const LAZY_PUBLISH_INTERVAL: Duration = Duration::from_secs(10);
     tokio::spawn(async move {
-        let mut last_hash: Option<blake3::Hash> = None;
+        let mut last_publish: Option<(blake3::Hash, Instant)> = None;
         loop {
-            let hash = {
-                let s = state.read().unwrap();
-                s.snapshot
-                    .as_ref()
-                    .map(|snap| snap.hash)
-                    .unwrap_or_else(|| {
-                        group_blob_hash(
-                            &s.members,
-                            &s.approved,
-                            &s.suggested_firewall,
-                            s.network_name.as_deref(),
-                            &s.reusable_keys,
-                            &s.nullifiers,
-                        )
-                    })
-            };
-            if last_hash != Some(hash) {
-                let mut seed_peers: Vec<EndpointId> = peers
-                    .peers_for_network(&network_name)
-                    .into_iter()
-                    .map(|(id, _)| id)
-                    .collect();
-                seed_peers.push(endpoint_id);
-                seed_peers.sort_by_key(|id| id.to_string());
-                seed_peers.dedup();
-                match dht::publish_network(&client, &net_secret_key, &hash, &seed_peers).await {
-                    Ok(()) => {
-                        tracing::info!(
-                            network = %network_name,
-                            "lazy publisher: published network record"
-                        );
-                        last_hash = Some(hash);
+            let hash = config::load_network(&network_name)
+                .ok()
+                .flatten()
+                .and_then(|net| net.last_group_hash);
+            let publish_due = hash.is_some_and(|hash| {
+                last_publish.is_none_or(|(last_hash, published_at)| {
+                    last_hash != hash || published_at.elapsed() >= RECORD_REPUBLISH_INTERVAL
+                })
+            });
+            if let Some(hash) = hash
+                && publish_due
+            {
+                let commit = state.read().unwrap().snapshot_commit.clone();
+                let _commit = commit.lock().await;
+                if snapshot_is_publishable(&blob_store, &network_name, hash).await {
+                    let mut seed_peers: Vec<EndpointId> = peers
+                        .peers_for_network(&network_name)
+                        .into_iter()
+                        .map(|(id, _)| id)
+                        .collect();
+                    seed_peers.push(endpoint_id);
+                    seed_peers.sort_by_key(|id| id.to_string());
+                    seed_peers.dedup();
+                    match dht::publish_network(&client, &net_secret_key, &hash, &seed_peers).await {
+                        Ok(()) => {
+                            tracing::info!(
+                                network = %network_name,
+                                "lazy publisher: published network record"
+                            );
+                            last_publish = Some((hash, Instant::now()));
+                        }
+                        Err(e) => tracing::warn!(error = %e, "lazy publisher: publish failed"),
                     }
-                    Err(e) => tracing::warn!(error = %e, "lazy publisher: publish failed"),
                 }
             }
             tokio::select! {
@@ -152,22 +171,140 @@ pub(crate) fn spawn_lazy_publisher(
     })
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SnapshotPersist {
+    Persisted,
+    Superseded,
+    Failed,
+}
+
+fn persist_current_snapshot_hash(
+    state: &SharedNetworkState,
+    network: &str,
+    hash: blake3::Hash,
+) -> SnapshotPersist {
+    let mut current = false;
+    match config::update_network(network, |net| {
+        current = state
+            .read()
+            .unwrap()
+            .snapshot
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.hash == hash);
+        if current {
+            net.last_group_hash = Some(hash);
+        }
+        Ok(())
+    }) {
+        Ok(Some(_)) if current => SnapshotPersist::Persisted,
+        Ok(Some(_)) => SnapshotPersist::Superseded,
+        Ok(None) => {
+            tracing::warn!(
+                network,
+                "failed to persist group snapshot hash: network was deleted"
+            );
+            SnapshotPersist::Failed
+        }
+        Err(e) => {
+            tracing::warn!(network, error = %e, "failed to persist complete group snapshot hash");
+            SnapshotPersist::Failed
+        }
+    }
+}
+
+pub(crate) fn persist_group_hash_locked(
+    state: &SharedNetworkState,
+    network: &str,
+    hash: blake3::Hash,
+) -> bool {
+    let mut current = false;
+    match config::update_network(network, |net| {
+        current = state.read().unwrap().converged_hash == Some(hash);
+        if current {
+            net.last_group_hash = Some(hash);
+        }
+        Ok(())
+    }) {
+        Ok(Some(_)) => current,
+        Ok(None) => {
+            tracing::warn!(
+                network,
+                "failed to persist group snapshot hash: network was deleted"
+            );
+            false
+        }
+        Err(e) => {
+            tracing::warn!(network, error = %e, "failed to persist complete group snapshot hash");
+            false
+        }
+    }
+}
+
+/// Commit the latest snapshot while the caller holds this state's
+/// `snapshot_commit` guard.
+pub(crate) async fn commit_current_snapshot(
+    state: &SharedNetworkState,
+    blob_store: &FsStore,
+    dht_notify: &Option<Arc<tokio::sync::Notify>>,
+) -> bool {
+    let ready_to_publish = loop {
+        let snapshot = {
+            let mut s = state.write().unwrap();
+            s.refresh_snapshot();
+            if s.network_secret_key.is_some() {
+                s.converged_hash = None;
+            }
+            s.snapshot.as_ref().map(|snap| {
+                (
+                    s.network_name.clone(),
+                    snap.hash,
+                    snap.msgpack_bytes.clone(),
+                )
+            })
+        };
+        let Some((network, hash, bytes)) = snapshot else {
+            break false;
+        };
+        if let Err(e) = blob_store.blobs().add_slice(&bytes).await {
+            tracing::warn!(error = %e, "failed to store complete group snapshot");
+            break false;
+        }
+        let outcome = match network.as_deref() {
+            Some(network) => persist_current_snapshot_hash(state, network, hash),
+            None => {
+                if state
+                    .read()
+                    .unwrap()
+                    .snapshot
+                    .as_ref()
+                    .is_some_and(|snapshot| snapshot.hash == hash)
+                {
+                    SnapshotPersist::Persisted
+                } else {
+                    SnapshotPersist::Superseded
+                }
+            }
+        };
+        match outcome {
+            SnapshotPersist::Persisted => break true,
+            SnapshotPersist::Superseded => continue,
+            SnapshotPersist::Failed => break false,
+        }
+    };
+    if ready_to_publish && let Some(notify) = dht_notify {
+        notify.notify_one();
+    }
+    ready_to_publish
+}
+
 pub(crate) async fn update_snapshot_and_publish(
     state: &SharedNetworkState,
     blob_store: &FsStore,
     dht_notify: &Option<Arc<tokio::sync::Notify>>,
-) {
-    let snap_bytes = {
-        let mut s = state.write().unwrap();
-        s.refresh_snapshot();
-        s.snapshot.as_ref().map(|snap| snap.msgpack_bytes.clone())
-    };
-    if let Some(bytes) = snap_bytes {
-        let _ = blob_store.blobs().add_slice(&bytes).await;
-    }
-    if let Some(notify) = dht_notify {
-        notify.notify_one();
-    }
+) -> bool {
+    let commit = state.read().unwrap().snapshot_commit.clone();
+    let _commit = commit.lock().await;
+    commit_current_snapshot(state, blob_store, dht_notify).await
 }
 
 impl Daemon {
@@ -197,5 +334,103 @@ impl Daemon {
     /// stops resolving once its pkarr record expires (~5 min).
     pub(crate) async fn rotate_contact(&self) -> IpcMessage {
         self.connect.rotate_contact().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CONFIG_ENV_LOCK;
+
+    fn state_with_snapshot(hash: blake3::Hash) -> SharedNetworkState {
+        Arc::new(RwLock::new(NetworkState {
+            members: MemberList::new(),
+            approved: ApprovedList::new(),
+            snapshot: Some(GroupSnapshot {
+                hash,
+                msgpack_bytes: Vec::new(),
+            }),
+            snapshot_commit: Arc::new(AsyncMutex::new(())),
+            converged_hash: None,
+            network_secret_key: None,
+            network_public_key: SecretKey::generate().public(),
+            network_name: Some("test".to_string()),
+            mode: GroupMode::Restricted,
+            suggested_firewall: SuggestedFirewall::default(),
+            reusable_keys: BTreeMap::new(),
+            nullifiers: BTreeSet::new(),
+            last_record_timestamp: None,
+            pending_suggestions: Vec::new(),
+            pending: HashMap::new(),
+        }))
+    }
+
+    #[test]
+    fn superseded_snapshot_cannot_replace_the_newer_recovery_pointer() {
+        let _lock = CONFIG_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let config_dir = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("RAYFISH_CONFIG_DIR");
+        unsafe { std::env::set_var("RAYFISH_CONFIG_DIR", config_dir.path()) };
+
+        let old = blake3::hash(b"old snapshot");
+        let current = blake3::hash(b"current snapshot");
+        let state = state_with_snapshot(current);
+        let mut net = config::empty_network_config("test");
+        net.last_group_hash = Some(current);
+        config::save_network(&net).unwrap();
+
+        assert_eq!(
+            persist_current_snapshot_hash(&state, "test", old),
+            SnapshotPersist::Superseded
+        );
+        assert_eq!(
+            config::load_network("test")
+                .unwrap()
+                .unwrap()
+                .last_group_hash,
+            Some(current)
+        );
+
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("RAYFISH_CONFIG_DIR", value),
+                None => std::env::remove_var("RAYFISH_CONFIG_DIR"),
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(clippy::await_holding_lock)] // serializes this process-global env override
+    async fn publication_requires_both_the_recovery_pointer_and_blob() {
+        let _lock = CONFIG_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let config_dir = tempfile::tempdir().unwrap();
+        let blobs_dir = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("RAYFISH_CONFIG_DIR");
+        unsafe { std::env::set_var("RAYFISH_CONFIG_DIR", config_dir.path()) };
+
+        let store = FsStore::load(blobs_dir.path()).await.unwrap();
+        let bytes = b"complete signed group";
+        let hash = blake3::hash(bytes);
+        let mut net = config::empty_network_config("test");
+        net.last_group_hash = Some(hash);
+        config::save_network(&net).unwrap();
+
+        assert!(!snapshot_is_publishable(&store, "test", hash).await);
+        store.blobs().add_slice(bytes).await.unwrap();
+        assert!(snapshot_is_publishable(&store, "test", hash).await);
+
+        config::update_network("test", |net| {
+            net.last_group_hash = Some(blake3::hash(b"newer complete group"));
+            Ok(())
+        })
+        .unwrap();
+        assert!(!snapshot_is_publishable(&store, "test", hash).await);
+
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("RAYFISH_CONFIG_DIR", value),
+                None => std::env::remove_var("RAYFISH_CONFIG_DIR"),
+            }
+        }
     }
 }

--- a/src/daemon/mesh/reconverge.rs
+++ b/src/daemon/mesh/reconverge.rs
@@ -201,6 +201,20 @@ pub(crate) async fn fetch_verified_blob(
     None
 }
 
+/// Compute a generation directly from the blob-bearing fields. `snapshot` is a
+/// publication cache and may lag mutations that have not reached
+/// `refresh_snapshot` yet, so it cannot safely guard an in-flight reconverge.
+fn current_group_hash(state: &NetworkState) -> blake3::Hash {
+    group_blob_hash(
+        &state.members,
+        &state.approved,
+        &state.suggested_firewall,
+        state.network_name.as_deref(),
+        &state.reusable_keys,
+        &state.nullifiers,
+    )
+}
+
 /// Reconverge the live network state from the signed pkarr record and apply it
 /// (roster + DNS + suggested firewall). Invoked when a peer sends a `MemberSync`
 /// or `BlobUpdated` *hint*: the hint is only a trigger; the roster/firewall come
@@ -228,7 +242,10 @@ pub(crate) async fn reconverge_and_apply(
         registry,
         ..
     } = ctx;
-    let floor = state.read().unwrap().last_record_timestamp;
+    let (floor, generation) = {
+        let s = state.read().unwrap();
+        (s.last_record_timestamp, current_group_hash(&s))
+    };
     let Some((signed, seeds, record_ts)) = resolve_signed(endpoint, net_pubkey).await else {
         tracing::debug!(network = %network_name, "reconverge: signed record unavailable");
         return;
@@ -289,7 +306,6 @@ pub(crate) async fn reconverge_and_apply(
         tracing::warn!(network = %network_name, "reconverge: could not fetch verified blob");
         return;
     };
-    state.write().unwrap().last_record_timestamp = Some(record_ts);
     // Self-unpair: if our own device cert is nullified in this (verified, signed)
     // blob and the blob is coordinated by our *own* primary, the primary has
     // revoked this device. Tear ourselves out (delete the cert + leave every
@@ -298,20 +314,30 @@ pub(crate) async fn reconverge_and_apply(
     // poller already fetches, so it needs no live mesh link. The
     // own-primary-coordinator gate stops a foreign network's coordinator from
     // forcing a global deauth by listing our key.
-    if let Some(cert) = device_cert
-        && self_is_nullified(cert, &data.members, &data.nullifiers)
-    {
-        tracing::warn!(network = %network_name, "this device is nullified by its primary in the signed blob; unpairing self");
-        let registry = registry.clone();
-        tokio::spawn(async move {
-            let _ = registry.unpair_self().await;
-        });
-        return;
-    }
+    let self_nullified = device_cert
+        .as_ref()
+        .is_some_and(|cert| self_is_nullified(cert, &data.members, &data.nullifiers));
+    let commit = state.read().unwrap().snapshot_commit.clone();
+    let commit_guard = commit.lock().await;
     // No tiebreak: an address is blake3 of the identity, so two coordinators
     // admitting concurrently cannot produce a roster with duplicate addresses.
+    // Revalidate and replace under one write guard so a mutation cannot land in
+    // the gap and then be overwritten by this fetched state.
     let roster = {
         let mut s = state.write().unwrap();
+        if current_group_hash(&s) != generation {
+            tracing::debug!(network = %network_name, "reconverge: local roster changed while fetching; discarding stale result");
+            return;
+        }
+        if self_nullified {
+            drop(s);
+            tracing::warn!(network = %network_name, "this device is nullified by its primary in the signed blob; unpairing self");
+            let registry = registry.clone();
+            tokio::spawn(async move {
+                let _ = registry.unpair_self().await;
+            });
+            return;
+        }
         s.members = MemberList::from_members(data.members.clone());
         s.approved = ApprovedList::from_entries(data.approved.clone());
         s.suggested_firewall = data.suggested_firewall.clone();
@@ -320,8 +346,11 @@ pub(crate) async fn reconverge_and_apply(
         // What the network agreed on, which is not our re-encoding of it unless
         // the publisher writes the same bytes we would. See `converged_hash`.
         s.converged_hash = Some(signed);
+        s.last_record_timestamp = Some(record_ts);
         s.roster()
     };
+    persist_group_hash_locked(state, network_name, signed);
+    drop(commit_guard);
     apply_roster_to_dns(
         &roster,
         network_name,
@@ -517,7 +546,7 @@ pub(crate) async fn apply_roster_to_dns(
         .find(|m| m.identity == my_identity)
         .and_then(|m| m.hostname.clone());
 
-    if let Ok(Some(mut net)) = config::load_network(network_name) {
+    let _ = config::update_network(network_name, |net| {
         match net.pending_hostname.clone() {
             // A locally-requested rename is in flight. Until the blob confirms
             // it, keep showing/persisting the requested name and don't let a
@@ -538,13 +567,11 @@ pub(crate) async fn apply_roster_to_dns(
                 }
                 if net.my_hostname.as_deref() != Some(pending.as_str()) {
                     net.my_hostname = Some(pending);
-                    let _ = config::save_network(&net);
                 }
             }
             // Either the rename landed, or there was none: follow the blob and
             // clear any (now-confirmed) pending intent.
             pending => {
-                let mut dirty = false;
                 if let Some(p) = &pending {
                     tracing::info!(
                         network = %network_name,
@@ -553,20 +580,16 @@ pub(crate) async fn apply_roster_to_dns(
                         "rename confirmed by signed blob; clearing pending intent"
                     );
                     net.pending_hostname = None;
-                    dirty = true;
                 }
                 if let Some(mine) = blob_self.clone()
                     && net.my_hostname.as_deref() != Some(mine.as_str())
                 {
                     net.my_hostname = Some(mine);
-                    dirty = true;
-                }
-                if dirty {
-                    let _ = config::save_network(&net);
                 }
             }
         }
-    }
+        Ok(())
+    });
 
     dns::sync_network_hostnames(hostname_table, reverse_table, network_name, &entries).await;
 }
@@ -669,6 +692,8 @@ pub(crate) enum ReconvergeOutcome {
     Applied,
     /// The blob could not be fetched from any peer or seed; nothing changed.
     Unfetched,
+    /// State changed while the blob was in flight, so its result was discarded.
+    Superseded,
     /// This node is no longer part of the network (kicked, or its own primary
     /// nullified this device). The caller should stop polling this network.
     Departed,
@@ -694,6 +719,7 @@ pub(crate) async fn fetch_and_apply_blob(
     remote_hash: blake3::Hash,
     seed_peers: &[EndpointId],
 ) -> ReconvergeOutcome {
+    let generation = current_group_hash(&state.read().unwrap());
     // Fetch the verified blob from any connected peer *or* the record's seed
     // peers. Including the seeds is essential: a node that has been isolated
     // (e.g. an unpaired device the coordinator already severed) has no connected
@@ -717,45 +743,42 @@ pub(crate) async fn fetch_and_apply_blob(
     // nullifiers (`ray unpair`). Tear ourselves out even though we never
     // received `ControlMsg::Unpaired` (we were offline/severed). Rides the
     // signed blob, so it needs no live mesh link. See `self_is_nullified`.
-    if let Some(cert) = crate::identity::load_device_cert().ok().flatten()
-        && self_is_nullified(&cert, &data.members, &data.nullifiers)
-    {
-        tracing::warn!(network = %network_name, "this device is nullified by its primary in the signed blob; unpairing self");
-        let registry = registry.clone();
-        tokio::spawn(async move {
-            let _ = registry.unpair_self().await;
-        });
-        return ReconvergeOutcome::Departed;
-    }
+    let self_nullified = crate::identity::load_device_cert()
+        .ok()
+        .flatten()
+        .is_some_and(|cert| self_is_nullified(&cert, &data.members, &data.nullifiers));
 
-    // Reconcile: find removed peers
-    let old_members: Vec<EndpointId> = {
-        let s = state.read().unwrap();
-        s.members.all().iter().map(|m| m.identity).collect()
-    };
     let new_member_ids: std::collections::HashSet<EndpointId> =
         data.members.iter().map(|m| m.identity).collect();
-
-    for old_id in &old_members {
-        if !new_member_ids.contains(old_id) {
-            let s = state.read().unwrap();
-            if s.members.get(old_id).is_some() {
-                peers.remove(&derive_ipv6(old_id));
-                tracing::info!(peer = %old_id.fmt_short(), "removed kicked peer");
-            }
-        }
-    }
-
     let my_id = endpoint.id();
-    if !new_member_ids.contains(&my_id) && !data.approved.iter().any(|a| a.identity == my_id) {
-        tracing::warn!("we have been removed from the network");
-        return ReconvergeOutcome::Departed;
-    }
+    let self_removed =
+        !new_member_ids.contains(&my_id) && !data.approved.iter().any(|a| a.identity == my_id);
 
-    // Update state and re-materialize suggested firewall rules from the freshly
-    // verified blob. Suggestions ride in the blob, so they are refreshed here.
-    {
+    let commit = state.read().unwrap().snapshot_commit.clone();
+    let commit_guard = commit.lock().await;
+    // Revalidate and replace under one write guard so a mutation cannot land in
+    // the gap and then be overwritten by this fetched state.
+    let old_members: Vec<EndpointId> = {
         let mut s = state.write().unwrap();
+        if current_group_hash(&s) != generation {
+            tracing::debug!(network = %network_name, "reconverge: local roster changed while fetching; discarding stale result");
+            return ReconvergeOutcome::Superseded;
+        }
+        if self_nullified {
+            drop(s);
+            tracing::warn!(network = %network_name, "this device is nullified by its primary in the signed blob; unpairing self");
+            let registry = registry.clone();
+            tokio::spawn(async move {
+                let _ = registry.unpair_self().await;
+            });
+            return ReconvergeOutcome::Departed;
+        }
+        if self_removed {
+            drop(s);
+            tracing::warn!("we have been removed from the network");
+            return ReconvergeOutcome::Departed;
+        }
+        let old_members = s.members.all().iter().map(|m| m.identity).collect();
         s.members = MemberList::from_members(data.members.clone());
         s.approved = ApprovedList::from_entries(data.approved.clone());
         s.suggested_firewall = data.suggested_firewall.clone();
@@ -764,7 +787,21 @@ pub(crate) async fn fetch_and_apply_blob(
         // The hash the network agreed on, not our re-encoding of it. See
         // `converged_hash`.
         s.converged_hash = Some(remote_hash);
+        old_members
+    };
+
+    // Reconcile: find removed peers after the state replacement. `old_members`
+    // was captured under the same guard, so each absent id was present in the
+    // generation we just replaced.
+    for old_id in &old_members {
+        if !new_member_ids.contains(old_id) {
+            peers.remove(&derive_ipv6(old_id));
+            tracing::info!(peer = %old_id.fmt_short(), "removed kicked peer");
+        }
     }
+
+    persist_group_hash_locked(state, network_name, remote_hash);
+    drop(commit_guard);
     apply_suggested_firewall(fw, endpoint.id(), network_name, state);
 
     // Exit-node reconciliation. The fresh roster may have wiped our advertised

--- a/src/daemon/mesh/runtime.rs
+++ b/src/daemon/mesh/runtime.rs
@@ -49,6 +49,60 @@ struct RestoredRoster {
     nullifiers: BTreeSet<EndpointId>,
 }
 
+/// Turn a complete content-addressed blob into coordinator state, reconciling the
+/// one authority the blob cannot revoke: possession of the network secret key.
+/// Existing signed metadata is preserved; only the local key-holder role and its
+/// online timestamp are local facts refreshed at boot.
+fn materialize_coordinator_roster(
+    data: crate::membership::GroupBlob,
+    local_identity: EndpointId,
+    persisted_hostname: Option<String>,
+) -> RestoredRoster {
+    let mut members = MemberList::from_members(data.members);
+    match members.get_mut(&local_identity) {
+        Some(local) => {
+            local.is_coordinator = true;
+            local.last_seen = None;
+        }
+        None => members.add(Member {
+            identity: local_identity,
+            is_coordinator: true,
+            hostname: persisted_hostname,
+            user_identity: None,
+            device_cert: None,
+            last_seen: None,
+            exit_node: false,
+            exit_families: ExitFamilies::Unknown,
+        }),
+    }
+    RestoredRoster {
+        members,
+        approved: ApprovedList::from_entries(data.approved),
+        suggested_firewall: data.suggested_firewall,
+        reusable_keys: data.reusable_keys,
+        nullifiers: data.nullifiers,
+    }
+}
+
+fn apply_coordinator_restore_to_config(
+    config: &mut config::NetworkConfig,
+    mode: GroupMode,
+    members: &MemberList,
+    approved: &ApprovedList,
+    net_secret_key: &SecretKey,
+    last_group_hash: Option<blake3::Hash>,
+) {
+    config.group_mode = mode;
+    config.pending_hostname = None;
+    config.members = to_member_entries(members.all());
+    config.approved = to_approved_entries(approved.all());
+    config.network_secret_key = Some(net_secret_key.clone());
+    config.network_public_key = Some(net_secret_key.public());
+    if let Some(hash) = last_group_hash {
+        config.last_group_hash = Some(hash);
+    }
+}
+
 impl NetworkRegistry {
     /// Rebuild a network's roster for a coordinator restart from the published,
     /// network-key-signed `GroupBlob` (members + approved + suggested firewall +
@@ -58,38 +112,24 @@ impl NetworkRegistry {
         &self,
         name: &str,
         net_public_key: EndpointId,
+        net_config: &config::NetworkConfig,
     ) -> Result<RestoredRoster> {
+        let persisted_peers: Vec<_> = net_config.members.iter().map(|m| m.identity).collect();
         let data = self
-            .restore_roster_from_blob(net_public_key)
+            .restore_roster_from_blob(net_public_key, net_config.last_group_hash, &persisted_peers)
             .await
-            .with_context(|| format!("restore authoritative roster for '{name}'"))?;
-        let mut member_list = MemberList::new();
-        let mut approved_list = ApprovedList::new();
-        for member in &data.members {
-            member_list.add(member.clone());
-        }
-        for approved in &data.approved {
-            approved_list.approve(approved.clone());
-        }
-        let me = self.transport.identity.local_identity();
-        if !member_list
-            .get(&me)
-            .is_some_and(|member| member.is_coordinator)
-        {
-            anyhow::bail!("authoritative roster does not list this key holder as a coordinator");
-        }
+            .with_context(|| format!("restore complete roster for '{name}'"))?;
+        let restored = materialize_coordinator_roster(
+            data,
+            self.transport.identity.local_identity(),
+            net_config.my_hostname.clone(),
+        );
         tracing::info!(
             network = %name,
-            members = member_list.all().len(),
-            "restored roster from published group blob"
+            members = restored.members.all().len(),
+            "restored roster from complete group blob"
         );
-        Ok(RestoredRoster {
-            members: member_list,
-            approved: approved_list,
-            suggested_firewall: data.suggested_firewall,
-            reusable_keys: data.reusable_keys,
-            nullifiers: data.nullifiers,
-        })
+        Ok(restored)
     }
 
     /// Restores a coordinator network from saved config (uses the existing name).
@@ -106,14 +146,14 @@ impl NetworkRegistry {
 
         let my_ip = self.transport.identity.local_ipv6();
 
-        // Load persisted network secret key from config
-        let app_config = config::load()?;
-        let net_config = app_config.networks.iter().find(|n| n.name == name);
+        // Load persisted network secret key from config.
+        let net_config = config::load_network(name)?.context("network is no longer saved")?;
         let net_secret_key = net_config
-            .and_then(|nc| nc.network_secret_key.clone())
+            .network_secret_key
+            .clone()
             .context("no network secret key in config — cannot restore as coordinator")?;
         let net_public_key = net_secret_key.public();
-        let persisted_hostname = net_config.and_then(|nc| nc.my_hostname.clone());
+        let persisted_hostname = net_config.my_hostname.clone();
 
         // Restore membership from the authoritative published GroupBlob. The blob
         // (members + approved) is signed by the per-network key and published
@@ -132,12 +172,15 @@ impl NetworkRegistry {
             suggested_firewall,
             reusable_keys,
             nullifiers,
-        } = self.restore_member_roster(name, net_public_key).await?;
+        } = self
+            .restore_member_roster(name, net_public_key, &net_config)
+            .await?;
 
         let mut net_state = NetworkState {
             members: member_list,
             approved: approved_list,
             snapshot: None,
+            snapshot_commit: Arc::new(AsyncMutex::new(())),
             converged_hash: None,
             network_secret_key: Some(net_secret_key.clone()),
             network_public_key: net_public_key,
@@ -153,45 +196,25 @@ impl NetworkRegistry {
             last_record_timestamp: None,
         };
 
-        self.seal_and_publish(&mut net_state, &net_secret_key).await;
+        let last_group_hash = self.seal_group_snapshot(&mut net_state).await?;
 
-        // Update config
-        let member_entries = to_member_entries(net_state.members.all());
-        let approved_entries = to_approved_entries(net_state.approved.all());
-        config::save_network(&config::NetworkConfig {
-            name: name.to_string(),
-            group_mode: mode,
-            my_hostname: persisted_hostname.clone(),
-            // Coordinators publish renames directly, so they never carry a
-            // pending intent.
-            pending_hostname: None,
-            members: member_entries,
-            approved: approved_entries,
-            network_secret_key: Some(net_secret_key.clone()),
-            network_public_key: Some(net_public_key),
-            transport: None,
-            // Preserve the persisted consent flag + admin roster across a
-            // restart; only the roster (members/approved) is authoritative
-            // from the blob.
-            auto_accept_firewall: net_config
-                .map(|nc| nc.auto_accept_firewall)
-                .unwrap_or(false),
-            auto_accept_files: net_config.map(|nc| nc.auto_accept_files).unwrap_or(false),
-            admins: net_config.map(|nc| nc.admins.clone()).unwrap_or_default(),
-            direct: net_config.map(|nc| nc.direct).unwrap_or(false),
-            direct_peer: net_config.and_then(|nc| nc.direct_peer),
-            ssh_allow: net_config
-                .map(|nc| nc.ssh_allow.clone())
-                .unwrap_or_default(),
-            aliases: net_config.map(|nc| nc.aliases.clone()).unwrap_or_default(),
-            ephemeral_ttl_secs: None,
-            // Local exit-node policy survives restarts (server allow-list and the
-            // client's selected exit peer); neither rides the signed blob.
-            exit_allow: net_config
-                .map(|nc| nc.exit_allow.clone())
-                .unwrap_or_default(),
-            exit_node_use: net_config.and_then(|nc| nc.exit_node_use.clone()),
+        // Replace only the blob-derived projection on the latest saved config.
+        // Everything else in this file is node-local policy and must survive
+        // both a coordinator restart and writes made while restoration awaited.
+        let updated = config::update_network(name, |latest| {
+            apply_coordinator_restore_to_config(
+                latest,
+                mode,
+                &net_state.members,
+                &net_state.approved,
+                &net_secret_key,
+                Some(last_group_hash),
+            );
+            Ok(())
         })?;
+        anyhow::ensure!(updated.is_some(), "network is no longer saved");
+        self.publish_group_hash(&net_secret_key, last_group_hash)
+            .await;
 
         let cancel = self.shutdown_token.child_token();
         let state = Arc::new(RwLock::new(net_state));
@@ -1626,4 +1649,149 @@ fn peer_underlay_ips(conn: &Connection) -> Vec<IpAddr> {
         }
     }
     ips
+}
+
+#[cfg(test)]
+mod coordinator_restore_tests {
+    use super::*;
+
+    fn id(seed: u8) -> EndpointId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed;
+        SecretKey::from(bytes).public()
+    }
+
+    fn member(identity: EndpointId, coordinator: bool) -> Member {
+        Member {
+            identity,
+            is_coordinator: coordinator,
+            hostname: None,
+            user_identity: None,
+            device_cert: None,
+            last_seen: Some(42),
+            exit_node: false,
+            exit_families: ExitFamilies::Unknown,
+        }
+    }
+
+    fn blob(members: Vec<Member>) -> crate::membership::GroupBlob {
+        crate::membership::GroupBlob {
+            members,
+            approved: Vec::new(),
+            suggested_firewall: SuggestedFirewall::default(),
+            name: Some("signed-name".to_string()),
+            reusable_keys: BTreeMap::new(),
+            nullifiers: BTreeSet::new(),
+        }
+    }
+
+    #[test]
+    fn restore_repairs_an_existing_key_holder() {
+        let me = id(1);
+        let mut existing = member(me, false);
+        existing.hostname = Some("signed-host".to_string());
+        existing.exit_node = true;
+        existing.exit_families = ExitFamilies::V6;
+
+        let restored = materialize_coordinator_roster(blob(vec![existing]), me, None);
+        let mine = restored.members.get(&me).unwrap();
+
+        assert!(mine.is_coordinator);
+        assert_eq!(mine.hostname.as_deref(), Some("signed-host"));
+        assert!(mine.exit_node);
+        assert_eq!(mine.exit_families, ExitFamilies::V6);
+        assert_eq!(mine.last_seen, None);
+    }
+
+    #[test]
+    fn restore_inserts_an_absent_key_holder_without_dropping_the_roster() {
+        let me = id(1);
+        let peer = id(2);
+
+        let restored = materialize_coordinator_roster(
+            blob(vec![member(peer, true)]),
+            me,
+            Some("local-host".to_string()),
+        );
+
+        assert_eq!(restored.members.all().len(), 2);
+        assert!(restored.members.get(&peer).is_some());
+        let mine = restored.members.get(&me).unwrap();
+        assert!(mine.is_coordinator);
+        assert_eq!(mine.hostname.as_deref(), Some("local-host"));
+    }
+
+    #[test]
+    fn restore_preserves_complete_blob_policy_state() {
+        let me = id(1);
+        let approved_id = id(2);
+        let nullified = id(3);
+        let (key_hash, key) = crate::membership::ReusableKey::from_secret(b"key", 10, 20);
+        let approved = ApprovedEntry {
+            identity: approved_id,
+            hostname: Some("waiting".to_string()),
+            user_identity: None,
+            device_cert: None,
+        };
+        let mut source = blob(vec![member(me, true)]);
+        source.approved.push(approved.clone());
+        source.reusable_keys.insert(key_hash.clone(), key.clone());
+        source.nullifiers.insert(nullified);
+
+        let restored = materialize_coordinator_roster(source, me, None);
+
+        assert_eq!(restored.approved.all(), vec![&approved]);
+        assert_eq!(restored.reusable_keys.get(&key_hash), Some(&key));
+        assert_eq!(restored.nullifiers, BTreeSet::from([nullified]));
+    }
+
+    #[test]
+    fn restore_changes_only_blob_derived_config_fields() {
+        let me = id(1);
+        let key = SecretKey::generate();
+        let hash = blake3::hash(b"complete snapshot");
+        let mut members = MemberList::new();
+        members.add(member(me, true));
+        let mut config = config::NetworkConfig {
+            name: "local-name".to_string(),
+            pending_hostname: Some("queued-rename".to_string()),
+            transport: Some(config::TransportMode::Tor),
+            auto_accept_firewall: true,
+            ephemeral_ttl_secs: Some(7_200),
+            exit_allow: vec!["*".to_string()],
+            ..Default::default()
+        };
+
+        apply_coordinator_restore_to_config(
+            &mut config,
+            GroupMode::Restricted,
+            &members,
+            &ApprovedList::new(),
+            &key,
+            Some(hash),
+        );
+
+        assert_eq!(config.name, "local-name");
+        assert_eq!(config.transport, Some(config::TransportMode::Tor));
+        assert!(config.auto_accept_firewall);
+        assert_eq!(config.ephemeral_ttl_secs, Some(7_200));
+        assert_eq!(config.exit_allow, vec!["*"]);
+        assert_eq!(config.pending_hostname, None);
+        assert_eq!(config.last_group_hash, Some(hash));
+        assert_eq!(config.network_public_key, Some(key.public()));
+
+        apply_coordinator_restore_to_config(
+            &mut config,
+            GroupMode::Restricted,
+            &members,
+            &ApprovedList::new(),
+            &key,
+            None,
+        );
+        assert_eq!(
+            config.last_group_hash,
+            Some(hash),
+            "a failed replacement snapshot write must retain the recovery pointer"
+        );
+    }
 }

--- a/src/daemon/mesh/runtime.rs
+++ b/src/daemon/mesh/runtime.rs
@@ -39,8 +39,8 @@ enum RestoreNext {
     Stop,
 }
 
-/// The membership a coordinator restores at startup, sourced from the signed
-/// `GroupBlob` (authoritative) or the stale config roster as a fallback.
+/// The membership a coordinator restores at startup from the authoritative,
+/// network-key-signed `GroupBlob`.
 struct RestoredRoster {
     members: MemberList,
     approved: ApprovedList,
@@ -50,93 +50,46 @@ struct RestoredRoster {
 }
 
 impl NetworkRegistry {
-    /// Rebuild a network's roster for a coordinator restart. Prefers the
-    /// published, network-key-signed `GroupBlob` (members + approved + suggested
-    /// firewall + reusable keys); if the DHT is unreachable, falls back to the
-    /// last-persisted config roster (which may be stale). Always ensures this
-    /// node is present as a coordinator member.
+    /// Rebuild a network's roster for a coordinator restart from the published,
+    /// network-key-signed `GroupBlob` (members + approved + suggested firewall +
+    /// reusable keys). A transient resolve/fetch failure is an error so the
+    /// restore supervisor retries without publishing stale local config.
     async fn restore_member_roster(
         &self,
         name: &str,
         net_public_key: EndpointId,
-        net_config: Option<&config::NetworkConfig>,
-        persisted_hostname: &Option<String>,
-    ) -> RestoredRoster {
+    ) -> Result<RestoredRoster> {
+        let data = self
+            .restore_roster_from_blob(net_public_key)
+            .await
+            .with_context(|| format!("restore authoritative roster for '{name}'"))?;
         let mut member_list = MemberList::new();
         let mut approved_list = ApprovedList::new();
-        // `suggested_firewall` is authoritative in the signed blob; fall back to
-        // an empty set only if the blob can't be fetched.
-        let mut suggested_firewall = SuggestedFirewall::default();
-        // Reusable join keys are authoritative in the signed blob too.
-        let mut reusable_keys = BTreeMap::new();
-        let mut nullifiers = BTreeSet::new();
-        match self.restore_roster_from_blob(net_public_key).await {
-            Ok(data) => {
-                suggested_firewall = data.suggested_firewall.clone();
-                reusable_keys = data.reusable_keys.clone();
-                nullifiers = data.nullifiers.clone();
-                for m in &data.members {
-                    member_list.add(m.clone());
-                }
-                for a in &data.approved {
-                    approved_list.approve(a.clone());
-                }
-                tracing::info!(
-                    network = %name,
-                    members = member_list.all().len(),
-                    "restored roster from published group blob"
-                );
-            }
-            Err(e) => {
-                tracing::warn!(
-                    network = %name,
-                    error = %e,
-                    "could not restore roster from DHT blob; falling back to config (may be stale)"
-                );
-                if let Some(nc) = net_config {
-                    for entry in &nc.members {
-                        member_list.add(Member {
-                            identity: entry.identity,
-                            is_coordinator: entry.is_coordinator,
-                            hostname: entry.hostname.clone(),
-                            user_identity: None,
-                            device_cert: None,
-                            last_seen: None,
-                            exit_node: false,
-                            exit_families: ExitFamilies::Unknown,
-                        });
-                    }
-                    for entry in &nc.approved {
-                        let ae = ApprovedEntry {
-                            identity: entry.identity,
-                            hostname: entry.hostname.clone(),
-                            user_identity: None,
-                            device_cert: None,
-                        };
-                        approved_list.approve(ae);
-                    }
-                }
-            }
+        for member in &data.members {
+            member_list.add(member.clone());
         }
-        if !member_list.is_member(&self.transport.identity.local_identity()) {
-            member_list.add(Member {
-                identity: self.transport.identity.local_identity(),
-                is_coordinator: true,
-                hostname: persisted_hostname.clone(),
-                user_identity: None,
-                device_cert: None,
-                last_seen: None,
-                exit_node: false,
-                exit_families: ExitFamilies::Unknown,
-            });
+        for approved in &data.approved {
+            approved_list.approve(approved.clone());
         }
-        RestoredRoster {
+        let me = self.transport.identity.local_identity();
+        if !member_list
+            .get(&me)
+            .is_some_and(|member| member.is_coordinator)
+        {
+            anyhow::bail!("authoritative roster does not list this key holder as a coordinator");
+        }
+        tracing::info!(
+            network = %name,
+            members = member_list.all().len(),
+            "restored roster from published group blob"
+        );
+        Ok(RestoredRoster {
             members: member_list,
             approved: approved_list,
-            suggested_firewall,
-            reusable_keys,
-            nullifiers,
-        }
+            suggested_firewall: data.suggested_firewall,
+            reusable_keys: data.reusable_keys,
+            nullifiers: data.nullifiers,
+        })
     }
 
     /// Restores a coordinator network from saved config (uses the existing name).
@@ -167,7 +120,8 @@ impl NetworkRegistry {
         // to DHT, so it is the source of truth and survives a daemon restart. The
         // local blob store still holds the bytes we published before going down, so
         // we read them back by the hash in the pkarr record (falling back to a seed
-        // peer, then to the stale config roster only if the DHT is unreachable).
+        // peer. If neither source has it, restoration fails and is retried without
+        // publishing anything.
         // Restoring from the blob is also what prevents a clobber: the rebuilt
         // snapshot hashes identical to the published record, so the periodic
         // re-publish becomes a no-op instead of overwriting the roster with a
@@ -178,9 +132,7 @@ impl NetworkRegistry {
             suggested_firewall,
             reusable_keys,
             nullifiers,
-        } = self
-            .restore_member_roster(name, net_public_key, net_config, &persisted_hostname)
-            .await;
+        } = self.restore_member_roster(name, net_public_key).await?;
 
         let mut net_state = NetworkState {
             members: member_list,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -315,6 +315,9 @@ pub(crate) struct NetworkState {
     members: MemberList,
     approved: ApprovedList,
     snapshot: Option<GroupSnapshot>,
+    /// Serializes durable snapshot-pointer updates with DHT publication for this
+    /// network. Clone the Arc under the state read lock, then await it separately.
+    snapshot_commit: Arc<AsyncMutex<()>>,
     /// The hash of the signed record this state is converged on, which is not
     /// always the hash of [`Self::snapshot`].
     ///
@@ -1017,17 +1020,12 @@ impl Daemon {
         key: NetworkKey,
         value: &str,
     ) -> IpcMessage {
-        let mut net = match config::load_network(network) {
-            Ok(Some(n)) => n,
-            Ok(None) => return ipc_err(format!("network '{network}' not found")),
-            Err(e) => return ipc_err(format!("failed to load network: {e}")),
-        };
-        if let Err(e) = settings::apply_network(&mut net, key, value) {
-            return ipc_err(e.to_string());
-        }
-        if let Err(e) = config::save_network(&net) {
-            return ipc_err(format!("failed to save config: {e}"));
-        }
+        let net =
+            match config::update_network(network, |net| settings::apply_network(net, key, value)) {
+                Ok(Some(net)) => net,
+                Ok(None) => return ipc_err(format!("network '{network}' not found")),
+                Err(e) => return ipc_err(format!("failed to save config: {e}")),
+            };
         // Run the live re-materialization the key implies, then confirm.
         match key {
             NetworkKey::AutoAcceptFirewall => self.registry.reapply_suggested_firewall(network),
@@ -1322,15 +1320,15 @@ impl Daemon {
         // pending intent so it keeps being delivered to a coordinator across
         // reconnects/restarts until the signed blob confirms it; a coordinator
         // publishes authoritatively, so it clears any pending intent.
-        if let Ok(Some(mut net)) = config::load_network(network) {
+        let _ = config::update_network(network, |net| {
             net.my_hostname = Some(new_hostname.clone());
             net.pending_hostname = if is_coord {
                 None
             } else {
                 Some(new_hostname.clone())
             };
-            let _ = config::save_network(&net);
-        }
+            Ok(())
+        });
 
         // Fast-path the rename to connected peers via `MeshHello`, regardless of
         // role. A peer *coordinator* only learns a self-rename this way: it acts
@@ -1996,6 +1994,7 @@ mod accept_handler_tests {
             members: MemberList::new(),
             approved: ApprovedList::new(),
             snapshot: None,
+            snapshot_commit: Arc::new(AsyncMutex::new(())),
             converged_hash: None,
             network_secret_key: None,
             network_public_key: net_pub,

--- a/src/daemon/network_registry.rs
+++ b/src/daemon/network_registry.rs
@@ -574,16 +574,7 @@ impl NetworkRegistry {
         let mut net_state =
             self.build_initial_roster(&name, &my_hostname, mode, &net_secret_key, pre_approve)?;
 
-        dns::update_hostname(
-            &self.dns.hostname_table,
-            &self.dns.reverse_table,
-            &name,
-            &my_hostname,
-            derive_ipv6(&self.transport.identity.local_identity()),
-        )
-        .await;
-
-        self.seal_and_publish(&mut net_state, &net_secret_key).await;
+        let last_group_hash = self.seal_group_snapshot(&mut net_state).await?;
 
         let member_entries = to_member_entries(net_state.members.all());
         let approved_entries = to_approved_entries(net_state.approved.all());
@@ -596,6 +587,7 @@ impl NetworkRegistry {
             approved: approved_entries,
             network_secret_key: Some(net_secret_key.clone()),
             network_public_key: Some(net_public_key),
+            last_group_hash: Some(last_group_hash),
             transport: None,
             auto_accept_firewall: false,
             // Own-device file offers are auto-accepted by default (identity-checked).
@@ -612,6 +604,16 @@ impl NetworkRegistry {
             exit_allow: vec![],
             exit_node_use: None,
         })?;
+        dns::update_hostname(
+            &self.dns.hostname_table,
+            &self.dns.reverse_table,
+            &name,
+            &my_hostname,
+            derive_ipv6(&self.transport.identity.local_identity()),
+        )
+        .await;
+        self.publish_group_hash(&net_secret_key, last_group_hash)
+            .await;
 
         let cancel = self.shutdown_token.child_token();
         let state = Arc::new(std::sync::RwLock::new(net_state));
@@ -700,6 +702,7 @@ impl NetworkRegistry {
             members: member_list,
             approved,
             snapshot: None,
+            snapshot_commit: Arc::new(AsyncMutex::new(())),
             converged_hash: None,
             network_secret_key: Some(net_secret_key.clone()),
             network_public_key: net_secret_key.public(),
@@ -716,14 +719,14 @@ impl NetworkRegistry {
         })
     }
 
-    /// Seed a coordinated network's nullifiers from our durable `revoked_devices`,
-    /// refresh its blob snapshot, store the bytes, and publish the signed pkarr
-    /// record. The coordinator-setup counterpart to [`Self::store_and_publish_group`].
-    pub(crate) async fn seal_and_publish(
+    /// Seed a coordinated network's nullifiers from our durable
+    /// `revoked_devices`, refresh its blob snapshot, and durably store the bytes.
+    /// The caller persists the returned hash before publishing it, so a crash can
+    /// never leave the DHT newer than the recovery pointer on disk.
+    pub(crate) async fn seal_group_snapshot(
         &self,
         net_state: &mut NetworkState,
-        net_secret_key: &SecretKey,
-    ) {
+    ) -> Result<blake3::Hash> {
         {
             let cfg = config::load().unwrap_or_default();
             net_state
@@ -731,30 +734,36 @@ impl NetworkRegistry {
                 .extend(config::revoked_device_ids(&cfg));
         }
         net_state.refresh_snapshot();
-        if let Some(snap) = &net_state.snapshot {
-            let _ = self
-                .transport
-                .blob_store
-                .blobs()
-                .add_slice(&snap.msgpack_bytes)
-                .await;
-        }
-        if let Ok(pkarr_client) = dht::create_pkarr_client(&self.transport.endpoint) {
-            let blob_hash = net_state
-                .snapshot
-                .as_ref()
-                .map(|s| s.hash)
-                .expect("snapshot set");
-            if let Err(e) = dht::publish_network(
-                &pkarr_client,
-                net_secret_key,
-                &blob_hash,
-                &[self.transport.endpoint.id()],
-            )
+        let snap = net_state
+            .snapshot
+            .as_ref()
+            .context("group snapshot missing")?;
+        self.transport
+            .blob_store
+            .blobs()
+            .add_slice(&snap.msgpack_bytes)
             .await
-            {
-                tracing::warn!(error = %e, "failed to publish network record");
-            }
+            .context("store complete group snapshot")?;
+        Ok(snap.hash)
+    }
+
+    pub(crate) async fn publish_group_hash(
+        &self,
+        net_secret_key: &SecretKey,
+        blob_hash: blake3::Hash,
+    ) {
+        let Ok(pkarr_client) = dht::create_pkarr_client(&self.transport.endpoint) else {
+            return;
+        };
+        if let Err(e) = dht::publish_network(
+            &pkarr_client,
+            net_secret_key,
+            &blob_hash,
+            &[self.transport.endpoint.id()],
+        )
+        .await
+        {
+            tracing::warn!(error = %e, "failed to publish network record");
         }
     }
 
@@ -779,6 +788,7 @@ impl NetworkRegistry {
                 pkarr_client,
                 net_secret_key.clone(),
                 state.clone(),
+                self.transport.blob_store.clone(),
                 self.transport.endpoint.id(),
                 self.peers.clone(),
                 name.to_string(),
@@ -798,40 +808,17 @@ impl NetworkRegistry {
         tasks
     }
 
-    /// Store a network's current blob snapshot in the blob store and publish the
-    /// signed pkarr record (hash + seed peers). No-op if the network is gone or
-    /// has no snapshot / secret key (only a coordinator holds the key).
+    /// Store a network's current blob snapshot, persist its recovery pointer,
+    /// and wake its single publisher. Publication stays serialized in that task,
+    /// so an older async write can never complete after a newer one.
     pub(crate) async fn store_and_publish_group(&self, network: &str) {
-        let (hash, net_key, snap_bytes) = {
+        let (state, notify) = {
             let Some(handle) = self.networks.get(network) else {
                 return;
             };
-            let s = handle.state.read().unwrap();
-            (
-                s.snapshot.as_ref().map(|x| x.hash),
-                s.network_secret_key.clone(),
-                s.snapshot.as_ref().map(|x| x.msgpack_bytes.clone()),
-            )
+            (handle.state.clone(), handle.dht_notify.clone())
         };
-        if let Some(bytes) = snap_bytes {
-            let _ = self.transport.blob_store.blobs().add_slice(&bytes).await;
-        }
-        if let (Some(hash), Some(key)) = (hash, net_key)
-            && let Ok(client) = dht::create_pkarr_client(&self.transport.endpoint)
-        {
-            let mut seed_peers: Vec<EndpointId> = self
-                .peers
-                .peers_for_network(network)
-                .into_iter()
-                .map(|(id, _)| id)
-                .collect();
-            seed_peers.push(self.transport.endpoint.id());
-            seed_peers.sort_by_key(|id| id.to_string());
-            seed_peers.dedup();
-            if let Err(e) = dht::publish_network(&client, &key, &hash, &seed_peers).await {
-                tracing::warn!(error = %e, "failed to publish network record after accept");
-            }
-        }
+        update_snapshot_and_publish(&state, &self.transport.blob_store, &notify).await;
     }
 
     /// This coordinator's current network record, serialized as a signed pkarr
@@ -841,13 +828,13 @@ impl NetworkRegistry {
     /// snapshot yet. Mirrors the record built by [`Self::store_and_publish_group`];
     /// the receiver verifies it against the network key before trusting it.
     pub(crate) fn current_signed_record(&self, network: &str) -> Option<Vec<u8>> {
-        let (hash, key) = {
+        let hash = config::load_network(network)
+            .ok()
+            .flatten()?
+            .last_group_hash?;
+        let key = {
             let handle = self.networks.get(network)?;
-            let s = handle.state.read().unwrap();
-            (
-                s.snapshot.as_ref().map(|x| x.hash)?,
-                s.network_secret_key.clone()?,
-            )
+            handle.state.read().unwrap().network_secret_key.clone()?
         };
         let mut seed_peers: Vec<EndpointId> = self
             .peers

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 const RECORD_NAME: &str = "_rayfish";
 const RECORD_VERSION: &str = "v1";
-const RECORD_TTL: u32 = 300;
+pub(crate) const RECORD_TTL: u32 = 300;
 const PKARR_RELAY_URL: &str = "https://dns.iroh.link/pkarr";
 
 /// Cap on a single record resolution. The relay is plain HTTPS and iroh's
@@ -21,6 +21,9 @@ const PKARR_RELAY_URL: &str = "https://dns.iroh.link/pkarr";
 /// stopped resolving the relay's own name) would otherwise leave `ray join`
 /// hanging with nothing on screen.
 const RESOLVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+/// Bound publication too: snapshot commits wait behind an in-flight publish so
+/// an older record cannot land after a newer recovery pointer.
+const PUBLISH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 /// Process-wide pkarr relay URL, set once at daemon startup from the
 /// `discovery-dns` config. The discovery server is a set-once constant for the
@@ -198,10 +201,14 @@ pub async fn publish_network(
     seed_peers: &[EndpointId],
 ) -> Result<()> {
     let packet = encode_network_record(key, blob_hash, seed_peers)?;
-    client
-        .publish(&packet)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to publish network record: {e:#}"))
+    match tokio::time::timeout(PUBLISH_TIMEOUT, client.publish(&packet)).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(anyhow::anyhow!("failed to publish network record: {e:#}")),
+        Err(_) => Err(anyhow::anyhow!(
+            "timed out publishing network record after {}s",
+            PUBLISH_TIMEOUT.as_secs()
+        )),
+    }
 }
 
 /// Resolves the raw signed network record packet. Use this when you need fields
@@ -242,10 +249,14 @@ pub async fn publish_contact(
     endpoint: EndpointId,
 ) -> Result<()> {
     let packet = encode_contact_record(contact_key, endpoint)?;
-    client
-        .publish(&packet)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to publish contact record: {e:#}"))
+    match tokio::time::timeout(PUBLISH_TIMEOUT, client.publish(&packet)).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => Err(anyhow::anyhow!("failed to publish contact record: {e:#}")),
+        Err(_) => Err(anyhow::anyhow!(
+            "timed out publishing contact record after {}s",
+            PUBLISH_TIMEOUT.as_secs()
+        )),
+    }
 }
 
 /// Resolve a contact id to the holder's current transport EndpointId.


### PR DESCRIPTION
## Summary

- require a coordinator restart to restore membership from the authoritative network-key-signed GroupBlob
- fail before sealing or publishing when the signed record/blob is temporarily unavailable
- let the existing restore supervisor retry the saved inactive network instead of authoring stale config state

## Root cause

A coordinator restart fell back to the persisted config roster when its DHT record or GroupBlob could not be fetched. That fallback can be older than live membership (in the observed outage it contained only the coordinator), but restore immediately sealed and published it as authoritative. Every peer then disappeared from the coordinator roster.

This is distinct from the member-side restore problem tracked in #59: the affected node holds the network key and must not publish a fallback as truth.

## Verification

- reproduced on a five-node network after a coordinator reboot
- recovered the signed five-member roster and restarted the coordinator successfully with this fix installed
- `cargo -q test -- --skip ssh::tests::agent_forwarding_hands_the_session_a_socket_that_reaches_the_client --skip ssh::tests::session_env_takes_locale_and_drops_the_rest`
- `cargo -q clippy --all-targets --all-features -- -D warnings`
- independent review found no correctness blockers

## Test gap

There is no direct automated DHT-failure regression test in this PR. Exercising the exact boundary currently requires injecting failures through the concrete endpoint/blob-store composition root; adding that abstraction would be substantially larger than this fail-closed change. The existing supervisor tests cover classification of saved inactive coordinator networks, and the control flow returns before publish/config/handler/network-registration side effects.