### PR TITLE
refactor(config): make network updates transactional

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,10 @@
+use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::fs::Permissions;
 use std::net::Ipv4Addr;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 // Only the test-only `CONFIG_ENV_LOCK` holds one.
 #[cfg(test)]
 use std::sync::Mutex;
@@ -580,6 +582,49 @@ const LEGACY_FILE: &str = "networks.toml";
 const SETTINGS_FILE: &str = "settings.toml";
 const NETWORKS_SUBDIR: &str = "networks";
 
+/// Process-wide transaction boundary for network shards. Public per-network
+/// reads take a shared guard; save, update, migration, and delete take an
+/// exclusive guard so a stale whole-file write cannot overwrite another task's
+/// fields or resurrect a deleted network.
+static NETWORK_CONFIG_LOCK: RwLock<()> = RwLock::new(());
+
+thread_local! {
+    /// Tripwire for the non-reentrant update callback contract. The process
+    /// lock deliberately remains the real transaction boundary.
+    static IN_NETWORK_CONFIG_UPDATE: Cell<bool> = const { Cell::new(false) };
+}
+
+struct NetworkUpdateScope;
+
+impl NetworkUpdateScope {
+    fn enter() -> Result<Self> {
+        IN_NETWORK_CONFIG_UPDATE.with(|active| {
+            anyhow::ensure!(
+                !active.get(),
+                "network config update callbacks must not call network config APIs"
+            );
+            active.set(true);
+            Ok(Self)
+        })
+    }
+}
+
+impl Drop for NetworkUpdateScope {
+    fn drop(&mut self) {
+        IN_NETWORK_CONFIG_UPDATE.with(|active| active.set(false));
+    }
+}
+
+fn ensure_not_in_network_update() -> Result<()> {
+    IN_NETWORK_CONFIG_UPDATE.with(|active| {
+        anyhow::ensure!(
+            !active.get(),
+            "network config update callbacks must not call network config APIs"
+        );
+        Ok(())
+    })
+}
+
 /// Globals persisted to `settings.toml` (everything in [`AppConfig`] except the
 /// per-network entries, which live in their own files).
 ///
@@ -884,7 +929,7 @@ fn migrate_legacy(dir: &Path) -> Result<()> {
 
     save_settings_in(dir, &old)?;
     for net in &old.networks {
-        save_network_in(dir, net)?;
+        save_network_unlocked(dir, net)?;
     }
 
     let bak = dir.join("networks.toml.bak");
@@ -898,8 +943,17 @@ fn migrate_legacy(dir: &Path) -> Result<()> {
 /// Returns a default config if nothing is stored yet. Runs the legacy migration
 /// on first call after an upgrade.
 pub fn load() -> Result<AppConfig> {
+    ensure_not_in_network_update()?;
     let dir = config_dir()?;
-    migrate_legacy(&dir)?;
+    {
+        let _guard = NETWORK_CONFIG_LOCK
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        migrate_legacy(&dir)?;
+    }
+    let _guard = NETWORK_CONFIG_LOCK
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     load_in(&dir)
 }
 
@@ -907,6 +961,10 @@ pub fn load() -> Result<AppConfig> {
 /// daemon is down). Creates nothing and runs no migration; a config tree that
 /// isn't there, or isn't readable by this user, reads as an empty config.
 pub fn load_for_read() -> Result<AppConfig> {
+    ensure_not_in_network_update()?;
+    let _guard = NETWORK_CONFIG_LOCK
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     load_in(&config_dir_for_read()?)
 }
 
@@ -1039,13 +1097,19 @@ fn remove_pending_join_in(dir: &Path, network_key: &str) -> Result<()> {
     Ok(())
 }
 
-/// Persist a single network to `networks/<name>.toml`. Touches only that file,
-/// so concurrent saves of distinct networks can never clobber one another.
+/// Persist a single network to `networks/<name>.toml`. Direct full-record
+/// writes share the same transaction boundary as updates and deletes.
 pub fn save_network(net: &NetworkConfig) -> Result<()> {
-    save_network_in(&config_dir()?, net)
+    ensure_not_in_network_update()?;
+    let dir = config_dir()?;
+    let _guard = NETWORK_CONFIG_LOCK
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    save_network_unlocked(&dir, net)
 }
 
-fn save_network_in(dir: &Path, net: &NetworkConfig) -> Result<()> {
+/// Caller holds [`NETWORK_CONFIG_LOCK`] when this runs in production.
+fn save_network_unlocked(dir: &Path, net: &NetworkConfig) -> Result<()> {
     validate_net_name(&net.name)?;
     let ndir = dir.join(NETWORKS_SUBDIR);
     let path = ndir.join(format!("{}.toml", net.name));
@@ -1056,10 +1120,16 @@ fn save_network_in(dir: &Path, net: &NetworkConfig) -> Result<()> {
 
 /// Load a single network's config, if present.
 pub fn load_network(name: &str) -> Result<Option<NetworkConfig>> {
-    load_network_in(&config_dir()?, name)
+    ensure_not_in_network_update()?;
+    let dir = config_dir()?;
+    let _guard = NETWORK_CONFIG_LOCK
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    load_network_unlocked(&dir, name)
 }
 
-fn load_network_in(dir: &Path, name: &str) -> Result<Option<NetworkConfig>> {
+/// Caller holds [`NETWORK_CONFIG_LOCK`] when this runs in production.
+fn load_network_unlocked(dir: &Path, name: &str) -> Result<Option<NetworkConfig>> {
     validate_net_name(name)?;
     let path = dir.join(NETWORKS_SUBDIR).join(format!("{name}.toml"));
     if !path.exists() {
@@ -1072,12 +1142,107 @@ fn load_network_in(dir: &Path, name: &str) -> Result<Option<NetworkConfig>> {
     ))
 }
 
-/// Delete a single network's config file. Returns true if it existed.
-pub fn delete_network(name: &str) -> Result<bool> {
-    delete_network_in(&config_dir()?, name)
+/// Atomically load, synchronously mutate, and save an existing network's latest
+/// config. The callback must not call another network-config API; the lock is
+/// deliberately never held across an await. Returns `None` when the network was
+/// deleted or never existed.
+pub fn update_network(
+    name: &str,
+    update: impl FnOnce(&mut NetworkConfig) -> Result<()>,
+) -> Result<Option<NetworkConfig>> {
+    update_network_in(&config_dir()?, name, update)
 }
 
-fn delete_network_in(dir: &Path, name: &str) -> Result<bool> {
+fn update_network_in(
+    dir: &Path,
+    name: &str,
+    update: impl FnOnce(&mut NetworkConfig) -> Result<()>,
+) -> Result<Option<NetworkConfig>> {
+    ensure_not_in_network_update()?;
+    let _guard = NETWORK_CONFIG_LOCK
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(mut net) = load_network_unlocked(dir, name)? else {
+        return Ok(None);
+    };
+    anyhow::ensure!(
+        net.name == name,
+        "network config {name:?} contains mismatched name {:?}",
+        net.name
+    );
+    let before = toml::to_string(&net).context("serializing network config")?;
+    let _update_scope = NetworkUpdateScope::enter()?;
+    update(&mut net)?;
+    drop(_update_scope);
+    anyhow::ensure!(
+        net.name == name,
+        "network update cannot rename {name:?} to {:?}",
+        net.name
+    );
+    let after = toml::to_string(&net).context("serializing network config")?;
+    if after != before {
+        save_network_unlocked(dir, &net)?;
+    }
+    Ok(Some(net))
+}
+
+/// Atomically update the latest network config, inserting `initial` only when
+/// the network is absent. This is the fresh-join counterpart to
+/// [`update_network`]; existing node-local fields remain available to `update`.
+pub fn update_network_or_insert(
+    name: &str,
+    initial: NetworkConfig,
+    update: impl FnOnce(&mut NetworkConfig) -> Result<()>,
+) -> Result<NetworkConfig> {
+    update_network_or_insert_in(&config_dir()?, name, initial, update)
+}
+
+fn update_network_or_insert_in(
+    dir: &Path,
+    name: &str,
+    initial: NetworkConfig,
+    update: impl FnOnce(&mut NetworkConfig) -> Result<()>,
+) -> Result<NetworkConfig> {
+    ensure_not_in_network_update()?;
+    let _guard = NETWORK_CONFIG_LOCK
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let existing = load_network_unlocked(dir, name)?;
+    let inserting = existing.is_none();
+    let mut net = existing.unwrap_or(initial);
+    anyhow::ensure!(
+        net.name == name,
+        "network config {name:?} contains mismatched name {:?}",
+        net.name
+    );
+    let before = toml::to_string(&net).context("serializing network config")?;
+    let _update_scope = NetworkUpdateScope::enter()?;
+    update(&mut net)?;
+    drop(_update_scope);
+    anyhow::ensure!(
+        net.name == name,
+        "network update cannot rename {name:?} to {:?}",
+        net.name
+    );
+    let after = toml::to_string(&net).context("serializing network config")?;
+    if inserting || after != before {
+        save_network_unlocked(dir, &net)?;
+    }
+    Ok(net)
+}
+
+/// Delete a single network's config file. Returns true if it existed.
+pub fn delete_network(name: &str) -> Result<bool> {
+    ensure_not_in_network_update()?;
+    let dir = config_dir()?;
+    let _guard = NETWORK_CONFIG_LOCK
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    delete_network_unlocked(&dir, name)
+}
+
+/// Caller holds [`NETWORK_CONFIG_LOCK`] when this runs in production.
+fn delete_network_unlocked(dir: &Path, name: &str) -> Result<bool> {
     validate_net_name(name)?;
     let path = dir.join(NETWORKS_SUBDIR).join(format!("{name}.toml"));
     match std::fs::remove_file(&path) {
@@ -1527,8 +1692,8 @@ name = "test"
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
 
-        save_network_in(dir, &net("homelab")).unwrap();
-        save_network_in(dir, &net("genesis")).unwrap();
+        save_network_unlocked(dir, &net("homelab")).unwrap();
+        save_network_unlocked(dir, &net("genesis")).unwrap();
         save_settings_in(
             dir,
             &AppConfig {
@@ -1543,12 +1708,12 @@ name = "test"
         assert_eq!(loaded.default_hostname.as_deref(), Some("laptop"));
 
         // Single-network load.
-        assert!(load_network_in(dir, "homelab").unwrap().is_some());
-        assert!(load_network_in(dir, "absent").unwrap().is_none());
+        assert!(load_network_unlocked(dir, "homelab").unwrap().is_some());
+        assert!(load_network_unlocked(dir, "absent").unwrap().is_none());
 
         // Deleting one leaves the other untouched.
-        assert!(delete_network_in(dir, "homelab").unwrap());
-        assert!(!delete_network_in(dir, "homelab").unwrap());
+        assert!(delete_network_unlocked(dir, "homelab").unwrap());
+        assert!(!delete_network_unlocked(dir, "homelab").unwrap());
         let after = load_in(dir).unwrap();
         assert_eq!(after.networks.len(), 1);
         assert_eq!(after.networks[0].name, "genesis");
@@ -1605,8 +1770,8 @@ name = "test"
         let mut n = net("homelab");
         n.aliases.insert("alice".into(), "id-alice".into());
         n.aliases.insert("bob".into(), "id-bob".into());
-        save_network_in(dir, &n).unwrap();
-        let loaded = load_network_in(dir, "homelab").unwrap().unwrap();
+        save_network_unlocked(dir, &n).unwrap();
+        let loaded = load_network_unlocked(dir, "homelab").unwrap().unwrap();
         assert_eq!(
             loaded.aliases.get("alice").map(String::as_str),
             Some("id-alice")
@@ -1848,7 +2013,7 @@ name = "test"
             for i in 0..N {
                 let dir = dir.clone();
                 s.spawn(move || {
-                    save_network_in(&dir, &net(&format!("net-{i}"))).unwrap();
+                    save_network_unlocked(&dir, &net(&format!("net-{i}"))).unwrap();
                 });
             }
         });
@@ -1858,6 +2023,103 @@ name = "test"
             loaded.networks.len(),
             N,
             "all concurrent saves must survive"
+        );
+    }
+
+    #[test]
+    fn concurrent_same_network_updates_preserve_unrelated_fields() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        save_network_unlocked(&dir, &net("homelab")).unwrap();
+        let barrier = std::sync::Barrier::new(3);
+
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                barrier.wait();
+                update_network_in(&dir, "homelab", |net| {
+                    net.aliases.insert("alice".into(), "id-alice".into());
+                    Ok(())
+                })
+                .unwrap();
+            });
+            scope.spawn(|| {
+                barrier.wait();
+                update_network_in(&dir, "homelab", |net| {
+                    net.auto_accept_files = false;
+                    Ok(())
+                })
+                .unwrap();
+            });
+            barrier.wait();
+        });
+
+        let loaded = load_network_unlocked(&dir, "homelab").unwrap().unwrap();
+        assert_eq!(
+            loaded.aliases.get("alice").map(String::as_str),
+            Some("id-alice")
+        );
+        assert!(!loaded.auto_accept_files);
+    }
+
+    #[test]
+    fn update_or_insert_uses_initial_only_when_network_is_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let mut initial = net("homelab");
+        initial.aliases.insert("local".into(), "first".into());
+
+        update_network_or_insert_in(dir, "homelab", initial, |net| {
+            net.auto_accept_firewall = true;
+            Ok(())
+        })
+        .unwrap();
+
+        let mut stale_initial = net("homelab");
+        stale_initial.aliases.insert("local".into(), "stale".into());
+        update_network_or_insert_in(dir, "homelab", stale_initial, |net| {
+            net.my_hostname = Some("latest".into());
+            Ok(())
+        })
+        .unwrap();
+
+        let loaded = load_network_unlocked(dir, "homelab").unwrap().unwrap();
+        assert_eq!(
+            loaded.aliases.get("local").map(String::as_str),
+            Some("first")
+        );
+        assert!(loaded.auto_accept_firewall);
+        assert_eq!(loaded.my_hostname.as_deref(), Some("latest"));
+    }
+
+    #[test]
+    fn network_update_reentry_is_rejected_before_locking() {
+        let _scope = NetworkUpdateScope::enter().unwrap();
+        let error = ensure_not_in_network_update().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("network config update callbacks must not call network config APIs")
+        );
+    }
+
+    #[test]
+    fn failed_network_update_does_not_persist_partial_mutation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        save_network_unlocked(dir, &net("homelab")).unwrap();
+
+        let result = update_network_in(dir, "homelab", |net| {
+            net.aliases.insert("alice".into(), "id-alice".into());
+            anyhow::bail!("reject update")
+        });
+
+        assert!(result.is_err());
+        assert!(
+            load_network_unlocked(dir, "homelab")
+                .unwrap()
+                .unwrap()
+                .aliases
+                .is_empty()
         );
     }
 
@@ -1898,8 +2160,8 @@ name = "test"
     fn rejects_unsafe_network_names() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
-        assert!(save_network_in(dir, &net("../escape")).is_err());
-        assert!(load_network_in(dir, "a/b").is_err());
+        assert!(save_network_unlocked(dir, &net("../escape")).is_err());
+        assert!(load_network_unlocked(dir, "a/b").is_err());
     }
 
     #[test]

--- a/src/daemon/connect_service.rs
+++ b/src/daemon/connect_service.rs
@@ -295,11 +295,11 @@ impl ConnectService {
                 false,
             )
             .await;
-        if let IpcMessage::Joined { name, .. } = &resp
-            && let Ok(Some(mut n)) = config::load_network(name)
-        {
-            n.direct = true;
-            let _ = config::save_network(&n);
+        if let IpcMessage::Joined { name, .. } = &resp {
+            let _ = config::update_network(name, |net| {
+                net.direct = true;
+                Ok(())
+            });
         }
         resp
     }

--- a/src/daemon/mesh/accept.rs
+++ b/src/daemon/mesh/accept.rs
@@ -796,12 +796,13 @@ impl CoordinatorAcceptState {
         // The key rode the Welcome above (see `direct_key`). Record the grant
         // locally (mirrors `admin_add`) so our own `ray admin list` shows the peer
         // as a co-coordinator too.
-        if grant_direct
-            && let Ok(Some(mut net)) = config::load_network(&self.network_name)
-            && !net.admins.contains(&remote_id)
-        {
-            net.admins.push(remote_id);
-            let _ = config::save_network(&net);
+        if grant_direct {
+            let _ = config::update_network(&self.network_name, |net| {
+                if !net.admins.contains(&remote_id) {
+                    net.admins.push(remote_id);
+                }
+                Ok(())
+            });
         }
         Some(peer_ip)
     }
@@ -1245,9 +1246,19 @@ impl MemberAcceptState {
             return;
         }
         let key = SecretKey::from(secret_key);
-        if let Ok(Some(mut net)) = config::load_network(&self.network_name) {
+        match config::update_network(&self.network_name, |net| {
             net.network_secret_key = Some(key.clone());
-            let _ = config::save_network(&net);
+            Ok(())
+        }) {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                tracing::warn!(network = %self.network_name, "admin grant arrived after network config was deleted");
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(network = %self.network_name, error = %e, "failed to persist admin grant");
+                return;
+            }
         }
         {
             let mut s = self.state.write().unwrap();

--- a/src/daemon/mesh/admin.rs
+++ b/src/daemon/mesh/admin.rs
@@ -90,12 +90,12 @@ impl NetworkRegistry {
         self.store_and_publish_group(network).await;
 
         // Record the grant locally (coordinator's record; not verifiable).
-        if let Ok(Some(mut net)) = config::load_network(network)
-            && !net.admins.contains(&identity)
-        {
-            net.admins.push(identity);
-            let _ = config::save_network(&net);
-        }
+        let _ = config::update_network(network, |net| {
+            if !net.admins.contains(&identity) {
+                net.admins.push(identity);
+            }
+            Ok(())
+        });
         IpcMessage::Ok {
             message: format!("granted network key to {}", identity.fmt_short()),
         }

--- a/src/daemon/mesh/alias.rs
+++ b/src/daemon/mesh/alias.rs
@@ -10,18 +10,13 @@ impl NetworkRegistry {
     /// canonicalized CLI-side (the string `ray identityof` prints); this just
     /// persists the mapping. Overwrites any existing alias of the same name.
     pub(crate) fn set_alias(&self, network: &str, identity: &str, alias: &str) -> IpcMessage {
-        let mut net = match config::load_network(network) {
-            Ok(Some(n)) => n,
-            Ok(None) => {
-                return ipc_err(format!("network '{network}' not found"));
-            }
-            Err(e) => {
-                return ipc_err(format!("failed to load network config: {e}"));
-            }
-        };
-        net.aliases.insert(alias.to_string(), identity.to_string());
-        if let Err(e) = config::save_network(&net) {
-            return ipc_err(format!("failed to save config: {e}"));
+        match config::update_network(network, |net| {
+            net.aliases.insert(alias.to_string(), identity.to_string());
+            Ok(())
+        }) {
+            Ok(Some(_)) => {}
+            Ok(None) => return ipc_err(format!("network '{network}' not found")),
+            Err(e) => return ipc_err(format!("failed to save config: {e}")),
         }
         IpcMessage::Ok {
             message: format!("alias '{alias}' -> {identity} on '{network}'"),
@@ -31,20 +26,15 @@ impl NetworkRegistry {
     /// Remove a local alias by name. Reports an error if no such alias exists so
     /// a typo is visible rather than silently succeeding.
     pub(crate) fn remove_alias(&self, network: &str, alias: &str) -> IpcMessage {
-        let mut net = match config::load_network(network) {
-            Ok(Some(n)) => n,
-            Ok(None) => {
-                return ipc_err(format!("network '{network}' not found"));
-            }
-            Err(e) => {
-                return ipc_err(format!("failed to load network config: {e}"));
-            }
-        };
-        if net.aliases.remove(alias).is_none() {
-            return ipc_err(format!("no alias '{alias}' on '{network}'"));
-        }
-        if let Err(e) = config::save_network(&net) {
-            return ipc_err(format!("failed to save config: {e}"));
+        let mut removed = false;
+        match config::update_network(network, |net| {
+            removed = net.aliases.remove(alias).is_some();
+            Ok(())
+        }) {
+            Ok(Some(_)) if removed => {}
+            Ok(Some(_)) => return ipc_err(format!("no alias '{alias}' on '{network}'")),
+            Ok(None) => return ipc_err(format!("network '{network}' not found")),
+            Err(e) => return ipc_err(format!("failed to save config: {e}")),
         }
         IpcMessage::Ok {
             message: format!("removed alias '{alias}' from '{network}'"),

--- a/src/daemon/mesh/create_join.rs
+++ b/src/daemon/mesh/create_join.rs
@@ -786,11 +786,16 @@ impl NetworkRegistry {
             let _ = self.transport.blob_store.blobs().add_slice(&bytes).await;
         }
 
-        // Save config with network public key (use display_name for config)
-        if let Ok(Some(mut net)) = config::load_network(display_name) {
+        // Save the network public key without replacing settings that may have
+        // changed while the join was in flight.
+        let updated = config::update_network(display_name, |net| {
             net.network_public_key = Some(net_pubkey);
-            let _ = config::save_network(&net);
-        }
+            Ok(())
+        })?;
+        anyhow::ensure!(
+            updated.is_some(),
+            "network config was deleted while joining"
+        );
 
         // Membership poller
         if let Ok(poller_client) = dht::create_pkarr_client(&self.transport.endpoint) {

--- a/src/daemon/mesh/exit_node.rs
+++ b/src/daemon/mesh/exit_node.rs
@@ -238,10 +238,6 @@ impl NetworkRegistry {
         peer: &str,
         allow: bool,
     ) -> IpcMessage {
-        let mut app_config = match config::load() {
-            Ok(c) => c,
-            Err(e) => return ipc_err(format!("failed to load config: {e}")),
-        };
         // Resolve to a stored allow-entry: `*` stays literal, otherwise the peer's
         // **user identity** hex, so a paired multi-device peer matches on any of
         // its devices (same normalization the SSH allow-list uses).
@@ -253,21 +249,21 @@ impl NetworkRegistry {
                 None => return ipc_err(format!("could not resolve peer: {peer}")),
             }
         };
-        let Some(net) = app_config.networks.iter_mut().find(|n| n.name == network) else {
-            return ipc_err(format!("no such network: {network}"));
-        };
-        if allow {
-            if !net.exit_allow.iter().any(|p| p == &entry) {
-                net.exit_allow.push(entry.clone());
+        let net = match config::update_network(network, |net| {
+            if allow {
+                if !net.exit_allow.iter().any(|p| p == &entry) {
+                    net.exit_allow.push(entry.clone());
+                }
+            } else {
+                net.exit_allow.retain(|p| p != &entry);
             }
-        } else {
-            net.exit_allow.retain(|p| p != &entry);
-        }
+            Ok(())
+        }) {
+            Ok(Some(net)) => net,
+            Ok(None) => return ipc_err(format!("no such network: {network}")),
+            Err(e) => return ipc_err(format!("failed to persist network config: {e}")),
+        };
         let offering = !net.exit_allow.is_empty();
-        let net = net.clone();
-        if let Err(e) = config::save_network(&net) {
-            return ipc_err(format!("failed to persist network config: {e}"));
-        }
         // Not advertised from here: the roster flag must reflect a gateway that
         // actually forwards, so [`Self::sync_exit_offers`] publishes it only once
         // the reconcile has the kernel state in place (now if the daemon is up,
@@ -292,10 +288,6 @@ impl NetworkRegistry {
     /// over IPv4 alone would receive this node's traffic and have no uplink to
     /// masquerade it onto. Refusing here turns a silent black hole into a sentence.
     pub(crate) async fn exit_node_use(&self, network: &str, peer: Option<String>) -> IpcMessage {
-        let mut app_config = match config::load() {
-            Ok(c) => c,
-            Err(e) => return ipc_err(format!("failed to load config: {e}")),
-        };
         // Validate the selection against the live roster before persisting.
         // Set when the gateway is allowed on an absent IPv6 claim rather than a
         // positive one, so the reply can say so: a log line is not where someone
@@ -329,13 +321,13 @@ impl NetworkRegistry {
             }
             None => None,
         };
-        let Some(net) = app_config.networks.iter_mut().find(|n| n.name == network) else {
-            return ipc_err(format!("no such network: {network}"));
-        };
-        net.exit_node_use = selection;
-        let net = net.clone();
-        if let Err(e) = config::save_network(&net) {
-            return ipc_err(format!("failed to persist network config: {e}"));
+        match config::update_network(network, |net| {
+            net.exit_node_use = selection;
+            Ok(())
+        }) {
+            Ok(Some(_)) => {}
+            Ok(None) => return ipc_err(format!("no such network: {network}")),
+            Err(e) => return ipc_err(format!("failed to persist network config: {e}")),
         }
         // "All traffic" would be a lie: the mesh carries no IPv4, so the tunnel
         // takes IPv6 and leaves the host's IPv4 egress where it already was. Say

--- a/src/daemon/mesh/firewall.rs
+++ b/src/daemon/mesh/firewall.rs
@@ -514,15 +514,12 @@ impl Daemon {
         users: Vec<String>,
         allow: bool,
     ) -> IpcMessage {
-        let mut app_config = match config::load() {
-            Ok(c) => c,
+        let ssh_enabled = match config::load() {
+            Ok(c) => c.ssh_enabled,
             Err(e) => {
                 return ipc_err(format!("failed to load config: {e}"));
             }
         };
-        if !app_config.networks.iter().any(|n| n.name == network) {
-            return ipc_err(format!("no such network: {network}"));
-        }
         // Resolve the peer to a stored allow-entry: `*` stays literal, otherwise
         // resolve to the peer's **user identity** hex. `resolve_peer_name` may
         // return a transport endpoint id (for a connected peer) which differs
@@ -539,29 +536,27 @@ impl Daemon {
                 }
             }
         };
-        let net = app_config
-            .networks
-            .iter_mut()
-            .find(|n| n.name == network)
-            .expect("network presence checked above");
-        if allow {
-            // Normalize: a `*` collapses the list to just `*` (any incl. root);
-            // otherwise dedupe. Empty = the non-root default.
-            let users = normalize_ssh_users(users);
-            match net.ssh_allow.iter_mut().find(|r| r.peer == entry) {
-                Some(r) => r.users = users,
-                None => net.ssh_allow.push(config::SshRule {
-                    peer: entry.clone(),
-                    users,
-                }),
+        let net = match config::update_network(network, |net| {
+            if allow {
+                // Normalize: a `*` collapses the list to just `*` (any incl. root);
+                // otherwise dedupe. Empty = the non-root default.
+                let users = normalize_ssh_users(users);
+                match net.ssh_allow.iter_mut().find(|r| r.peer == entry) {
+                    Some(r) => r.users = users,
+                    None => net.ssh_allow.push(config::SshRule {
+                        peer: entry.clone(),
+                        users,
+                    }),
+                }
+            } else {
+                net.ssh_allow.retain(|r| r.peer != entry);
             }
-        } else {
-            net.ssh_allow.retain(|r| r.peer != entry);
-        }
-        let net = net.clone();
-        if let Err(e) = config::save_network(&net) {
-            return ipc_err(format!("failed to persist network config: {e}"));
-        }
+            Ok(())
+        }) {
+            Ok(Some(net)) => net,
+            Ok(None) => return ipc_err(format!("no such network: {network}")),
+            Err(e) => return ipc_err(format!("failed to persist network config: {e}")),
+        };
         // Push the change to any live listener.
         #[cfg(feature = "desktop")]
         self.rebuild_ssh_authz();
@@ -579,7 +574,7 @@ impl Daemon {
         // Mirror of the `ssh on` nudge: a rule with the server off looks like it
         // took effect, but `:22` still falls through to the host sshd (which
         // asks for a password), so the failure doesn't point back here.
-        if allow && !app_config.ssh_enabled {
+        if allow && !ssh_enabled {
             detail.push_str(
                 "\n\nmesh SSH is off, so this rule is not in effect yet. \
                  Start the server with `ray firewall ssh on`.",

--- a/src/daemon/mesh/join.rs
+++ b/src/daemon/mesh/join.rs
@@ -155,6 +155,7 @@ pub(crate) async fn join_mesh_shared(
         auto_accept_firewall,
         auto_accept_files,
         direct_key.as_ref(),
+        initial,
     )?;
 
     let remote_id = initial_conn.remote_id();
@@ -277,59 +278,61 @@ fn persist_join_config(
     // network key so we survive a restart as a key-holder (a plain member persists
     // `None`).
     direct_key: Option<&SecretKey>,
+    initial: bool,
 ) -> Result<()> {
     let persisted_hostname = members
         .iter()
         .find(|m| m.identity == my_identity)
         .and_then(|m| m.hostname.clone())
         .or(my_hostname.clone());
-    // Preserve across reconnects/restores state the just-fetched blob doesn't
-    // carry: the direct-connection flag, a queued rename intent, the SSH allow
-    // list, node-local aliases, and the local exit-node policy (server
-    // allow-list + selected exit peer). Anything node-local left out of this
-    // list is silently erased on every member daemon restart.
-    let prev = config::load_network(network_name)?;
-    let (direct, direct_peer, pending_hostname, ssh_allow, aliases, prev_auto_accept_files) = prev
-        .as_ref()
-        .map(|n| {
-            (
-                n.direct,
-                n.direct_peer,
-                n.pending_hostname.clone(),
-                n.ssh_allow.clone(),
-                n.aliases.clone(),
-                n.auto_accept_files,
-            )
-        })
-        .unwrap_or((false, None, None, vec![], BTreeMap::new(), false));
-    let (exit_allow, exit_node_use) = prev
-        .map(|n| (n.exit_allow, n.exit_node_use))
-        .unwrap_or((vec![], None));
-    // The toggle command (`ray files auto-accept`) is authoritative, so preserve
-    // a previously-persisted value; the join-time `--auto-accept-files` seed only
-    // needs to take effect on the first join (no prior config).
-    let auto_accept_files = prev_auto_accept_files || auto_accept_files;
-    config::save_network(&config::NetworkConfig {
+    // Reconnects replace only data learned from the join. Node-local policy is
+    // updated against the latest saved config so an unrelated concurrent write
+    // cannot be lost; a fresh join inserts these defaults atomically.
+    let member_entries = to_member_entries(members.iter());
+    let approved_entries = to_approved_entries(approved.iter());
+    let initial_config = config::NetworkConfig {
         name: network_name.to_string(),
         group_mode: GroupMode::Restricted,
-        my_hostname: persisted_hostname,
-        pending_hostname,
-        members: to_member_entries(members.iter()),
-        approved: to_approved_entries(approved.iter()),
+        my_hostname: persisted_hostname.clone(),
+        members: member_entries.clone(),
+        approved: approved_entries.clone(),
         network_secret_key: direct_key.cloned(),
         network_public_key: Some(net_pubkey),
-        transport: None,
         auto_accept_firewall,
         auto_accept_files,
-        admins: vec![],
-        direct,
-        direct_peer,
-        ssh_allow,
-        aliases,
-        ephemeral_ttl_secs: None,
-        exit_allow,
-        exit_node_use,
-    })
+        ..Default::default()
+    };
+    let update = |net: &mut config::NetworkConfig| {
+        net.group_mode = GroupMode::Restricted;
+        // A rename requested while the handshake was in flight is newer than
+        // the roster projection we just received.
+        if net.pending_hostname.is_none() {
+            net.my_hostname = persisted_hostname;
+        }
+        net.members = member_entries;
+        net.approved = approved_entries;
+        if let Some(key) = direct_key {
+            net.network_secret_key = Some(key.clone());
+        } else if initial {
+            net.network_secret_key = None;
+        }
+        net.network_public_key = Some(net_pubkey);
+        if initial {
+            net.auto_accept_firewall = auto_accept_firewall;
+            net.auto_accept_files |= auto_accept_files;
+        }
+        Ok(())
+    };
+    if initial {
+        config::update_network_or_insert(network_name, initial_config, update)?;
+    } else {
+        let updated = config::update_network(network_name, update)?;
+        anyhow::ensure!(
+            updated.is_some(),
+            "network config was deleted while reconnecting"
+        );
+    }
+    Ok(())
 }
 
 /// Build the in-memory `NetworkState` cell for a joined member from the admitted
@@ -654,22 +657,23 @@ mod persist_config_tests {
         // Pre-existing config: this node offers an exit (`*`) and routes its own
         // traffic through a chosen peer. This is the state a restart must keep.
         let exit_peer = id(3).to_string();
+        let admin_key = SecretKey::generate();
         config::save_network(&NetworkConfig {
             name: "homelab".to_string(),
             group_mode: GroupMode::Restricted,
-            my_hostname: Some("umbrel".to_string()),
-            pending_hostname: None,
+            my_hostname: Some("new-name".to_string()),
+            pending_hostname: Some("new-name".to_string()),
             members: vec![MemberEntry {
                 identity: me,
                 is_coordinator: false,
                 hostname: Some("umbrel".to_string()),
             }],
             approved: vec![],
-            network_secret_key: None,
+            network_secret_key: Some(admin_key.clone()),
             network_public_key: Some(net_pubkey),
             transport: None,
-            auto_accept_firewall: false,
-            auto_accept_files: false,
+            auto_accept_firewall: true,
+            auto_accept_files: true,
             admins: vec![],
             direct: false,
             direct_peer: None,
@@ -693,6 +697,7 @@ mod persist_config_tests {
             false,
             false,
             None,
+            false,
         )
         .unwrap();
 
@@ -707,6 +712,75 @@ mod persist_config_tests {
             Some(exit_peer),
             "selected exit peer must survive a reconnect"
         );
+        assert!(after.auto_accept_firewall);
+        assert!(after.auto_accept_files);
+        assert_eq!(
+            after.network_secret_key.as_ref().map(SecretKey::to_bytes),
+            Some(admin_key.to_bytes()),
+            "a reconnect without a direct key must not demote a saved co-coordinator"
+        );
+        assert_eq!(after.my_hostname.as_deref(), Some("new-name"));
+        assert_eq!(after.pending_hostname.as_deref(), Some("new-name"));
+
+        persist_join_config(
+            "homelab",
+            &[member(2, false), member(4, true)],
+            &[],
+            me,
+            net_pubkey,
+            &Some("umbrel".to_string()),
+            false,
+            false,
+            None,
+            true,
+        )
+        .unwrap();
+        let after_fresh_join = config::load_network("homelab").unwrap().unwrap();
+        assert!(
+            !after_fresh_join.auto_accept_firewall,
+            "a fresh join's firewall-consent flag must replace a saved value"
+        );
+        assert!(
+            after_fresh_join.auto_accept_files,
+            "a fresh join must not turn off an existing file-auto-accept opt-in"
+        );
+        assert!(
+            after_fresh_join.network_secret_key.is_none(),
+            "a fresh member join must clear a stale coordinator key"
+        );
+
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("RAYFISH_CONFIG_DIR", v),
+                None => std::env::remove_var("RAYFISH_CONFIG_DIR"),
+            }
+        }
+    }
+
+    #[test]
+    fn reconnect_does_not_recreate_a_deleted_network_config() {
+        let _lock = CONFIG_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = std::env::var_os("RAYFISH_CONFIG_DIR");
+        unsafe { std::env::set_var("RAYFISH_CONFIG_DIR", tmp.path()) };
+
+        let net_pubkey = id(1);
+        let me = id(2);
+        let result = persist_join_config(
+            "homelab",
+            &[member(2, false), member(4, true)],
+            &[],
+            me,
+            net_pubkey,
+            &Some("umbrel".to_string()),
+            false,
+            false,
+            None,
+            false,
+        );
+
+        assert!(result.is_err());
+        assert!(config::load_network("homelab").unwrap().is_none());
 
         unsafe {
             match prev {

--- a/src/daemon/mesh/reconverge.rs
+++ b/src/daemon/mesh/reconverge.rs
@@ -517,7 +517,7 @@ pub(crate) async fn apply_roster_to_dns(
         .find(|m| m.identity == my_identity)
         .and_then(|m| m.hostname.clone());
 
-    if let Ok(Some(mut net)) = config::load_network(network_name) {
+    let _ = config::update_network(network_name, |net| {
         match net.pending_hostname.clone() {
             // A locally-requested rename is in flight. Until the blob confirms
             // it, keep showing/persisting the requested name and don't let a
@@ -538,13 +538,11 @@ pub(crate) async fn apply_roster_to_dns(
                 }
                 if net.my_hostname.as_deref() != Some(pending.as_str()) {
                     net.my_hostname = Some(pending);
-                    let _ = config::save_network(&net);
                 }
             }
             // Either the rename landed, or there was none: follow the blob and
             // clear any (now-confirmed) pending intent.
             pending => {
-                let mut dirty = false;
                 if let Some(p) = &pending {
                     tracing::info!(
                         network = %network_name,
@@ -553,21 +551,16 @@ pub(crate) async fn apply_roster_to_dns(
                         "rename confirmed by signed blob; clearing pending intent"
                     );
                     net.pending_hostname = None;
-                    dirty = true;
                 }
                 if let Some(mine) = blob_self.clone()
                     && net.my_hostname.as_deref() != Some(mine.as_str())
                 {
                     net.my_hostname = Some(mine);
-                    dirty = true;
-                }
-                if dirty {
-                    let _ = config::save_network(&net);
                 }
             }
         }
-    }
-
+        Ok(())
+    });
     dns::sync_network_hostnames(hostname_table, reverse_table, network_name, &entries).await;
 }
 

--- a/src/daemon/mesh/runtime.rs
+++ b/src/daemon/mesh/runtime.rs
@@ -203,43 +203,18 @@ impl NetworkRegistry {
 
         self.seal_and_publish(&mut net_state, &net_secret_key).await;
 
-        // Update config
-        let member_entries = to_member_entries(net_state.members.all());
-        let approved_entries = to_approved_entries(net_state.approved.all());
-        config::save_network(&config::NetworkConfig {
-            name: name.to_string(),
-            group_mode: mode,
-            my_hostname: persisted_hostname.clone(),
-            // Coordinators publish renames directly, so they never carry a
-            // pending intent.
-            pending_hostname: None,
-            members: member_entries,
-            approved: approved_entries,
-            network_secret_key: Some(net_secret_key.clone()),
-            network_public_key: Some(net_public_key),
-            transport: None,
-            // Preserve the persisted consent flag + admin roster across a
-            // restart; only the roster (members/approved) is authoritative
-            // from the blob.
-            auto_accept_firewall: net_config
-                .map(|nc| nc.auto_accept_firewall)
-                .unwrap_or(false),
-            auto_accept_files: net_config.map(|nc| nc.auto_accept_files).unwrap_or(false),
-            admins: net_config.map(|nc| nc.admins.clone()).unwrap_or_default(),
-            direct: net_config.map(|nc| nc.direct).unwrap_or(false),
-            direct_peer: net_config.and_then(|nc| nc.direct_peer),
-            ssh_allow: net_config
-                .map(|nc| nc.ssh_allow.clone())
-                .unwrap_or_default(),
-            aliases: net_config.map(|nc| nc.aliases.clone()).unwrap_or_default(),
-            ephemeral_ttl_secs: None,
-            // Local exit-node policy survives restarts (server allow-list and the
-            // client's selected exit peer); neither rides the signed blob.
-            exit_allow: net_config
-                .map(|nc| nc.exit_allow.clone())
-                .unwrap_or_default(),
-            exit_node_use: net_config.and_then(|nc| nc.exit_node_use.clone()),
+        // Replace only the roster-derived projection on the latest saved config.
+        // Node-local policy may have changed while restoration awaited.
+        let updated = config::update_network(name, |latest| {
+            latest.group_mode = mode;
+            latest.pending_hostname = None;
+            latest.members = to_member_entries(net_state.members.all());
+            latest.approved = to_approved_entries(net_state.approved.all());
+            latest.network_secret_key = Some(net_secret_key.clone());
+            latest.network_public_key = Some(net_public_key);
+            Ok(())
         })?;
+        anyhow::ensure!(updated.is_some(), "network is no longer saved");
 
         let cancel = self.shutdown_token.child_token();
         let state = Arc::new(RwLock::new(net_state));

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1017,17 +1017,20 @@ impl Daemon {
         key: NetworkKey,
         value: &str,
     ) -> IpcMessage {
-        let mut net = match config::load_network(network) {
-            Ok(Some(n)) => n,
+        let mut validation_error = None;
+        let updated = config::update_network(network, |net| {
+            settings::apply_network(net, key, value).inspect_err(|e| {
+                validation_error = Some(e.to_string());
+            })
+        });
+        let net = match updated {
+            Ok(Some(net)) => net,
             Ok(None) => return ipc_err(format!("network '{network}' not found")),
-            Err(e) => return ipc_err(format!("failed to load network: {e}")),
+            Err(_) if validation_error.is_some() => {
+                return ipc_err(validation_error.unwrap());
+            }
+            Err(e) => return ipc_err(format!("failed to save config: {e}")),
         };
-        if let Err(e) = settings::apply_network(&mut net, key, value) {
-            return ipc_err(e.to_string());
-        }
-        if let Err(e) = config::save_network(&net) {
-            return ipc_err(format!("failed to save config: {e}"));
-        }
         // Run the live re-materialization the key implies, then confirm.
         match key {
             NetworkKey::AutoAcceptFirewall => self.registry.reapply_suggested_firewall(network),
@@ -1322,15 +1325,15 @@ impl Daemon {
         // pending intent so it keeps being delivered to a coordinator across
         // reconnects/restarts until the signed blob confirms it; a coordinator
         // publishes authoritatively, so it clears any pending intent.
-        if let Ok(Some(mut net)) = config::load_network(network) {
+        let _ = config::update_network(network, |net| {
             net.my_hostname = Some(new_hostname.clone());
             net.pending_hostname = if is_coord {
                 None
             } else {
                 Some(new_hostname.clone())
             };
-            let _ = config::save_network(&net);
-        }
+            Ok(())
+        });
 
         // Fast-path the rename to connected peers via `MeshHello`, regardless of
         // role. A peer *coordinator* only learns a self-rename this way: it acts
@@ -3037,6 +3040,15 @@ mod headless_tests {
             .net_config_apply("gaming", NetworkKey::AutoAcceptFiles, "off")
             .await;
         assert!(matches!(msg, IpcMessage::Ok { .. }), "{msg:?}");
+
+        let msg = daemon
+            .net_config_apply("gaming", NetworkKey::EphemeralTtl, "3599")
+            .await;
+        assert!(
+            matches!(&msg, IpcMessage::Error { message }
+                if message == "ttl must be at least 3600 seconds (1 hour)"),
+            "validation errors must not be mislabeled as save failures: {msg:?}"
+        );
     }
 
     /// A stopped node must be rebuildable in the same process, which is the


### PR DESCRIPTION
## Summary

- serialize per-network config reads, writes, updates, migration, and deletion behind one process-wide transaction boundary
- add `update_network` / `update_network_or_insert` and migrate existing-network read-modify-write callers
- preserve concurrent node-local settings during joins, restores, aliases, firewall, exit-node, direct-link, and admin updates
- reject callback re-entry before it can deadlock the non-reentrant lock

## Why this is separate

This is the config-consistency prerequisite extracted from #132. The durable coordinator recovery pointer added by the follow-up must not be overwritten by an unrelated stale whole-file save. Keeping this layer separate makes the broader config migration independently reviewable and revertible.

No user-facing behavior is intentionally changed, so there is no changelog entry.

## Verification

- `cargo -q check --workspace --all-targets`
- `cargo -q clippy --workspace --all-targets -- -D warnings`
- focused config, join-persistence, and IPC validation tests
- workspace suite passes with the two known local-login-shell-dependent SSH tests excluded
- independent review: clean
