### PR TITLE
fix(cli): keep styled values readable on light terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `ssh localhost`, instead of leaving a bare "connection refused" to explain
   itself.
 
+### Fixed
+
+- **CLI text stays readable on light terminals.** Value and headline text was
+  hard-coded to near-white grays that vanish on a light background. Both now
+  use the terminal's default foreground, which adapts to the theme (headlines
+  also stay bold), so `ray status`, tables and invite codes stay legible on
+  light and dark terminals alike — without bold body text.
+
 ### Security
 
 - **Android no longer sends your keys to Google's backup.** The app allowed

--- a/src/term/style.rs
+++ b/src/term/style.rs
@@ -64,13 +64,13 @@ pub fn label(s: &str) -> String {
 pub fn faint(s: &str) -> String {
     paint("38;5;240", s)
 }
-/// Primary value text, bright and readable.
+/// Primary value text: theme-adaptive default foreground (not bold).
 pub fn value(s: &str) -> String {
-    paint("38;5;252", s)
+    paint("39", s)
 }
-/// Emphasis for names/headlines.
+/// Emphasis for names/headlines: bold default foreground.
 pub fn bold(s: &str) -> String {
-    paint("1;38;5;255", s)
+    paint("1", s)
 }
 /// Warning / loss. red-400-ish.
 pub fn red(s: &str) -> String {


### PR DESCRIPTION
<!--
Keep the title as a conventional commit subject (feat/fix/docs/style/ci/chore/...),
since release notes are generated from commit subjects by git-cliff.
Example: fix(ssh): reuse the host's OpenSSH ed25519 key for mesh SSH
-->

## What this does

`style::value()` and `style::bold()` had hard-coded near-white xterm grays
(`38;5;252` and `1;38;5;255`) that vanish on a light background. Both now use
the terminal's *default* foreground color, which is theme-adaptive:

- `style::value()` → default foreground (`39`), not bold, so body text stays
  visually beneath headlines
- `style::bold()` → bold default foreground (`1`), unchanged emphasis

The saturated accents (`rose`/`green`/`red`/`label`/`faint`) are unchanged.

## Why

Closes #142 

## How it was tested

<!-- Commands you ran and what you observed. -->

When running `ray status`:

Before with light theme:
<img width="252" height="66" alt="image" src="https://github.com/user-attachments/assets/4b1dc795-631e-4d8d-9739-8f8d9cb094ef" />
After:
<img width="252" height="69" alt="image" src="https://github.com/user-attachments/assets/206db506-8d77-41d2-9790-2baf792b3442" />

Before with dark theme:
<img width="239" height="68" alt="image" src="https://github.com/user-attachments/assets/e021a9ab-a420-461d-827c-5d92c585b847" />
After:
<img width="249" height="64" alt="image" src="https://github.com/user-attachments/assets/c5a134d4-9c1c-4cfd-bd38-aefac8e6479e" />

Results: negligible impact on dark themes, while making light themes usable and improving accessibility.

```
cargo -q build
cargo -q test
cargo -q clippy
```
All passed.

## Checklist

- [x] Title is a conventional commit subject (`feat`/`fix`/`docs`/`style`/`ci`/...).
- [x] `cargo build`, `cargo test`, and `cargo clippy` pass.
- [x]  Docs updated (`README.md` / `CLAUDE.md`) if behavior changed.
- [x] `CHANGELOG.md` updated under `## [Unreleased]` if the change is user-visible.
- [x] Bumped the relevant ALPN version if a wire protocol changed incompatibly.
