### PR TITLE
feat(roles): coordinator-assigned roles as firewall selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Roles: firewall rules that name a class of nodes.** A subject or peer in a
+  `ray apply` spec can now be `role:sentry` instead of a hostname. A hostname
+  names one machine, so covering a group meant listing every member by hand and
+  re-running `ray apply` each time the group grew. A role is assigned by the
+  coordinator from the join code and resolved on each node against the signed
+  roster, so the spec stops changing when the fleet does.
+
+  `ray invite <net> create --reusable --role sentry` mints one code that seats a
+  group. `--role` is allowed on a reusable key where `--hostname` is not: a
+  hostname is unique per node, a role is shared by a class of them on purpose,
+  which is what lets one code sit in a machine image or Terraform user-data and
+  cover an autoscaling group. Every instance then runs the same bare
+  `ray join <code>`, and a node joining later picks up its rules on the next
+  roster update with no second apply.
+
+  `ray join --role <name>` asks for a subset of what the code grants; asking for
+  a role it does not grant refuses the join. `ray requests <net> accept <id>
+  --role <name>` assigns roles on a live approval, which has no code to read
+  them from. `ray status` shows the roles a peer holds.
+
+- **`--json` on `ray apply` and `ray invite`.** Enough machine-readable output
+  to drive a deploy from Terraform or Ansible: the networks touched, role
+  coverage, the hosts a spec expects that have not joined, and any codes minted
+  for them. `changed` in the apply payload is what an Ansible `changed_when`
+  wants.
+
 - **Windows on ARM64.** Releases and nightlies now publish
   `ray-windows-aarch64.exe`, so Snapdragon and other ARM laptops get a native
   binary instead of running the x86_64 one under emulation. CI builds the
@@ -61,7 +87,37 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `ssh localhost`, instead of leaving a bare "connection refused" to explain
   itself.
 
+### Fixed
+
+- **A coordinator never picked up a peer that joined after a rule was
+  published.** Suggested rules name their peers by hostname, resolved against
+  the roster, and the docs promised a rule for a not-yet-joined peer would
+  appear once it joined. That held for members, which reconverge from the
+  published record, but not for the coordinator: it *is* that record's source,
+  so the poller's hash check short-circuited and it only ever re-resolved when
+  suggestions themselves were republished. It now re-resolves whenever its
+  roster changes, on both admission and removal.
+
+- **The invite command `ray apply` printed could not be pasted.** The
+  membership-gap tip rendered `ray invite <net> --hostname <h>`, which the parser
+  rejects: those flags belong to the `create` subcommand. It now prints
+  `ray invite <net> create --hostname <h>`.
+
+- **`ray apply --invite-missing` minted invites on the wrong network.** The
+  expected-host diff was computed over the whole spec but reported once per
+  network, so a host belonging to one network read as missing from every other
+  and its invite was minted there. Harmless when reading the output by eye, and
+  not when a provisioner consumes it. The diff is now scoped to the network it
+  is reported under.
+
 ### Security
+
+- **A role cannot be self-claimed.** Firewall rules keyed on a hostname rest on
+  a name the joiner picked whenever the invite did not bind one, so an unbound
+  join could take a name the spec had rules for. A role never comes from the
+  joiner: the coordinator reads it off the redeemed code, and `--role` on the
+  join side can only narrow that grant. Rules written against `role:` are free
+  of that hole.
 
 - **Android no longer sends your keys to Google's backup.** The app allowed
   Android Auto Backup with no exclusions, so the identity key, the device

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   roster update with no second apply.
 
   `ray join --role <name>` asks for a subset of what the code grants; asking for
-  a role it does not grant refuses the join. `ray requests <net> accept <id>
-  --role <name>` assigns roles on a live approval, which has no code to read
-  them from. `ray status` shows the roles a peer holds.
+  a role it does not grant refuses the join, and does so once rather than
+  retrying. `ray requests <net> accept <id> --role <name>` assigns roles on a
+  live approval, which has no code to read them from; `ray requests` shows what
+  each waiting peer asked for, so there is something to copy into that flag.
+  `ray status` shows the roles a peer holds.
+
+  Role names are lowercase `[a-z0-9-]`. A `role:` key in a spec is matched
+  against the roster as written, so one with capitals is an error when the spec
+  is read rather than a rule that silently matches nobody.
 
 - **`--json` on `ray apply` and `ray invite`.** Enough machine-readable output
   to drive a deploy from Terraform or Ansible: the networks touched, role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   a role it does not grant refuses the join, and does so once rather than
   retrying. `ray requests <net> accept <id> --role <name>` assigns roles on a
   live approval, which has no code to read them from; `ray requests` shows what
-  each waiting peer asked for, so there is something to copy into that flag.
+  each waiting peer asked for, so there is something to copy into that flag. An
+  accept that leaves out a role the peer asked for is refused and the request
+  stays queued: seating it without them would refuse its next attempt for good.
   `ray status` shows the roles a peer holds.
 
   Role names are lowercase `[a-z0-9-]`. A `role:` key in a spec is matched

--- a/README.md
+++ b/README.md
@@ -452,6 +452,9 @@ A few rules of thumb:
 - Roles are the opposite: they are published as written and resolved on each
   node against the signed roster, so a node that joins later is covered without
   a second `ray apply`. Use a role wherever the count can change.
+- A role name is lowercase `[a-z0-9-]`, and the spec is matched against the
+  roster byte for byte, so `role:Sentry` is rejected when the spec is read
+  rather than published as a rule no member can match.
 
 ### Roles, for fleets that grow
 

--- a/README.md
+++ b/README.md
@@ -433,17 +433,55 @@ networks:
       denies:
         eve: "icmp"
     carol: {}                 # empty subject = fully open, no rules
+  hyperliquid:
+    "role:validator":         # a role: a class of nodes, not one machine
+      allows:
+        "role:sentry": "tcp:4000-4004"
 ```
 
 A few rules of thumb:
 
 - Subject and peer keys are **hostnames** (or an alias/group that expands to
-  them). `*` as a subject means every node; `*` as a peer means any peer.
+  them), or a **role** (`role:sentry`). `*` as a subject means every node; `*`
+  as a peer means any peer.
 - If a subject has an `allows:` list, it's an allow-list: only the listed peers
   get through, everything else is denied. `denies:` carves exceptions out.
 - Aliases and groups are coordinator-side shorthand, expanded before publishing.
   They never travel over the mesh. An alias only resolves once that user has
   joined; literal hostnames work before anyone joins.
+- Roles are the opposite: they are published as written and resolved on each
+  node against the signed roster, so a node that joins later is covered without
+  a second `ray apply`. Use a role wherever the count can change.
+
+### Roles, for fleets that grow
+
+A hostname names one machine, so a rule keyed on one cannot say "every sentry".
+A role can. The coordinator assigns it from the join code, and the node never
+gets a say, which is what makes it safe to write firewall rules against:
+
+```bash
+# Mint one key per role. Unlike --hostname, --role is allowed on a reusable key:
+# a hostname is unique per node, a role is shared by a class of them on purpose.
+ray invite hyperliquid create --reusable --role sentry --json
+
+# Every instance runs the same line, whether there is one of them or twenty.
+ray join <code> --auto-accept-firewall
+```
+
+That is the whole scale-out story: the spec never changes, and each new sentry
+picks up its rules on the next roster update. `ray join --role <name>` can ask
+for a subset of what the code grants; asking for anything it does not grant
+refuses the join rather than seating the node with the wrong policy.
+
+For Terraform or Ansible, `--json` on `ray apply` and `ray invite` gives the
+machine-readable output to drive it from:
+
+```yaml
+- name: publish the mesh policy
+  command: ray apply /etc/ray/deploy.yaml --json
+  register: out
+  changed_when: (out.stdout | from_json).changed
+```
 
 Run it, and iterate safely:
 
@@ -453,6 +491,7 @@ ray apply deploy.yaml --dry-run  # show what would change, apply nothing
 ray apply deploy.yaml            # create missing networks, publish suggestions
 ray apply deploy.yaml --invite-missing   # also mint invites for expected-but-absent hosts
 ray apply deploy.yaml --prune            # drop suggestions for hosts no longer in the spec
+ray apply deploy.yaml --json             # machine-readable, for Terraform/Ansible
 ```
 
 Suggestions are still advisory on the receiving end: each node queues them for

--- a/ray-mobile/src/lib.rs
+++ b/ray-mobile/src/lib.rs
@@ -73,7 +73,7 @@ use android_tun::{AndroidTunReader, AndroidTunWriter};
 use rayfish::config;
 use rayfish::control;
 use rayfish::daemon::transfers;
-use rayfish::daemon::{DaemonState, build_headless};
+use rayfish::daemon::{DaemonState, JoinOptions, build_headless};
 use rayfish::deeplink::{self, RayfishLink};
 use rayfish::firewall::{Action, Direction, Protocol};
 use rayfish::hostname;
@@ -513,11 +513,13 @@ impl Node {
         let result = self.runtime.block_on(state.join_network(
             &network_key,
             None,
-            None,
-            invite,
-            coordinator,
-            false, // auto_accept_firewall
-            true,  // auto_accept_files (own-device offers, identity-checked)
+            JoinOptions {
+                invite,
+                coordinator,
+                // Own-device offers, identity-checked.
+                auto_accept_files: true,
+                ..Default::default()
+            },
         ));
 
         match result {
@@ -570,10 +572,14 @@ impl Node {
     /// Mint a single-use invite code for `network` (default 7d TTL), to share.
     pub fn invite(&self, network: String) -> Result<String, RayError> {
         let state = self.state()?;
-        // 7 days, single-use, coordinator-picked hostname (None).
-        let result =
-            self.runtime
-                .block_on(state.invite_create(&network, 7 * 24 * 60 * 60, None, false));
+        // 7 days, single-use, coordinator-picked hostname (None), no roles.
+        let result = self.runtime.block_on(state.invite_create(
+            &network,
+            7 * 24 * 60 * 60,
+            None,
+            Vec::new(),
+            false,
+        ));
         match result {
             IpcMessage::InviteCreated { code, .. } => Ok(code),
             IpcMessage::Error { message } => Err(RayError::Network(message)),
@@ -954,7 +960,7 @@ impl Node {
         let state = self.state()?;
         match self
             .runtime
-            .block_on(state.accept_request(&network, &short_id))
+            .block_on(state.accept_request(&network, &short_id, Vec::new()))
         {
             IpcMessage::Ok { .. } => Ok(()),
             IpcMessage::Error { message } => Err(RayError::Network(message)),

--- a/ray-proto/src/ipc.rs
+++ b/ray-proto/src/ipc.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 #[cfg(unix)]
 use std::io::{IoSlice, IoSliceMut};
 use std::marker::PhantomData;
@@ -60,6 +60,12 @@ pub enum IpcMessage {
         /// network (`--auto-accept-files`).
         #[serde(default)]
         auto_accept_files: bool,
+        /// Roles to ask for (`ray join --role sentry`). A request, not a claim:
+        /// the coordinator grants only what the presented credential permits,
+        /// and refuses the join outright for anything outside it. Empty means
+        /// "whatever the credential carries", which is the usual case.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        roles: Vec<String>,
     },
     Leave {
         name: String,
@@ -295,6 +301,11 @@ pub enum IpcMessage {
         /// so any network-key holder can admit. Hostname is not authoritative.
         #[serde(default)]
         reusable: bool,
+        /// Roles every node redeeming this credential is assigned. Unlike
+        /// `hostname` these are allowed on a reusable key: a role is shared by a
+        /// class of nodes by design, so one key can seat a whole group.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        roles: Vec<String>,
     },
     /// List invites for a network (coordinator-only).
     InviteList {
@@ -313,6 +324,10 @@ pub enum IpcMessage {
     AcceptRequest {
         network: String,
         id: String,
+        /// Roles to assign on approval. A live approval has no credential to
+        /// read them off, so the operator names them.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        roles: Vec<String>,
     },
     /// Drop a pending peer's join request by short id (coordinator-only).
     DenyRequest {
@@ -594,6 +609,10 @@ pub enum IpcMessage {
         code: String,
         id: String,
         expires_secs: u64,
+        /// Roles the credential grants, echoed back so `--json` can report what
+        /// was actually minted rather than what was asked for.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        roles: Vec<String>,
     },
     /// The list of invites for a network.
     InviteListResponse {
@@ -853,6 +872,9 @@ pub struct NetworkStatus {
     /// seeds `ray apply`'s `aliases:` map.
     #[serde(default)]
     pub aliases: BTreeMap<String, String>,
+    /// Roles this node itself holds on this network, from the signed roster.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub my_roles: BTreeSet<String>,
     /// Per-network ephemeral auto-kick TTL in seconds, if the policy is on
     /// (`ray ephemeral <net> <dur>`). `None` = off. Shown on the network line.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -914,6 +936,11 @@ pub struct PeerStatus {
     /// when idle, so a bare `connection.is_none()` must read as `Idle`, not offline.
     #[serde(default)]
     pub state: PeerState,
+    /// Roles the coordinator assigned this peer, from the signed roster. What a
+    /// `role:` firewall rule resolves against, so `ray apply` can report which
+    /// members a role actually covers.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub roles: BTreeSet<String>,
     /// True when this peer advertises itself as an exit node on this network
     /// (`Member.exit_node` in the signed roster). Shown as a badge in status.
     #[serde(default)]
@@ -1709,6 +1736,7 @@ mod tests {
             expires_secs: 604_800,
             hostname: None,
             reusable: true,
+            roles: vec!["sentry".to_string()],
         };
         // The IPC codec uses `to_vec_named`; positional encoding can't survive a
         // `skip_serializing_if` field followed by another field.
@@ -1720,10 +1748,15 @@ mod tests {
                 expires_secs,
                 hostname: _,
                 reusable,
+                roles,
             } => {
                 assert_eq!(network, "gaming");
                 assert_eq!(expires_secs, 604_800);
                 assert!(reusable);
+                // A reusable key carrying roles is the shape a provisioner
+                // mints; it must survive the codec alongside the skipped
+                // `hostname` in front of it.
+                assert_eq!(roles, vec!["sentry".to_string()]);
             }
             _ => panic!("wrong variant"),
         }
@@ -1765,6 +1798,7 @@ mod tests {
             coordinator: Some(coord),
             auto_accept_firewall: false,
             auto_accept_files: false,
+            roles: Vec::new(),
         };
         let bytes = rmp_serde::to_vec(&req).unwrap();
         let decoded: IpcMessage = rmp_serde::from_slice(&bytes).unwrap();
@@ -1883,6 +1917,7 @@ mod tests {
                     ipv6: Ipv6Addr::new(0x0200, 0, 0, 0, 0, 0, 0, 6),
                     hostname: None,
                     user_identity: None,
+                    roles: Default::default(),
                     is_own_device: false,
                     incompatible: false,
                     connection: None,
@@ -1893,6 +1928,7 @@ mod tests {
                 pending_suggestions: 0,
                 pending_requests: 0,
                 aliases: BTreeMap::new(),
+                my_roles: Default::default(),
                 ephemeral_ttl_secs: None,
                 my_exit_node: None,
                 exit_offering: false,

--- a/ray-proto/src/ipc.rs
+++ b/ray-proto/src/ipc.rs
@@ -787,6 +787,11 @@ pub struct PendingRequestInfo {
     pub short_id: String,
     pub hostname: Option<String>,
     pub waiting_secs: u64,
+    /// Roles the peer asked for (`ray join --role`). Shown so the operator can
+    /// see what to pass to `ray requests accept --role`; the request itself
+    /// confers nothing, the approval does.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requested_roles: Vec<String>,
 }
 
 /// An outbound send waiting in the daemon's outbox for its peer to come online.

--- a/ray-proto/src/policy.rs
+++ b/ray-proto/src/policy.rs
@@ -8,6 +8,11 @@
 //! the rules targeting its own hostname, resolving peer hostnames to identities
 //! from the same blob's member list.
 //!
+//! A subject or peer key is a hostname, the wildcard `*`, or a **role**
+//! (`role:sentry`, see [`ROLE_PREFIX`]). A role names a class of nodes rather
+//! than one machine, so a rule written against it covers every member the
+//! coordinator has assigned that role, including ones that join later.
+//!
 //! [`BTreeMap`] keys give a canonical (sorted) serialization, so the blob hash
 //! is stable regardless of authoring order.
 
@@ -41,3 +46,49 @@ pub struct HostSuggestions {
 
 /// Subject hostname -> its suggested rules. Sorted keys ⇒ canonical bytes.
 pub type SuggestedFirewall = BTreeMap<String, HostSuggestions>;
+
+/// Marks a subject or peer key as naming a **role** instead of a hostname.
+///
+/// Roles are assigned by the coordinator from the redeemed join key, never
+/// claimed by the joining node, so a rule keyed on one cannot be captured by a
+/// peer picking a convenient name for itself.
+pub const ROLE_PREFIX: &str = "role:";
+
+/// The role a subject/peer key names, or `None` if it names a hostname or `*`.
+///
+/// The single parser for the prefix, shared by the authoring side (a `ray apply`
+/// spec passes a role through unexpanded, exactly like `*`) and the node side
+/// (`materialize_suggestions` resolves it against the blob's member list). A
+/// bare `role:` with nothing after it is not a role: it would match every member
+/// carrying the empty role, which no member can carry.
+pub fn role_of(key: &str) -> Option<&str> {
+    match key.strip_prefix(ROLE_PREFIX) {
+        Some("") | None => None,
+        Some(role) => Some(role),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_keys_are_recognised() {
+        assert_eq!(role_of("role:sentry"), Some("sentry"));
+        assert_eq!(role_of("role:non-validating"), Some("non-validating"));
+    }
+
+    #[test]
+    fn hostnames_and_wildcards_are_not_roles() {
+        assert_eq!(role_of("sentry"), None);
+        assert_eq!(role_of("*"), None);
+        assert_eq!(role_of("sentry-01.hyperliquid.ray"), None);
+    }
+
+    /// A bare prefix would otherwise resolve to the empty role and match on a
+    /// value no member can hold; treat it as a plain (odd) hostname instead.
+    #[test]
+    fn a_bare_prefix_is_not_a_role() {
+        assert_eq!(role_of("role:"), None);
+    }
+}

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -115,6 +115,17 @@ fn validate_names(spec: &DeploySpec) -> Result<()> {
              role resolved on each node; a group or alias cannot shadow one"
         );
     }
+    // A group member is not expanded when it names a role: `expand_firewall`
+    // passes it through and the node side resolves it, so it reaches the
+    // published rules exactly as a subject or peer key would, and needs the same
+    // check. Nothing downstream would report it: `expected_hosts` skips `role:`
+    // keys, so a miscased one is not even listed as a host that never joined.
+    for (group, members) in &spec.groups {
+        for member in members {
+            validate_role_selector(member)
+                .with_context(|| format!("group `{group}`: member `{member}`"))?;
+        }
+    }
     for (network, firewall) in &spec.networks {
         for (subject, rules) in firewall {
             validate_role_key(network, subject)?;
@@ -141,11 +152,17 @@ fn validate_names(spec: &DeploySpec) -> Result<()> {
 /// are distinct YAML keys, and folding them would merge one into the other and
 /// drop its rules without a word.
 fn validate_role_key(network: &str, key: &str) -> Result<()> {
-    let Some(role) = policy::role_of(key) else {
-        return Ok(());
-    };
-    crate::roles::validate_role(role)
+    validate_role_selector(key)
         .with_context(|| format!("network `{network}`: firewall key `{key}`"))
+}
+
+/// The check itself, without the caller's context: a name that is not a `role:`
+/// selector passes untouched, one that is has to name a role a member can hold.
+fn validate_role_selector(name: &str) -> Result<()> {
+    match policy::role_of(name) {
+        Some(role) => crate::roles::validate_role(role),
+        None => Ok(()),
+    }
 }
 
 /// Recursively replace `ValueKind::Nil` with an empty `Table` so a null
@@ -647,6 +664,51 @@ networks:
         )
         .unwrap_err();
         assert!(err.to_string().contains("role:"), "{err}");
+    }
+
+    /// A group member naming a role is not expanded here, it passes through into
+    /// the published rules, so a miscased one is the same silent no-match as a
+    /// miscased subject key and is rejected at the same place.
+    #[test]
+    fn a_role_inside_a_group_is_held_to_the_same_case_rule() {
+        let yaml = r#"
+groups:
+  fleet: ["role:Sentry"]
+networks:
+  prod:
+    alice:
+      allows:
+        fleet: "tcp:22"
+"#;
+        let err = parse(yaml).unwrap_err();
+        let text = format!("{err:#}");
+        assert!(text.contains("role:Sentry"), "{text}");
+        assert!(text.contains("fleet"), "{text}");
+    }
+
+    /// The other side of it: a canonical role in a group expands to itself and
+    /// reaches the published firewall as a selector the node side resolves.
+    #[test]
+    fn a_canonical_role_inside_a_group_expands_to_itself() {
+        let yaml = r#"
+groups:
+  fleet: ["role:sentry", "alice"]
+networks:
+  prod:
+    bob:
+      allows:
+        fleet: "tcp:22"
+"#;
+        let spec = parse(yaml).unwrap();
+        let (expanded, empty) = expand_firewall(
+            &spec.networks["prod"],
+            &BTreeMap::new(),
+            &spec.groups,
+            &|_| vec![],
+        );
+        assert!(empty.is_empty());
+        let peers: Vec<&String> = expanded["bob"].allows.keys().collect();
+        assert_eq!(peers, vec!["alice", "role:sentry"]);
     }
 
     /// The bug this guards: `config` preserves key case, so a spec written with

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -23,7 +23,7 @@ use std::collections::BTreeSet;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use ray_proto::policy::SuggestedFirewall;
+use ray_proto::policy::{self, SuggestedFirewall};
 use serde::{Deserialize, Serialize};
 
 /// The full deploy spec: a `networks:` map of network name → its suggested
@@ -97,12 +97,21 @@ fn deserialize_spec(cfg: config::Config) -> Result<DeploySpec> {
 }
 
 /// Structural validation independent of live state: a name may not be defined as
-/// both a group and an alias (resolution would be ambiguous).
+/// both a group and an alias (resolution would be ambiguous), and neither may
+/// take a `role:` name, which the node side resolves against the roster and the
+/// admin side must therefore pass through untouched.
 fn validate_names(spec: &DeploySpec) -> Result<()> {
     for name in spec.groups.keys() {
         anyhow::ensure!(
             !spec.aliases.contains_key(name),
             "`{name}` is defined as both a group and an alias; names must be unique"
+        );
+    }
+    for name in spec.groups.keys().chain(spec.aliases.keys()) {
+        anyhow::ensure!(
+            policy::role_of(name).is_none(),
+            "`{name}` starts with `role:`, which names a coordinator-assigned \
+             role resolved on each node; a group or alias cannot shadow one"
         );
     }
     Ok(())
@@ -149,12 +158,20 @@ pub const EXAMPLE_SPEC: &str = r#"# Rayfish deploy spec. See `ray apply --help`.
 # `ray firewall accept`, or auto-installs them if it joined with
 # `--auto-accept-firewall`.
 #
+# A subject or peer can also be a ROLE (`role:sentry`). A role names a class of
+# nodes rather than one machine: the coordinator assigns it from the join code
+# (`ray invite <net> create --reusable --role sentry`), and every node resolves
+# it against the signed roster, so a node joining later is covered with no second
+# `ray apply`. Roles are what to reach for when a group has 1 or 20 instances.
+#
 # Optional `aliases:` and `groups:` are coordinator-side shorthand, expanded
 # client-side before publishing (they never reach the network). An alias names a
 # user by identity (copy it from `ray identityof <net> <host>`) and expands to
 # all of that user's joined device hostnames. A group is a named set of aliases
 # and/or literal hostnames. Both can be used as a rule subject or peer. An alias
 # only resolves once the user has joined; literal hostnames work pre-join.
+# Unlike a role, a group is expanded before publishing, so growing one needs
+# another `ray apply`.
 
 aliases:
   # Fill in a real identity, e.g.:
@@ -186,27 +203,67 @@ networks:
     "*":
       allows:
         admins: "tcp:22"
+  hyperliquid:
+    # Roles, for a fleet whose size changes. Mint one key per role and bake it
+    # into the machine image or user-data:
+    #   ray invite hyperliquid create --reusable --role sentry
+    # Every instance then joins with a bare `ray join <code>` and is covered.
+    "role:validator":
+      allows:
+        "role:sentry": "tcp:4000-4004"
+    "role:sentry":
+      allows:
+        "role:nonvalid": "tcp:4000-4004"
+    # A role and a hostname mix freely in either position.
+    "role:streamer":
+      allows:
+        "*": "tcp:8080"
+        jumpbox: "tcp:22"
 "#;
 
-/// Union of every concrete hostname mentioned in the spec, both subjects and
-/// peer hostnames in `allows`/`denies`. This is the set of hosts the spec
-/// expects to exist; it is diffed against the joined hosts. The `*` wildcard
-/// (subject or peer) is not a real host and is excluded.
-pub fn expected_hosts(spec: &DeploySpec) -> Vec<String> {
+/// Union of every concrete hostname mentioned in one network's firewall, both
+/// subjects and peer hostnames in `allows`/`denies`. This is the set of hosts
+/// that network expects to exist; it is diffed against the hosts joined to *that
+/// network*. The `*` wildcard and any `role:` key are not real hosts and are
+/// excluded: a role has no single machine to mint a hostname-bound invite for,
+/// and its members are covered by the reusable key that grants it.
+pub fn expected_hosts(firewall: &SuggestedFirewall) -> Vec<String> {
     let mut set: BTreeSet<String> = BTreeSet::new();
-    for firewall in spec.networks.values() {
-        for (subject, rules) in firewall {
-            if subject != "*" {
-                set.insert(subject.clone());
-            }
-            for peer in rules.allows.keys().chain(rules.denies.keys()) {
-                if peer != "*" {
-                    set.insert(peer.clone());
-                }
+    for (subject, rules) in firewall {
+        if is_host_key(subject) {
+            set.insert(subject.clone());
+        }
+        for peer in rules.allows.keys().chain(rules.denies.keys()) {
+            if is_host_key(peer) {
+                set.insert(peer.clone());
             }
         }
     }
     set.into_iter().collect()
+}
+
+/// Every role named as a subject or peer in one network's firewall, sorted. The
+/// counterpart to [`expected_hosts`]: `ray apply` reports these by how many
+/// members hold them rather than as hosts that have not joined.
+pub fn expected_roles(firewall: &SuggestedFirewall) -> Vec<String> {
+    let mut set: BTreeSet<String> = BTreeSet::new();
+    for (subject, rules) in firewall {
+        if let Some(role) = policy::role_of(subject) {
+            set.insert(role.to_string());
+        }
+        for peer in rules.allows.keys().chain(rules.denies.keys()) {
+            if let Some(role) = policy::role_of(peer) {
+                set.insert(role.to_string());
+            }
+        }
+    }
+    set.into_iter().collect()
+}
+
+/// Whether a subject/peer key names a machine that has to join, as opposed to
+/// the `*` wildcard or a role the roster resolves.
+fn is_host_key(key: &str) -> bool {
+    key != "*" && policy::role_of(key).is_none()
 }
 
 /// Expand all group/alias references in one network's firewall into a pure,
@@ -216,7 +273,8 @@ pub fn expected_hosts(spec: &DeploySpec) -> Vec<String> {
 /// identity *in this network* (the caller builds it from live `Status`). A name
 /// used as a subject or peer resolves by precedence: **group → alias → literal
 /// hostname** (a name matching no group or alias passes through as itself, so
-/// plain-hostname specs behave exactly as before). `*` is never expanded.
+/// plain-hostname specs behave exactly as before). Neither `*` nor a `role:`
+/// name is ever expanded: both are resolved node-side against the signed blob.
 ///
 /// Returns the expanded firewall plus the sorted, unique set of alias names that
 /// resolved to zero joined hosts (the caller surfaces these as warnings; their
@@ -253,10 +311,13 @@ pub fn expand_firewall(
         hosts
     };
 
-    // Resolve a subject/peer name to concrete hostnames (or keep `*`).
+    // Resolve a subject/peer name to concrete hostnames (or keep `*`/`role:`).
     let mut resolve_name = |name: &str| -> Vec<String> {
-        if name == "*" {
-            return vec!["*".to_string()];
+        // A role is resolved on each node against the signed roster, not here:
+        // expanding it now would freeze today's membership into the published
+        // rules and a node joining later would never be covered.
+        if name == "*" || policy::role_of(name).is_some() {
+            return vec![name.to_string()];
         }
         if let Some(members) = groups.get(name) {
             let mut out: Vec<String> = Vec::new();
@@ -473,16 +534,98 @@ networks:
                 denies: [].into(),
             },
         );
-        let mut spec = DeploySpec {
-            networks: BTreeMap::new(),
-            ..Default::default()
-        };
-        spec.networks.insert("gaming".to_string(), fw);
-        let hosts = expected_hosts(&spec);
+        let hosts = expected_hosts(&fw);
         assert_eq!(
             hosts,
             vec!["alice".to_string(), "bob".to_string(), "carol".to_string()]
         );
+    }
+
+    /// A role survives expansion untouched. Expanding it here would freeze
+    /// today's membership into the published rules, and the node that joins
+    /// tomorrow would never be covered.
+    #[test]
+    fn a_role_passes_through_expansion_unexpanded() {
+        let mut fw = SuggestedFirewall::new();
+        let mut entry = HostSuggestions::default();
+        entry
+            .allows
+            .insert("role:sentry".to_string(), "tcp:4000".to_string());
+        fw.insert("role:validator".to_string(), entry);
+
+        let groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        let aliases: BTreeMap<String, String> = BTreeMap::new();
+        let (out, empty) = expand_firewall(&fw, &aliases, &groups, &|_| Vec::new());
+        assert!(empty.is_empty());
+        assert_eq!(
+            out.get("role:validator")
+                .and_then(|h| h.allows.get("role:sentry"))
+                .map(String::as_str),
+            Some("tcp:4000")
+        );
+    }
+
+    /// A role is not a host, so it is neither a gap to report nor something to
+    /// mint a hostname-bound invite for.
+    #[test]
+    fn expected_hosts_skips_roles_and_wildcards() {
+        let mut fw = SuggestedFirewall::new();
+        let mut entry = HostSuggestions::default();
+        entry
+            .allows
+            .insert("role:sentry".to_string(), "tcp:4000".to_string());
+        entry.allows.insert("*".to_string(), "icmp".to_string());
+        entry
+            .allows
+            .insert("jumpbox".to_string(), "tcp:22".to_string());
+        fw.insert("role:validator".to_string(), entry);
+        fw.insert("named-host".to_string(), HostSuggestions::default());
+
+        assert_eq!(
+            expected_hosts(&fw),
+            vec!["jumpbox".to_string(), "named-host".to_string()]
+        );
+        assert_eq!(
+            expected_roles(&fw),
+            vec!["sentry".to_string(), "validator".to_string()]
+        );
+    }
+
+    /// A group or alias called `role:x` would shadow a name the node side
+    /// resolves against the roster, so it is rejected at parse time.
+    #[test]
+    fn a_group_or_alias_cannot_shadow_a_role() {
+        let err = parse(
+            r#"
+groups:
+  "role:sentry": [box]
+networks:
+  prod: {}
+"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("role:"), "{err}");
+
+        let err = parse(
+            r#"
+aliases:
+  "role:sentry": abc
+networks:
+  prod: {}
+"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("role:"), "{err}");
+    }
+
+    /// A bare `role:` is not a role, so it stays an (odd) hostname and still
+    /// counts as a host the spec expects.
+    #[test]
+    fn a_bare_role_prefix_is_treated_as_a_host() {
+        let mut fw = SuggestedFirewall::new();
+        fw.insert("role:".to_string(), HostSuggestions::default());
+        assert_eq!(expected_hosts(&fw), vec!["role:".to_string()]);
+        assert!(expected_roles(&fw).is_empty());
     }
 
     /// Build a HostSuggestions from (peer, spec) allow pairs.

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -97,9 +97,10 @@ fn deserialize_spec(cfg: config::Config) -> Result<DeploySpec> {
 }
 
 /// Structural validation independent of live state: a name may not be defined as
-/// both a group and an alias (resolution would be ambiguous), and neither may
-/// take a `role:` name, which the node side resolves against the roster and the
-/// admin side must therefore pass through untouched.
+/// both a group and an alias (resolution would be ambiguous), neither may take a
+/// `role:` name, which the node side resolves against the roster and the admin
+/// side must therefore pass through untouched, and every `role:` selector must
+/// name a role a member can actually hold.
 fn validate_names(spec: &DeploySpec) -> Result<()> {
     for name in spec.groups.keys() {
         anyhow::ensure!(
@@ -114,7 +115,37 @@ fn validate_names(spec: &DeploySpec) -> Result<()> {
              role resolved on each node; a group or alias cannot shadow one"
         );
     }
+    for (network, firewall) in &spec.networks {
+        for (subject, rules) in firewall {
+            validate_role_key(network, subject)?;
+            for peer in rules.allows.keys().chain(rules.denies.keys()) {
+                validate_role_key(network, peer)?;
+            }
+        }
+    }
     Ok(())
+}
+
+/// Check one subject/peer key that names a role. Keys that name a hostname or
+/// `*` pass untouched.
+///
+/// A `role:` selector is compared byte for byte against the roles the
+/// coordinator minted, and those are canonical ([`crate::roles::normalize`]
+/// lowercases and trims). The spec is not canonicalized on the way in: the
+/// `config` crate preserves the case a key was written in, so `role:Sentry`
+/// would publish verbatim and then resolve on no member at all, on every node,
+/// silently. Reject it here, where the author can still see it, rather than let
+/// `ray apply` report "no members yet" for a role nobody can hold.
+///
+/// Rejected rather than lowercased in place: two subjects differing only in case
+/// are distinct YAML keys, and folding them would merge one into the other and
+/// drop its rules without a word.
+fn validate_role_key(network: &str, key: &str) -> Result<()> {
+    let Some(role) = policy::role_of(key) else {
+        return Ok(());
+    };
+    crate::roles::validate_role(role)
+        .with_context(|| format!("network `{network}`: firewall key `{key}`"))
 }
 
 /// Recursively replace `ValueKind::Nil` with an empty `Table` so a null
@@ -616,6 +647,68 @@ networks:
         )
         .unwrap_err();
         assert!(err.to_string().contains("role:"), "{err}");
+    }
+
+    /// The bug this guards: `config` preserves key case, so a spec written with
+    /// `role:Sentry` published verbatim and matched no member on any node, while
+    /// `ray apply` blamed the roster ("no members yet").
+    #[test]
+    fn a_role_key_with_capitals_is_rejected() {
+        let yaml = r#"
+networks:
+  prod:
+    "role:Sentry":
+      allows:
+        "*": "tcp:22"
+"#;
+        let err = parse(yaml).unwrap_err();
+        let text = format!("{err:#}");
+        assert!(text.contains("role:Sentry"), "{text}");
+        assert!(text.contains("prod"), "{text}");
+    }
+
+    /// Peer keys resolve the same way subjects do, so they are held to the same
+    /// rule.
+    #[test]
+    fn a_role_peer_key_with_capitals_is_rejected() {
+        let yaml = r#"
+networks:
+  prod:
+    alice:
+      allows:
+        "role:Sentry": "tcp:22"
+"#;
+        assert!(parse(yaml).is_err());
+    }
+
+    #[test]
+    fn a_denies_role_key_with_capitals_is_rejected() {
+        let yaml = r#"
+networks:
+  prod:
+    alice:
+      denies:
+        "role:Sentry": "tcp:22"
+"#;
+        assert!(parse(yaml).is_err());
+    }
+
+    /// Canonical role keys, `*` and plain hostnames all pass untouched.
+    #[test]
+    fn canonical_role_keys_and_hostnames_pass() {
+        let yaml = r#"
+networks:
+  prod:
+    "role:sentry":
+      allows:
+        "role:non-validating": "tcp:4000"
+        "*": "tcp:22"
+    alice:
+      denies:
+        bob: "tcp:22"
+"#;
+        let spec = parse(yaml).unwrap();
+        assert_eq!(spec.networks["prod"].len(), 2);
     }
 
     /// A bare `role:` is not a role, so it stays an (odd) hostname and still

--- a/src/cli/firewall.rs
+++ b/src/cli/firewall.rs
@@ -544,6 +544,12 @@ pub(crate) async fn ipc_apply(
     // A dry-run with no aliases/groups needs nothing from the daemon: just echo
     // the normalized spec (the historical behavior).
     if dry_run && !has_dynamic {
+        if json_enabled() {
+            print_json(&serde_json::json!({
+                "dry_run": true, "changed": false, "spec": spec,
+            }));
+            return Ok(());
+        }
         println!("{}", style::bold("Spec (normalized):"));
         print!("{}", apply::to_yaml(&spec)?);
         println!("{}", style::faint("(dry-run; no changes applied)"));
@@ -577,15 +583,23 @@ pub(crate) async fn ipc_apply(
         };
         let (efw, empty_aliases) = apply::expand_firewall(fw, &net_aliases, &spec.groups, &resolve);
         for a in empty_aliases {
-            eprintln!(
-                "{}  {net_name}: alias '{a}' has no joined devices yet; its rules are skipped",
-                style::faint("note:")
-            );
+            if !json_enabled() {
+                eprintln!(
+                    "{}  {net_name}: alias '{a}' has no joined devices yet; its rules are skipped",
+                    style::faint("note:")
+                );
+            }
         }
         expanded.networks.insert(net_name.clone(), efw);
     }
 
     if dry_run {
+        if json_enabled() {
+            print_json(&serde_json::json!({
+                "dry_run": true, "changed": false, "spec": expanded,
+            }));
+            return Ok(());
+        }
         println!("{}", style::bold("Spec (expanded):"));
         print!("{}", apply::to_yaml(&expanded)?);
         println!("{}", style::faint("(dry-run; no changes applied)"));
@@ -593,21 +607,38 @@ pub(crate) async fn ipc_apply(
     }
 
     let mut missing_hosts: Vec<(String, String)> = Vec::new(); // (network, hostname)
+    let mut role_counts: Vec<RoleCoverage> = Vec::new();
+    let mut net_reports: Vec<serde_json::Value> = Vec::new();
+    // Ansible's `changed_when` reads this: creating a network or publishing a
+    // suggestion set counts, reporting a gap does not.
+    let mut changed = false;
+    let json = json_enabled();
 
     for (net_name, net_firewall) in &expanded.networks {
         let is_active = active_names.contains(net_name.as_str());
+        let mut created = false;
         // Create-if-absent (always a closed network).
         if !is_active {
-            println!(
-                "{} {}: creating closed network",
-                style::label("apply"),
-                style::bold(net_name),
-            );
+            if !json {
+                println!(
+                    "{} {}: creating closed network",
+                    style::label("apply"),
+                    style::bold(net_name),
+                );
+            }
             if let Err(e) = ipc_apply_create(net_name).await {
-                eprintln!("{}  create failed: {e}", style::red("  !"));
+                if json {
+                    net_reports.push(serde_json::json!({
+                        "network": net_name, "created": false, "error": e.to_string(),
+                    }));
+                } else {
+                    eprintln!("{}  create failed: {e}", style::red("  !"));
+                }
                 continue;
             }
-        } else {
+            created = true;
+            changed = true;
+        } else if !json {
             println!(
                 "{} {}: already active",
                 style::label("apply"),
@@ -630,21 +661,115 @@ pub(crate) async fn ipc_apply(
             }
             live
         };
-        match ipc_firewall_suggest_set(net_name, to_publish).await {
-            Ok(msg) => println!("{}   {msg}", style::faint("→")),
-            Err(e) => eprintln!("{}   suggest failed: {e}", style::red("  !")),
+        let published = ipc_firewall_suggest_set(net_name, to_publish).await;
+        match &published {
+            Ok(msg) => {
+                changed = true;
+                if !json {
+                    println!("{}   {msg}", style::faint("→"));
+                }
+            }
+            Err(e) => {
+                if !json {
+                    eprintln!("{}   suggest failed: {e}", style::red("  !"));
+                }
+            }
+        }
+        if json {
+            net_reports.push(serde_json::json!({
+                "network": net_name,
+                "created": created,
+                "published": published.is_ok(),
+                "error": published.as_ref().err().map(|e| e.to_string()),
+            }));
         }
 
-        // B3, membership diff for this network.
+        // B3, membership diff for this network. Scoped to *this* network's
+        // firewall: over the whole spec, a host expected in one network reads as
+        // missing from every other, and `--invite-missing` mints its invite on
+        // the wrong network.
         let joined = joined_hostnames(&status_networks, net_name);
-        for host in apply::expected_hosts(&expanded) {
+        for host in apply::expected_hosts(net_firewall) {
             if !joined.iter().any(|j| j == &host) {
                 missing_hosts.push((net_name.clone(), host));
             }
         }
+        // A role is not a host to invite: report who holds it instead. Zero
+        // holders is worth saying, since its rules materialize on nobody.
+        for role in apply::expected_roles(net_firewall) {
+            let holders = role_holders(&status_networks, net_name, &role);
+            role_counts.push(RoleCoverage {
+                network: net_name.clone(),
+                role,
+                holders,
+            });
+        }
     }
 
-    // B3, report the membership gap.
+    if !role_counts.is_empty() && !json {
+        println!("\n{} Roles the spec targets:", style::label("roles"));
+        for RoleCoverage {
+            network,
+            role,
+            holders,
+        } in &role_counts
+        {
+            let line = format!("role:{role}");
+            if *holders == 0 {
+                println!(
+                    "  {}  {}",
+                    style::red(&line),
+                    style::faint(&format!(
+                        "no members yet - mint one with `ray invite {network} create --reusable --role {role}`"
+                    ))
+                );
+            } else {
+                println!(
+                    "  {}  {}",
+                    style::bold(&line),
+                    style::faint(&format!("{holders} member(s)"))
+                );
+            }
+        }
+        println!(
+            "  {}",
+            style::faint("nodes joining later are covered without re-running apply")
+        );
+    }
+
+    // B3, report the membership gap. In JSON the codes go in the payload, so
+    // the whole human branch is skipped.
+    if json {
+        let mut hosts = Vec::new();
+        for (net, host) in &missing_hosts {
+            let code = if invite_missing {
+                ipc_invite_mint(net, Some(host.clone()), Vec::new())
+                    .await
+                    .ok()
+            } else {
+                None
+            };
+            if code.is_some() {
+                changed = true;
+            }
+            hosts.push(serde_json::json!({
+                "network": net, "hostname": host, "code": code,
+            }));
+        }
+        print_json(&serde_json::json!({
+            "dry_run": false,
+            "changed": changed,
+            "networks": net_reports,
+            "roles": role_counts
+                .iter()
+                .map(|r| serde_json::json!({
+                    "network": r.network, "role": r.role, "holders": r.holders,
+                }))
+                .collect::<Vec<_>>(),
+            "missing_hosts": hosts,
+        }));
+        return Ok(());
+    }
     if missing_hosts.is_empty() {
         println!("{}", style::green("All expected hosts have joined."));
     } else {
@@ -653,9 +778,9 @@ pub(crate) async fn ipc_apply(
             style::label("diff")
         );
         for (net, host) in &missing_hosts {
-            let cmd = format!("ray invite {net} --hostname {host}");
+            let cmd = format!("ray invite {net} create --hostname {host}");
             if invite_missing {
-                match ipc_invite_mint(net, Some(host.clone())).await {
+                match ipc_invite_mint(net, Some(host.clone()), Vec::new()).await {
                     Ok(code) => println!(
                         "  {}  {}  {}",
                         style::bold(host),
@@ -680,6 +805,28 @@ pub(crate) async fn ipc_apply(
         }
     }
     Ok(())
+}
+
+/// How many members currently hold `role` on `network`. What a `role:` rule
+/// will actually resolve to on each node, so apply can say whether a rule
+/// covers anyone yet.
+fn role_holders(networks: &[ipc::NetworkStatus], network: &str, role: &str) -> usize {
+    let Some(net) = networks.iter().find(|n| n.name == network) else {
+        return 0;
+    };
+    let mine = usize::from(net.my_roles.iter().any(|r| r == role));
+    mine + net
+        .peers
+        .iter()
+        .filter(|p| p.roles.iter().any(|r| r == role))
+        .count()
+}
+
+/// One `role:` key in the spec and how many members it covers today.
+struct RoleCoverage {
+    network: String,
+    role: String,
+    holders: usize,
 }
 
 /// Joined hostnames on `network` (this node's hostname + every peer's hostname).
@@ -877,7 +1024,11 @@ pub(crate) async fn ipc_firewall_suggest_set(
     }
 }
 
-pub(crate) async fn ipc_invite_mint(network: &str, hostname: Option<String>) -> Result<String> {
+pub(crate) async fn ipc_invite_mint(
+    network: &str,
+    hostname: Option<String>,
+    roles: Vec<String>,
+) -> Result<String> {
     let mut stream = ipc::connect().await?;
     ipc::send(
         &mut stream,
@@ -886,6 +1037,7 @@ pub(crate) async fn ipc_invite_mint(network: &str, hostname: Option<String>) -> 
             expires_secs: 7 * 24 * 3600,
             hostname,
             reusable: false,
+            roles,
         },
     )
     .await?;
@@ -1019,6 +1171,7 @@ mod tests {
             state: ipc::PeerState::Idle,
             exit_node: false,
             exit_in_use: false,
+            roles: Default::default(),
         }
     }
 
@@ -1038,6 +1191,7 @@ mod tests {
             my_exit_node: None,
             exit_offering: false,
             incompatible: None,
+            my_roles: Default::default(),
         }
     }
 

--- a/src/cli/firewall.rs
+++ b/src/cli/firewall.rs
@@ -649,22 +649,30 @@ pub(crate) async fn ipc_apply(
         // Publish suggestions (idempotent). With --prune, publish exactly the
         // spec's set; without it, merge into the live set (so `apply` never
         // silently drops subjects authored out-of-band - use --prune for that).
+        //
+        // The live set is read either way, not only for the merge: publishing
+        // always replaces the live set, so a successful publish says nothing
+        // about whether anything moved, and `changed` has to come from the
+        // comparison or Ansible's `changed_when` reports a change on every play.
+        // A read that failed reads as empty, which errs towards "changed".
+        let live = ipc_firewall_suggestions_get(net_name)
+            .await
+            .unwrap_or_default();
         let to_publish = if prune {
             net_firewall.clone()
         } else {
-            let mut live = ipc_firewall_suggestions_get(net_name)
-                .await
-                .unwrap_or_default();
             // Merge spec subjects over live (spec wins on conflict).
+            let mut merged = live.clone();
             for (subj, rules) in net_firewall {
-                live.insert(subj.clone(), rules.clone());
+                merged.insert(subj.clone(), rules.clone());
             }
-            live
+            merged
         };
+        let differs = to_publish != live;
         let published = ipc_firewall_suggest_set(net_name, to_publish).await;
         match &published {
             Ok(msg) => {
-                changed = true;
+                changed |= differs;
                 if !json {
                     println!("{}   {msg}", style::faint("→"));
                 }

--- a/src/cli/invite.rs
+++ b/src/cli/invite.rs
@@ -240,33 +240,58 @@ pub(crate) async fn ipc_requests(network: &str) -> Result<()> {
     match ipc::recv(&mut stream).await? {
         ipc::IpcMessage::PendingRequests { requests } => {
             if json_enabled() {
-                print_json(&serde_json::json!(requests
-                    .iter()
-                    .map(|r| serde_json::json!({
-                        "id": r.short_id, "hostname": r.hostname, "waiting_secs": r.waiting_secs,
-                    }))
-                    .collect::<Vec<_>>()));
+                print_json(&serde_json::json!(
+                    requests
+                        .iter()
+                        .map(|r| serde_json::json!({
+                            "id": r.short_id,
+                            "hostname": r.hostname,
+                            "waiting_secs": r.waiting_secs,
+                            "requested_roles": r.requested_roles,
+                        }))
+                        .collect::<Vec<_>>()
+                ));
             } else if requests.is_empty() {
                 println!("\n  {}\n", style::faint("no pending join requests"));
             } else {
+                // The peer's `--role` is a request, not a grant: only
+                // `accept --role` confers one, so the column is what tells the
+                // operator which flag to repeat.
+                let any_roles = requests.iter().any(|r| !r.requested_roles.is_empty());
                 let rows = requests
                     .iter()
                     .map(|r| {
                         let host = r.hostname.clone().unwrap_or_else(|| "—".to_string());
                         let wait = format!("{}s", r.waiting_secs);
-                        vec![
+                        let mut row = vec![
                             layout::Cell::new(r.short_id.clone(), style::rose(&r.short_id)),
                             layout::Cell::new(host.clone(), style::value(&host)),
-                            layout::Cell::right(wait.clone(), style::faint(&wait)),
-                        ]
+                        ];
+                        if any_roles {
+                            let asked = if r.requested_roles.is_empty() {
+                                "—".to_string()
+                            } else {
+                                r.requested_roles.join(", ")
+                            };
+                            row.push(layout::Cell::new(asked.clone(), style::value(&asked)));
+                        }
+                        row.push(layout::Cell::right(wait.clone(), style::faint(&wait)));
+                        row
                     })
                     .collect();
+                let headers: &[&str] = if any_roles {
+                    &["id", "host", "asked for", "waiting"]
+                } else {
+                    &["id", "host", "waiting"]
+                };
                 println!();
-                print!("{}", table(&["id", "host", "waiting"], rows, 2));
-                println!(
-                    "\n  {}",
-                    style::faint(&format!("admit with: ray requests {network} accept <id>"))
-                );
+                print!("{}", table(headers, rows, 2));
+                let hint = if any_roles {
+                    format!("admit with: ray requests {network} accept <id> [--role <asked for>]")
+                } else {
+                    format!("admit with: ray requests {network} accept <id>")
+                };
+                println!("\n  {}", style::faint(&hint));
             }
         }
         ipc::IpcMessage::Error { message } => fail_with("error", &message),

--- a/src/cli/invite.rs
+++ b/src/cli/invite.rs
@@ -28,6 +28,7 @@ pub(crate) async fn ipc_invite(network: &str, action: Option<InviteAction>) -> R
         expires: None,
         hostname: None,
         reusable: false,
+        roles: Vec::new(),
         qr: false,
     });
     let hostname_opt = match &action {
@@ -40,6 +41,7 @@ pub(crate) async fn ipc_invite(network: &str, action: Option<InviteAction>) -> R
             expires,
             hostname,
             reusable,
+            roles,
             qr: _,
         } => {
             // Reusable keys default to a longer 30d TTL; single-use to 7d.
@@ -55,6 +57,7 @@ pub(crate) async fn ipc_invite(network: &str, action: Option<InviteAction>) -> R
                 expires_secs: parse_duration_secs(&ttl)?,
                 hostname,
                 reusable,
+                roles,
             }
         }
         InviteAction::List => ipc::IpcMessage::InviteList {
@@ -72,14 +75,16 @@ pub(crate) async fn ipc_invite(network: &str, action: Option<InviteAction>) -> R
             code,
             id,
             expires_secs,
-        } => print_invite_created(
-            &code,
-            &id,
+            roles,
+        } => print_invite_created(MintedInvite {
+            code: &code,
+            id: &id,
             expires_secs,
+            roles: &roles,
             show_qr,
             reusable_requested,
-            &hostname_opt,
-        ),
+            hostname_opt: &hostname_opt,
+        }),
         ipc::IpcMessage::InviteListResponse { invites } => print_invite_list(&invites),
         ipc::IpcMessage::Ok { message } => println!("{}", message),
         ipc::IpcMessage::Error { message } => fail_with("error", &message),
@@ -90,14 +95,43 @@ pub(crate) async fn ipc_invite(network: &str, action: Option<InviteAction>) -> R
 
 /// Render a freshly minted invite: id, join code, optional QR, TTL, and the
 /// reusable/single-use + hostname-binding notes.
-fn print_invite_created(
-    code: &str,
-    id: &str,
+/// What was actually minted, as the coordinator reports it back. A struct
+/// rather than seven positionals, and it is also the shape `--json` renders, so
+/// the human and machine outputs cannot drift apart.
+struct MintedInvite<'a> {
+    code: &'a str,
+    id: &'a str,
     expires_secs: u64,
+    /// Roles the credential grants, as the daemon normalized them (lowercased,
+    /// deduped), not as they were typed.
+    roles: &'a [String],
     show_qr: bool,
     reusable_requested: bool,
-    hostname_opt: &Option<String>,
-) {
+    hostname_opt: &'a Option<String>,
+}
+
+fn print_invite_created(minted: MintedInvite) {
+    let MintedInvite {
+        code,
+        id,
+        expires_secs,
+        roles,
+        show_qr,
+        reusable_requested,
+        hostname_opt,
+    } = minted;
+    // A provisioner reads this: emit the code and what it grants, nothing else.
+    if json_enabled() {
+        print_json(&serde_json::json!({
+            "id": id,
+            "code": code,
+            "expires_secs": expires_secs,
+            "reusable": reusable_requested,
+            "hostname": hostname_opt,
+            "roles": roles,
+        }));
+        return;
+    }
     println!();
     println!(
         "  {} {} {}",
@@ -127,17 +161,26 @@ fn print_invite_created(
     };
     if reusable_requested {
         println!("  reusable (multi-use), expires in {ttl}");
-        println!(
-            "  servers join unattended with: {}",
-            style::faint(&format!(
-                "ray join {code} --hostname <h> --auto-accept-firewall"
-            ))
-        );
+        // With roles the per-host `--hostname` is the wrong advice: the whole
+        // point is that every machine runs the identical line.
+        let join = if roles.is_empty() {
+            format!("ray join {code} --hostname <h> --auto-accept-firewall")
+        } else {
+            format!("ray join {code} --auto-accept-firewall")
+        };
+        println!("  servers join unattended with: {}", style::faint(&join));
     } else {
         println!("  single-use, expires in {ttl}");
     }
     if let Some(h) = hostname_opt {
         println!("  binds hostname: {}", style::bold(h));
+    }
+    if !roles.is_empty() {
+        println!("  assigns roles: {}", style::bold(&roles.join(", ")));
+        println!(
+            "  firewall rules targeting {} now cover every node that redeems this",
+            style::faint(&format!("role:{}", roles[0]))
+        );
     }
 }
 
@@ -232,13 +275,14 @@ pub(crate) async fn ipc_requests(network: &str) -> Result<()> {
     Ok(())
 }
 
-pub(crate) async fn ipc_accept_request(network: &str, id: &str) -> Result<()> {
+pub(crate) async fn ipc_accept_request(network: &str, id: &str, roles: Vec<String>) -> Result<()> {
     let mut stream = ipc::connect().await?;
     ipc::send(
         &mut stream,
         ipc::IpcMessage::AcceptRequest {
             network: network.to_string(),
             id: id.to_string(),
+            roles,
         },
     )
     .await?;

--- a/src/cli/network.rs
+++ b/src/cli/network.rs
@@ -65,14 +65,25 @@ pub(crate) async fn ipc_create(
     Ok(())
 }
 
-pub(crate) async fn ipc_join(
-    network_key: &str,
-    name: Option<&str>,
-    hostname: Option<String>,
-    tor: bool,
-    auto_accept_firewall: bool,
-    auto_accept_files: bool,
-) -> Result<()> {
+/// The choices `ray join` carries beyond the code itself. Grouped so the call
+/// site names each one: four of them are bare flags that would swap silently.
+pub(crate) struct JoinArgs {
+    pub(crate) hostname: Option<String>,
+    pub(crate) tor: bool,
+    pub(crate) auto_accept_firewall: bool,
+    pub(crate) auto_accept_files: bool,
+    /// Roles to ask for. Narrows what the code grants, never widens it.
+    pub(crate) roles: Vec<String>,
+}
+
+pub(crate) async fn ipc_join(network_key: &str, name: Option<&str>, args: JoinArgs) -> Result<()> {
+    let JoinArgs {
+        hostname,
+        tor,
+        auto_accept_firewall,
+        auto_accept_files,
+        roles,
+    } = args;
     let transport = if tor {
         Some(config::TransportMode::Tor)
     } else {
@@ -97,6 +108,7 @@ pub(crate) async fn ipc_join(
             coordinator,
             auto_accept_firewall,
             auto_accept_files,
+            roles,
         },
     )
     .await?;

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -6,7 +6,20 @@ use rayfish::deeplink::{RayfishLink, parse_rayfish_uri};
 
 pub(crate) async fn cmd_open(uri: &str) -> Result<()> {
     match parse_rayfish_uri(uri)? {
-        RayfishLink::Join(code) => ipc_join(&code, None, None, false, false, false).await,
+        RayfishLink::Join(code) => {
+            ipc_join(
+                &code,
+                None,
+                JoinArgs {
+                    hostname: None,
+                    tor: false,
+                    auto_accept_firewall: false,
+                    auto_accept_files: false,
+                    roles: Vec::new(),
+                },
+            )
+            .await
+        }
         RayfishLink::Pair(ticket) => ipc_pair_accept(&ticket).await,
     }
 }

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -895,6 +895,15 @@ fn device_row(
         (false, true) => layout::Cell::new("offers", style::faint("offers")),
         (false, false) => layout::Cell::plain(""),
     });
+    // Roles last: what a `role:` firewall rule resolves this peer as. Only shown
+    // when it holds any, so a mesh that uses none looks exactly as it did.
+    cells.push(if peer.roles.is_empty() {
+        layout::Cell::plain("")
+    } else {
+        let text = peer.roles.iter().cloned().collect::<Vec<_>>().join(",");
+        let styled = style::faint(&text);
+        layout::Cell::new(&text, styled)
+    });
     cells
 }
 
@@ -1097,6 +1106,7 @@ mod grouping_tests {
             },
             exit_node: false,
             exit_in_use: false,
+            roles: Default::default(),
         }
     }
 
@@ -1116,6 +1126,7 @@ mod grouping_tests {
             my_exit_node: None,
             exit_offering: false,
             incompatible: None,
+            my_roles: Default::default(),
         }
     }
 
@@ -1180,6 +1191,7 @@ mod grouping_tests {
             state: ipc::PeerState::Active,
             exit_node: false,
             exit_in_use: false,
+            roles: Default::default(),
         };
         let secondary = peer("sm-f966b", Some(laptop), false, false, false);
         let net = net("umbrel", vec![primary, secondary]);
@@ -1192,6 +1204,18 @@ mod grouping_tests {
         assert!(out.contains("└─"), "{out}");
         let at = |s: &str| out.find(s).unwrap();
         assert!(at("laptop") < at("sm-f966b"), "{out}");
+    }
+
+    /// A peer's roles show in its row, and a peer with none renders exactly as
+    /// it did before roles existed.
+    #[test]
+    fn peer_rows_show_roles_when_a_peer_holds_any() {
+        let plain = net("laptop", vec![peer("server", None, false, true, false)]);
+        assert!(!render(&plain).contains("sentry"));
+
+        let mut tagged = plain;
+        tagged.peers[0].roles = ["sentry".to_string()].into();
+        assert!(render(&tagged).contains("sentry"));
     }
 
     #[test]
@@ -1316,6 +1340,7 @@ mod grouping_tests {
                 state: ipc::PeerState::Offline,
                 exit_node: false,
                 exit_in_use: false,
+                roles: Default::default(),
             })
             .collect();
         let mut n = net("laptop", peers);

--- a/src/config.rs
+++ b/src/config.rs
@@ -426,6 +426,12 @@ pub struct PendingJoinEntry {
     /// The local display name to use once admitted, if the user gave one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Roles the join asked for (`ray join --role`). Kept so a restart resumes
+    /// the same request: coming back asking for nothing would let the node be
+    /// seated without the policy class it was provisioned for, and a firewall
+    /// rule keyed on that role would quietly never reach it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub roles: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2711,6 +2717,7 @@ name = "test"
             PendingJoinEntry {
                 network_key: "abc123".to_string(),
                 name: Some("homelab".to_string()),
+                roles: vec!["sentry".to_string()],
             },
         )
         .unwrap();
@@ -2718,6 +2725,9 @@ name = "test"
         let loaded = load_in(dir).unwrap();
         assert_eq!(loaded.pending_joins.len(), 1);
         assert_eq!(loaded.pending_joins[0].network_key, "abc123");
+        // The roles survive the round trip: a restart that resumed without them
+        // would ask for nothing and be seated without its policy class.
+        assert_eq!(loaded.pending_joins[0].roles, vec!["sentry".to_string()]);
 
         // Adding the same key again does not duplicate it.
         add_pending_join_in(
@@ -2725,6 +2735,7 @@ name = "test"
             PendingJoinEntry {
                 network_key: "abc123".to_string(),
                 name: None,
+                roles: Vec::new(),
             },
         )
         .unwrap();

--- a/src/control.rs
+++ b/src/control.rs
@@ -266,10 +266,20 @@ pub enum ControlMsg {
     },
     /// Coordinator → coordinators: share a minted single-use invite's hash so any
     /// coordinator can redeem it. Carries the hash only, never the secret.
+    ///
+    /// `roles` travels with it because it is part of what the invite grants, and
+    /// the ledger entry a co-coordinator writes from this message is the only
+    /// thing it has to redeem against: without them a role-bearing code redeemed
+    /// through any coordinator but its minter seats the node with no roles at
+    /// all, and its `role:` rules never materialize. (The invite's authoritative
+    /// hostname does not travel yet, so that half still falls back to the
+    /// joiner's own claim on a co-coordinator.)
     InviteShare {
         id: String,
         secret_hash: Vec<u8>,
         expires: u64,
+        #[serde(default)]
+        roles: BTreeSet<String>,
     },
     /// Coordinator → coordinators: a shared single-use invite was redeemed; burn it.
     InviteUsed {
@@ -995,6 +1005,7 @@ mod tests {
                 id: "ab3f".into(),
                 secret_hash: vec![1, 2, 3],
                 expires: 42,
+                roles: ["sentry".to_string()].into(),
             },
             ControlMsg::InviteUsed {
                 secret_hash: vec![4, 5, 6],

--- a/src/control.rs
+++ b/src/control.rs
@@ -118,6 +118,12 @@ pub enum ConnectMsg {
 }
 
 /// Control messages exchanged between peers over QUIC bidirectional streams.
+/// `serde(default)` for a `bool` field that means "yes" when an older peer's
+/// shorter array leaves it out.
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ControlMsg {
     /// Sent by a joining peer as the first message on an initial (non-reconnect)
@@ -146,6 +152,14 @@ pub enum ControlMsg {
     },
     JoinDenied {
         reason: String,
+        /// Whether trying again could ever produce a different answer. A
+        /// coordinator-side hiccup (a direct grant it cannot reproduce yet, a
+        /// roster commit that did not land) is retryable; a refused `--role` is
+        /// not, and the joiner's pending-join loop would otherwise reask on a
+        /// backoff forever with nothing surfacing the deadlock. Defaults to
+        /// `true` so a shorter array from an older peer keeps the old behaviour.
+        #[serde(default = "default_true")]
+        retryable: bool,
     },
     /// Notify connected members that the roster/blob changed. Payload-free: it
     /// is a *trigger only*. Receivers reconverge from the network-key-signed
@@ -793,6 +807,7 @@ mod tests {
     fn test_roundtrip_join_denied() {
         let msg = ControlMsg::JoinDenied {
             reason: "not authorized".to_string(),
+            retryable: false,
         };
         let bytes = encode_msg(None, &msg);
         let decoded = decode_msg(&bytes).unwrap();

--- a/src/control.rs
+++ b/src/control.rs
@@ -3,7 +3,7 @@
 //! Each message is encoded as a 4-byte big-endian length prefix followed by a msgpack body.
 //! Control messages manage membership (join, approve, sync) and mesh topology (hello, reconnect).
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{Context, Result};
 use iroh::endpoint::{RecvStream, SendStream};
@@ -131,6 +131,12 @@ pub enum ControlMsg {
         hostname: Option<String>,
         #[serde(default)]
         device_cert: Option<DeviceCert>,
+        /// Roles the joiner *asks* for (`ray join --role sentry`). A request,
+        /// not a claim: the coordinator only grants what the redeemed key
+        /// already permits, and denies the join outright if this asks for
+        /// anything outside it. Empty means "whatever the key carries".
+        #[serde(default)]
+        roles: BTreeSet<String>,
     },
     /// Coordinator response telling the joiner it has been queued for live
     /// approval (closed network, no invite). The joiner retries until accepted.
@@ -169,6 +175,11 @@ pub enum ControlMsg {
         hostname: Option<String>,
         #[serde(default)]
         device_cert: Option<DeviceCert>,
+        /// Roles the coordinator assigned. Unlike the request side on
+        /// [`Self::JoinRequest`] this is the authoritative grant, so members
+        /// resolving a `role:` firewall key agree on who holds what.
+        #[serde(default)]
+        roles: BTreeSet<String>,
     },
     Welcome {
         members: Vec<Member>,
@@ -576,6 +587,7 @@ mod tests {
                 last_seen: None,
                 exit_node: false,
                 exit_families: ExitFamilies::Unknown,
+                roles: Default::default(),
             }],
         };
         let bytes = encode_msg(None, &msg);
@@ -725,6 +737,7 @@ mod tests {
             invite_secret: Some(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
             hostname: Some("alice".to_string()),
             device_cert: None,
+            roles: Default::default(),
         };
         let bytes = encode_msg(None, &msg);
         let decoded = decode_msg(&bytes).unwrap();
@@ -737,6 +750,7 @@ mod tests {
             invite_secret: None,
             hostname: None,
             device_cert: None,
+            roles: Default::default(),
         };
         let bytes = encode_msg(None, &msg);
         let decoded = decode_msg(&bytes).unwrap();
@@ -799,6 +813,7 @@ mod tests {
             identity: test_id(1),
             hostname: None,
             device_cert: None,
+            roles: Default::default(),
         };
         let bytes = encode_msg(None, &msg);
         let decoded = decode_msg(&bytes).unwrap();
@@ -818,12 +833,14 @@ mod tests {
                 last_seen: None,
                 exit_node: false,
                 exit_families: ExitFamilies::Unknown,
+                roles: Default::default(),
             }],
             approved: vec![ApprovedEntry {
                 identity: test_id(2),
                 hostname: None,
                 user_identity: None,
                 device_cert: None,
+                roles: Default::default(),
             }],
             direct_key: Some([7u8; 32]),
             direct_record: Some(vec![1, 2, 3]),

--- a/src/daemon/connect_service.rs
+++ b/src/daemon/connect_service.rs
@@ -362,6 +362,9 @@ impl ConnectService {
                 short_id: p.from_contact_id.fmt_short().to_string(),
                 hostname: p.hostname.clone(),
                 waiting_secs: now.saturating_duration_since(p.requested_at).as_secs(),
+                // `ray connect` is a 2-peer link, not a network join: it has no
+                // credential to carry roles and no `--role` to ask with.
+                requested_roles: Vec::new(),
             })
             .collect();
         IpcMessage::PendingRequests { requests }

--- a/src/daemon/connect_service.rs
+++ b/src/daemon/connect_service.rs
@@ -291,11 +291,11 @@ impl ConnectService {
             .join_network(
                 &room_id.to_string(),
                 None,
-                hostname,
-                None,
-                Some(coordinator),
-                false,
-                false,
+                JoinOptions {
+                    hostname,
+                    coordinator: Some(coordinator),
+                    ..Default::default()
+                },
             )
             .await;
         if let IpcMessage::Joined { name, .. } = &resp {

--- a/src/daemon/mesh/accept.rs
+++ b/src/daemon/mesh/accept.rs
@@ -38,6 +38,38 @@ pub(crate) fn evict_oldest_pending(
     Some(oldest)
 }
 
+/// The parts of a gossiped [`ControlMsg::InviteShare`] a ledger entry is written
+/// from. One struct rather than four positional arguments, because two handlers
+/// (a coordinator's, and a member's for the co-coordinator case) build the same
+/// call.
+pub(crate) struct SharedInvite {
+    pub(crate) id: String,
+    /// The hex `blake3(secret)` as UTF-8 bytes, the form it travels in.
+    pub(crate) secret_hash: Vec<u8>,
+    pub(crate) expires: u64,
+    /// What the minter bound to the code, so redeeming it here grants the same
+    /// thing it would have there.
+    pub(crate) roles: BTreeSet<String>,
+}
+
+/// Write a coordinator-gossiped invite into `network`'s ledger. The caller holds
+/// the invite lock. A hash that is not UTF-8 is not one we minted, so it is
+/// dropped rather than stored.
+fn record_shared_invite(network: &str, shared: SharedInvite) {
+    let SharedInvite {
+        id,
+        secret_hash,
+        expires,
+        roles,
+    } = shared;
+    let Ok(hash) = String::from_utf8(secret_hash) else {
+        return;
+    };
+    if let Ok(mut store) = crate::invite::InviteStore::load(network) {
+        let _ = store.record_shared(id, hash, expires, roles);
+    }
+}
+
 /// A paired device is auto-admitted into a closed network only when its device
 /// cert is signed by this coordinator's own owner identity. The cert's
 /// signature is verified by the caller before this check.
@@ -290,9 +322,18 @@ impl CoordinatorAcceptState {
                 id,
                 secret_hash,
                 expires,
+                roles,
             } => {
-                self.handle_invite_share(peer_id, id, secret_hash, expires)
-                    .await;
+                self.handle_invite_share(
+                    peer_id,
+                    SharedInvite {
+                        id,
+                        secret_hash,
+                        expires,
+                        roles,
+                    },
+                )
+                .await;
                 None
             }
             ControlMsg::InviteUsed { secret_hash } => {
@@ -774,24 +815,13 @@ impl CoordinatorAcceptState {
     /// Handle an `InviteShare` gossiped by another coordinator: record its hash so
     /// this coordinator can redeem the cross-minted single-use invite too. Honored
     /// only from a coordinator peer in our verified roster.
-    async fn handle_invite_share(
-        &self,
-        peer_id: EndpointId,
-        id: String,
-        secret_hash: Vec<u8>,
-        expires: u64,
-    ) {
+    async fn handle_invite_share(&self, peer_id: EndpointId, shared: SharedInvite) {
         if !sender_is_coordinator(&self.state, peer_id) {
             tracing::warn!(peer = %peer_id.fmt_short(), "ignoring InviteShare from non-coordinator");
             return;
         }
-        let Ok(hash) = String::from_utf8(secret_hash) else {
-            return;
-        };
         let _guard = self.invite_lock.lock().await;
-        if let Ok(mut store) = crate::invite::InviteStore::load(&self.network_name) {
-            let _ = store.record_shared(id, hash, expires);
-        }
+        record_shared_invite(&self.network_name, shared);
     }
 
     /// Handle an `InviteUsed` gossiped by another coordinator: burn the single-use
@@ -1480,14 +1510,19 @@ impl MemberAcceptState {
                 id,
                 secret_hash,
                 expires,
+                roles,
             } => {
-                if sender_is_coordinator(&self.state, peer_id)
-                    && let Ok(hash) = String::from_utf8(secret_hash)
-                {
+                if sender_is_coordinator(&self.state, peer_id) {
                     let _guard = self.invite_lock.lock().await;
-                    if let Ok(mut store) = crate::invite::InviteStore::load(&self.network_name) {
-                        let _ = store.record_shared(id, hash, expires);
-                    }
+                    record_shared_invite(
+                        &self.network_name,
+                        SharedInvite {
+                            id,
+                            secret_hash,
+                            expires,
+                            roles,
+                        },
+                    );
                 }
                 None
             }
@@ -2295,6 +2330,7 @@ mod stranger_policy_tests {
                 id: "ab".into(),
                 secret_hash: vec![],
                 expires: 0,
+                roles: Default::default(),
             },
             ControlMsg::InviteUsed {
                 secret_hash: vec![],

--- a/src/daemon/mesh/accept.rs
+++ b/src/daemon/mesh/accept.rs
@@ -366,6 +366,21 @@ impl CoordinatorAcceptState {
                 .await;
         }
 
+        // Canonicalize what was asked for before any branch compares it. Our own
+        // joiner normalizes first, but `grant` compares by exact set difference,
+        // so an older or hand-rolled client asking for `Sentry` would be refused
+        // a role its key does grant. Placed after the reconnect short-circuit: a
+        // seated member's roles come from the roster, not from this field.
+        let requested_roles = match crate::roles::canonicalize(&requested_roles) {
+            Ok(roles) => roles,
+            Err(e) => {
+                tracing::warn!(peer = %remote_id.fmt_short(), error = %e, "malformed role request");
+                self.deny_final(conn, send, format!("role request refused: {e}"))
+                    .await;
+                return None;
+            }
+        };
+
         // A peer pre-approved via `ray accept` is admitted directly.
         let is_approved = self.state.read().unwrap().approved.is_approved(&remote_id);
         if is_approved {
@@ -385,7 +400,7 @@ impl CoordinatorAcceptState {
                 Ok(roles) => roles,
                 Err(e) => {
                     tracing::warn!(peer = %remote_id.fmt_short(), error = %e, "role request refused");
-                    self.deny(conn, send, format!("role request refused: {e}"))
+                    self.deny_final(conn, send, format!("role request refused: {e}"))
                         .await;
                     return None;
                 }
@@ -427,9 +442,22 @@ impl CoordinatorAcceptState {
         // Unknown peer, no invite: open networks auto-admit; closed networks queue
         // the request for live operator approval (`ray accept`).
         let mode = self.state.read().unwrap().mode;
+        // Neither admission path below reads a credential, so neither has a
+        // grant to narrow. `grant` against an empty permitted set is exactly the
+        // answer: fine for the usual empty request, an error for anything else.
+        // Seating the node quietly without the roles it asked for is the failure
+        // this module refuses to have (see `crate::roles::grant`) - it would
+        // report success and leave the firewall shut with nothing to point at.
+        let no_roles = crate::roles::grant(&BTreeSet::new(), &requested_roles);
         match mode {
-            GroupMode::Open => self
-                .admit_peer(
+            GroupMode::Open => {
+                if let Err(e) = no_roles {
+                    tracing::warn!(peer = %remote_id.fmt_short(), error = %e, "role request refused");
+                    self.deny_final(conn, send, format!("role request refused: {e}"))
+                        .await;
+                    return None;
+                }
+                self.admit_peer(
                     conn,
                     send,
                     AdmitRequest {
@@ -444,11 +472,18 @@ impl CoordinatorAcceptState {
                     },
                 )
                 .await
-                .into_ip(),
+                .into_ip()
+            }
             GroupMode::Restricted => {
                 // A device cert signed by this coordinator's own owner identity is
                 // one of our own paired devices: admit directly (no approval step).
                 if owner_admits(device_cert.as_ref(), self.ctx.identity.local_identity()) {
+                    if let Err(e) = no_roles {
+                        tracing::warn!(peer = %remote_id.fmt_short(), error = %e, "role request refused");
+                        self.deny_final(conn, send, format!("role request refused: {e}"))
+                            .await;
+                        return None;
+                    }
                     return self
                         .admit_peer(
                             conn,
@@ -486,6 +521,7 @@ impl CoordinatorAcceptState {
                         PendingJoin {
                             hostname,
                             device_cert,
+                            requested_roles,
                             requested_at: Instant::now(),
                         },
                     );
@@ -685,15 +721,25 @@ impl CoordinatorAcceptState {
         };
 
         if changed {
-            let mut s = self.state.write().unwrap();
-            if let Some(m) = s.members.get_mut(&remote_id) {
-                m.hostname = Some(final_hostname.clone());
+            {
+                let mut s = self.state.write().unwrap();
+                if let Some(m) = s.members.get_mut(&remote_id) {
+                    m.hostname = Some(final_hostname.clone());
+                }
             }
-        }
-        if changed {
             commit_current_snapshot(&self.state, &self.ctx.blob_store, &self.dht_notify).await;
         }
         drop(commit_guard);
+        if changed {
+            // A rename moves this member in and out of every suggested rule that
+            // names a hostname, and changes which host a rule keyed on a `role:`
+            // it holds resolves to. Same reason as `admit_peer`: the coordinator
+            // is the published record's source, so its own poller short-circuits
+            // and nothing else re-resolves its installed rules.
+            self.ctx
+                .registry
+                .reapply_suggested_firewall(&self.network_name);
+        }
 
         // Re-assert this peer's DNS entry (idempotent).
         dns::remove_hostname_by_ip(
@@ -799,7 +845,7 @@ impl CoordinatorAcceptState {
                     Ok(roles) => roles,
                     Err(e) => {
                         tracing::warn!(peer = %remote_id.fmt_short(), error = %e, "role request refused");
-                        self.deny(conn, send, format!("role request refused: {e}"))
+                        self.deny_final(conn, send, format!("role request refused: {e}"))
                             .await;
                         // The secret was burned above; a refused role request is
                         // a definite denial, so give it back to its holder.
@@ -883,7 +929,7 @@ impl CoordinatorAcceptState {
                         Ok(roles) => roles,
                         Err(e) => {
                             tracing::warn!(peer = %remote_id.fmt_short(), error = %e, "role request refused");
-                            self.deny(conn, send, format!("role request refused: {e}"))
+                            self.deny_final(conn, send, format!("role request refused: {e}"))
                                 .await;
                             return None;
                         }
@@ -914,13 +960,41 @@ impl CoordinatorAcceptState {
         }
     }
 
+    /// Refuse this attempt but invite another. For a condition on our side that
+    /// a later attempt may find gone: a direct grant we cannot reproduce yet, a
+    /// roster commit that did not land.
+    async fn deny(&self, conn: &Connection, send: iroh::endpoint::SendStream, reason: String) {
+        self.send_denial(conn, send, reason, true).await
+    }
+
+    /// Refuse the join for good. Nothing the joiner can do by asking again
+    /// changes the answer: it asked for a role that neither its credential nor
+    /// the operator's approval carries, or for one that is not a role name at
+    /// all. Say so, because a closed-network joiner retries on a backoff until
+    /// told to stop, and its CLI returned at "waiting for approval", so an
+    /// unmarked refusal loops silently forever.
+    async fn deny_final(
+        &self,
+        conn: &Connection,
+        send: iroh::endpoint::SendStream,
+        reason: String,
+    ) {
+        self.send_denial(conn, send, reason, false).await
+    }
+
     /// Reply on the joiner's stream that the join was refused, then wait for the
     /// joiner to close so the JoinDenied flushes before `conn` is dropped.
-    async fn deny(&self, conn: &Connection, mut send: iroh::endpoint::SendStream, reason: String) {
+    async fn send_denial(
+        &self,
+        conn: &Connection,
+        mut send: iroh::endpoint::SendStream,
+        reason: String,
+        retryable: bool,
+    ) {
         let _ = control::send_msg(
             &mut send,
             Some(self.net_pubkey()),
-            &ControlMsg::JoinDenied { reason },
+            &ControlMsg::JoinDenied { reason, retryable },
         )
         .await;
         let _ = tokio::time::timeout(Duration::from_secs(5), conn.closed()).await;
@@ -2478,6 +2552,7 @@ mod pending_cap_tests {
         PendingJoin {
             hostname: None,
             device_cert: None,
+            requested_roles: BTreeSet::new(),
             requested_at: t,
         }
     }

--- a/src/daemon/mesh/accept.rs
+++ b/src/daemon/mesh/accept.rs
@@ -7,6 +7,8 @@
 //! `blobs`/`files`/`pair`/`connect` arms). `MeshCtx` and the roster-projection
 //! helpers stay in `daemon/mod.rs` since they are shared infrastructure.
 
+use std::collections::BTreeSet;
+
 use crate::daemon;
 
 use super::super::*;
@@ -251,9 +253,15 @@ impl CoordinatorAcceptState {
                 invite_secret,
                 hostname,
                 device_cert,
+                roles,
             } => {
-                self.handle_join_request(conn, send, peer_id, invite_secret, hostname, device_cert)
-                    .await
+                let attempt = JoinAttempt {
+                    invite_secret,
+                    hostname,
+                    device_cert,
+                    roles,
+                };
+                self.handle_join_request(conn, send, peer_id, attempt).await
             }
             // A known member re-announcing (reconnect or rename); an unknown peer
             // sending a bare MeshHello is an older client doing a no-invite join.
@@ -267,8 +275,15 @@ impl CoordinatorAcceptState {
                     self.handle_member_hello(conn, send, peer_id, hostname, device_cert)
                         .await
                 } else {
-                    self.handle_join_request(conn, send, peer_id, None, hostname, device_cert)
-                        .await
+                    let attempt = JoinAttempt {
+                        invite_secret: None,
+                        hostname,
+                        device_cert,
+                        // An older client predating roles asks for none, so it
+                        // takes whatever its credential carries.
+                        roles: BTreeSet::new(),
+                    };
+                    self.handle_join_request(conn, send, peer_id, attempt).await
                 }
             }
             ControlMsg::InviteShare {
@@ -307,10 +322,14 @@ impl CoordinatorAcceptState {
         conn: &Connection,
         send: iroh::endpoint::SendStream,
         remote_id: EndpointId,
-        invite_secret: Option<Vec<u8>>,
-        hostname: Option<String>,
-        device_cert: Option<control::DeviceCert>,
+        attempt: JoinAttempt,
     ) -> Option<Ipv6Addr> {
+        let JoinAttempt {
+            invite_secret,
+            hostname,
+            device_cert,
+            roles: requested_roles,
+        } = attempt;
         // Verify a device certificate if presented, and record the transport-key →
         // user-identity binding so paired devices resolve.
         if let Some(ref cert) = device_cert {
@@ -351,8 +370,39 @@ impl CoordinatorAcceptState {
         let is_approved = self.state.read().unwrap().approved.is_approved(&remote_id);
         if is_approved {
             // Live-approved name is joiner-chosen, not authoritative.
+            let approved_roles = self
+                .state
+                .read()
+                .unwrap()
+                .approved
+                .get(&remote_id)
+                .map(|e| e.roles.clone())
+                .unwrap_or_default();
+            // Same narrowing rule as the credential paths: the approval is the
+            // grant, `--role` may only ask for a subset of it, and asking
+            // outside it fails the join rather than seating the wrong policy.
+            let roles = match crate::roles::grant(&approved_roles, &requested_roles) {
+                Ok(roles) => roles,
+                Err(e) => {
+                    tracing::warn!(peer = %remote_id.fmt_short(), error = %e, "role request refused");
+                    self.deny(conn, send, format!("role request refused: {e}"))
+                        .await;
+                    return None;
+                }
+            };
             return self
-                .admit_peer(conn, send, remote_id, hostname, device_cert, true, false)
+                .admit_peer(
+                    conn,
+                    send,
+                    AdmitRequest {
+                        remote_id,
+                        hostname,
+                        device_cert,
+                        roles,
+                        was_approved: true,
+                        authoritative: false,
+                    },
+                )
                 .await
                 .into_ip();
         }
@@ -360,7 +410,17 @@ impl CoordinatorAcceptState {
         // Unknown peer presenting an invite secret: verify and burn it.
         if let Some(secret) = invite_secret {
             return self
-                .redeem_invite_and_admit(conn, send, remote_id, hostname, device_cert, secret)
+                .redeem_invite_and_admit(
+                    conn,
+                    send,
+                    remote_id,
+                    RedeemAttempt {
+                        hostname,
+                        device_cert,
+                        requested_roles,
+                        secret,
+                    },
+                )
                 .await;
         }
 
@@ -369,7 +429,20 @@ impl CoordinatorAcceptState {
         let mode = self.state.read().unwrap().mode;
         match mode {
             GroupMode::Open => self
-                .admit_peer(conn, send, remote_id, hostname, device_cert, false, false)
+                .admit_peer(
+                    conn,
+                    send,
+                    AdmitRequest {
+                        remote_id,
+                        hostname,
+                        device_cert,
+                        // An open network admits on no credential at all, so
+                        // there is nothing to take a role from.
+                        roles: BTreeSet::new(),
+                        was_approved: false,
+                        authoritative: false,
+                    },
+                )
                 .await
                 .into_ip(),
             GroupMode::Restricted => {
@@ -377,7 +450,20 @@ impl CoordinatorAcceptState {
                 // one of our own paired devices: admit directly (no approval step).
                 if owner_admits(device_cert.as_ref(), self.ctx.identity.local_identity()) {
                     return self
-                        .admit_peer(conn, send, remote_id, hostname, device_cert, false, false)
+                        .admit_peer(
+                            conn,
+                            send,
+                            AdmitRequest {
+                                remote_id,
+                                hostname,
+                                device_cert,
+                                // One of our own paired devices, admitted on its
+                                // cert rather than a role-bearing key.
+                                roles: BTreeSet::new(),
+                                was_approved: false,
+                                authoritative: false,
+                            },
+                        )
                         .await
                         .into_ip();
                 }
@@ -688,10 +774,14 @@ impl CoordinatorAcceptState {
         conn: &Connection,
         send: iroh::endpoint::SendStream,
         remote_id: EndpointId,
-        hostname: Option<String>,
-        device_cert: Option<control::DeviceCert>,
-        secret: Vec<u8>,
+        attempt: RedeemAttempt,
     ) -> Option<Ipv6Addr> {
+        let RedeemAttempt {
+            hostname,
+            device_cert,
+            requested_roles,
+            secret,
+        } = attempt;
         let redeemed = {
             let _guard = self.invite_lock.lock().await;
             match crate::invite::InviteStore::load(&self.network_name) {
@@ -700,22 +790,44 @@ impl CoordinatorAcceptState {
             }
         };
         match redeemed {
-            Ok(invite_hostname) => {
+            Ok(grant) => {
                 tracing::info!(peer = %remote_id.fmt_short(), "invite redeemed");
+                // The joiner may ask for a subset of what the invite grants;
+                // anything outside it fails the join rather than seating the
+                // peer with roles it did not ask for.
+                let roles = match crate::roles::grant(&grant.roles, &requested_roles) {
+                    Ok(roles) => roles,
+                    Err(e) => {
+                        tracing::warn!(peer = %remote_id.fmt_short(), error = %e, "role request refused");
+                        self.deny(conn, send, format!("role request refused: {e}"))
+                            .await;
+                        // The secret was burned above; a refused role request is
+                        // a definite denial, so give it back to its holder.
+                        let _guard = self.invite_lock.lock().await;
+                        if let Ok(mut store) = crate::invite::InviteStore::load(&self.network_name)
+                        {
+                            let _ = store.restore(&secret);
+                        }
+                        return None;
+                    }
+                };
                 // A hostname bound to the invite is authoritative: it overrides
                 // the joiner's `--hostname` claim and is rejected on collision.
                 // A free-chosen name (no binding) keeps collision-rename.
-                let authoritative = invite_hostname.is_some();
-                let assigned = invite_hostname.or(hostname);
+                let authoritative = grant.hostname.is_some();
+                let assigned = grant.hostname.or(hostname);
                 let admitted = self
                     .admit_peer(
                         conn,
                         send,
-                        remote_id,
-                        assigned,
-                        device_cert,
-                        false,
-                        authoritative,
+                        AdmitRequest {
+                            remote_id,
+                            hostname: assigned,
+                            device_cert,
+                            roles,
+                            was_approved: false,
+                            authoritative,
+                        },
                     )
                     .await;
                 // Admission can still be denied (hostname/IP collision) after
@@ -751,22 +863,47 @@ impl CoordinatorAcceptState {
                 // Not a single-use invite, it may be a reusable key, which
                 // lives in the signed blob and is redeemable by any network-key
                 // holder (no burn). The blob is the verified source of truth.
-                let reusable_id = {
+                let redeemed_key = {
                     let s = self.state.read().unwrap();
                     crate::membership::validate_reusable_key(&s.reusable_keys, &secret, now_secs())
-                        .map(|k| k.id.clone())
+                        .map(|k| (k.id.clone(), k.roles.clone()))
                 };
-                if let Some(key_id) = reusable_id {
+                if let Some((key_id, permitted_roles)) = redeemed_key {
                     tracing::info!(
                         peer = %remote_id.fmt_short(),
                         key_id = %key_id,
                         "reusable key redeemed"
                     );
+                    // The path a provisioner takes: one key in a user-data blob
+                    // admits the whole group, and each node is seated with the
+                    // key's roles. The *name* is still joiner-chosen (a shared
+                    // key cannot bind a unique hostname), which is exactly why
+                    // policy keys on the role and not on the name.
+                    let roles = match crate::roles::grant(&permitted_roles, &requested_roles) {
+                        Ok(roles) => roles,
+                        Err(e) => {
+                            tracing::warn!(peer = %remote_id.fmt_short(), error = %e, "role request refused");
+                            self.deny(conn, send, format!("role request refused: {e}"))
+                                .await;
+                            return None;
+                        }
+                    };
                     // Reusable joins are non-authoritative: joiner-chosen name,
                     // collision → suffix.
-                    self.admit_peer(conn, send, remote_id, hostname, device_cert, false, false)
-                        .await
-                        .into_ip()
+                    self.admit_peer(
+                        conn,
+                        send,
+                        AdmitRequest {
+                            remote_id,
+                            hostname,
+                            device_cert,
+                            roles,
+                            was_approved: false,
+                            authoritative: false,
+                        },
+                    )
+                    .await
+                    .into_ip()
                 } else {
                     tracing::warn!(peer = %remote_id.fmt_short(), error = %single_use_err, "invite rejected");
                     self.deny(conn, send, format!("invite rejected: {single_use_err}"))
@@ -797,20 +934,20 @@ impl CoordinatorAcceptState {
     /// the peer is retained in a generation whose directory sync is still
     /// ambiguous, or `Denied` for a definite rejection. A caller that burned a
     /// single-use credential restores it only for `Denied`.
-    #[allow(clippy::too_many_arguments)]
     async fn admit_peer(
         &self,
         conn: &Connection,
         mut send: iroh::endpoint::SendStream,
-        remote_id: EndpointId,
-        hostname: Option<String>,
-        device_cert: Option<control::DeviceCert>,
-        was_approved: bool,
-        // The hostname is coordinator-authoritative (came from an invite binding).
-        // Authoritative names are rejected on collision (no silent rename), so no
-        // peer can claim another's name to take its suggested firewall rules.
-        authoritative: bool,
+        req: AdmitRequest,
     ) -> AdmissionResult {
+        let AdmitRequest {
+            remote_id,
+            hostname,
+            device_cert,
+            roles,
+            was_approved,
+            authoritative,
+        } = req;
         let Admission {
             peer_ip,
             hostname: final_hostname,
@@ -849,6 +986,7 @@ impl CoordinatorAcceptState {
             last_seen: Some(crate::membership::now_secs()),
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: roles.clone(),
         };
         let (displaced_member, removed_approved, removed_pending) = {
             let mut s = self.state.write().unwrap();
@@ -983,9 +1121,22 @@ impl CoordinatorAcceptState {
                 identity: remote_id,
                 hostname: final_hostname.clone(),
                 device_cert: device_cert.clone(),
+                roles: roles.clone(),
             },
         )
         .await;
+
+        // A suggested rule names its peers by hostname or `role:`, and both
+        // resolve against the roster this admission just changed. Members pick
+        // that up when they reconverge from the published record; the
+        // coordinator never does, because it *is* the record's source and the
+        // poller's hash check (local == published) short-circuits. So a peer
+        // authored into a rule before it joined would never materialize here.
+        // Re-resolve now, which is also what makes a role cover a node that
+        // joins after the rule was published.
+        self.ctx
+            .registry
+            .reapply_suggested_firewall(&self.network_name);
 
         // A direct (`ray connect`) link is symmetric, so the pre-approved requester
         // is made a co-coordinator. Hand it the network key inside the Welcome it is
@@ -1108,6 +1259,43 @@ impl AdmissionResult {
     }
 }
 
+/// What a joiner sent to get in: a `JoinRequest`, or the bare `MeshHello` an
+/// older client sends instead. Every field is the joiner's own say-so, and the
+/// coordinator decides what each is worth.
+struct JoinAttempt {
+    invite_secret: Option<Vec<u8>>,
+    hostname: Option<String>,
+    device_cert: Option<control::DeviceCert>,
+    /// Roles asked for. Granted only where the redeemed credential already
+    /// permits them, so this narrows a grant and can never widen one.
+    roles: BTreeSet<String>,
+}
+
+/// A join that presented a credential, on its way to being redeemed.
+struct RedeemAttempt {
+    hostname: Option<String>,
+    device_cert: Option<control::DeviceCert>,
+    requested_roles: BTreeSet<String>,
+    secret: Vec<u8>,
+}
+
+/// Everything the coordinator decided about a joiner, handed to `admit_peer` to
+/// seat. A struct rather than eight positional arguments: the two booleans sit
+/// next to each other and swapping them silently would grant the wrong thing.
+struct AdmitRequest {
+    remote_id: EndpointId,
+    hostname: Option<String>,
+    device_cert: Option<control::DeviceCert>,
+    /// Roles to seat the member with, taken from the redeemed credential or a
+    /// prior approval. Never anything the joiner asserted on its own.
+    roles: BTreeSet<String>,
+    was_approved: bool,
+    /// The hostname is coordinator-authoritative (came from an invite binding).
+    /// Authoritative names are rejected on collision (no silent rename), so no
+    /// peer can claim another's name to take its suggested firewall rules.
+    authoritative: bool,
+}
+
 /// What a coordinator settled for a joiner it is about to seat.
 struct Admission {
     /// Derived from the joiner's identity, not chosen here.
@@ -1168,7 +1356,10 @@ impl MemberAcceptState {
             // at the IP *this message* chose, writes its `.ray` name, and
             // registers its route. Same gate as `InviteShare`/`KickedFromNetwork`.
             ControlMsg::MemberApproved {
-                identity, hostname, ..
+                identity,
+                hostname,
+                roles,
+                ..
             } => {
                 if !sender_is_coordinator(&self.state, peer_id) {
                     tracing::warn!(peer = %peer_id.fmt_short(), "ignoring MemberApproved from non-coordinator");
@@ -1179,6 +1370,9 @@ impl MemberAcceptState {
                     hostname,
                     user_identity: None,
                     device_cert: None,
+                    // Gated on the sender being the coordinator just above, so
+                    // this is an assignment, not a peer's claim about itself.
+                    roles,
                 };
                 let mut s = self.state.write().unwrap();
                 s.approved.approve(entry);
@@ -1437,7 +1631,13 @@ impl MemberAcceptState {
         }
         let (snap_bytes, member_ip) = {
             let mut s = self.state.write().unwrap();
-            s.approved.remove(&peer_identity);
+            // The approval carries the roles the coordinator assigned; take them
+            // off it before it is consumed.
+            let approved_roles = s
+                .approved
+                .remove(&peer_identity)
+                .map(|e| e.roles)
+                .unwrap_or_default();
             let user_id_opt = device_cert.as_ref().map(|c| c.user_identity);
             // The address is derived from the identity that dialed, so there is
             // nothing left for a peer to claim and nothing to cross-check it
@@ -1452,6 +1652,7 @@ impl MemberAcceptState {
                 last_seen: Some(crate::membership::now_secs()),
                 exit_node: false,
                 exit_families: ExitFamilies::Unknown,
+                roles: approved_roles,
             });
             s.refresh_snapshot();
             (
@@ -1500,6 +1701,12 @@ impl MemberAcceptState {
             Some(derive_ipv6(&peer_identity)),
         )
         .await;
+        // Seating a member changes what this network's suggested rules resolve
+        // to. See the same call in `admit_peer` for why the coordinator has to
+        // do this itself.
+        self.ctx
+            .registry
+            .reapply_suggested_firewall(&self.network_name);
         Some(member_ip)
     }
 
@@ -1867,6 +2074,7 @@ mod admission_rollback_tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         }
     }
 
@@ -1979,6 +2187,7 @@ mod stranger_policy_tests {
                 invite_secret: None,
                 hostname: None,
                 device_cert: None,
+                roles: Default::default(),
             },
             ControlMsg::MeshHello {
                 identity: eid(1),
@@ -2002,6 +2211,7 @@ mod stranger_policy_tests {
                 identity: eid(1),
                 hostname: None,
                 device_cert: None,
+                roles: Default::default(),
             },
             ControlMsg::AdminGrant {
                 network_pubkey: eid(1),
@@ -2054,6 +2264,7 @@ mod direct_grant_tests {
                 last_seen: None,
                 exit_node: false,
                 exit_families: ExitFamilies::Unknown,
+                roles: Default::default(),
             });
         }
         Arc::new(RwLock::new(NetworkState {

--- a/src/daemon/mesh/coordinator.rs
+++ b/src/daemon/mesh/coordinator.rs
@@ -596,6 +596,11 @@ pub(crate) async fn finalize_removal(
     victims: &[EndpointId],
 ) {
     update_snapshot_and_publish(state, &ctx.blob_store, dht_notify).await;
+    // The departure side of the same problem `admit_peer` solves: a rule naming
+    // the removed peer (by hostname, or by a `role:` it held) has to stop
+    // resolving to it, and the coordinator does not reconverge from its own
+    // published record.
+    ctx.registry.reapply_suggested_firewall(network);
     let net_pubkey = state.read().unwrap().network_public_key;
     broadcast_member_sync(&ctx.registry, net_pubkey, network, None).await;
     for (pid, ip, conn) in ctx.peers.peers_for_network_with_conn(network) {
@@ -708,6 +713,7 @@ mod prune_tests {
             last_seen,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         }
     }
 
@@ -783,6 +789,7 @@ mod sender_authority_tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         }
     }
 

--- a/src/daemon/mesh/create_join.rs
+++ b/src/daemon/mesh/create_join.rs
@@ -56,8 +56,10 @@ struct JoinContext<'a> {
     invite_lock: Arc<AsyncMutex<()>>,
     /// Pinned coordinator to dial first (the invite minter), if known.
     coordinator: Option<EndpointId>,
-    /// Roles this join asks for, forwarded in the `JoinRequest`.
-    roles: Vec<String>,
+    /// Roles this join asks for, forwarded in the `JoinRequest`. Canonical
+    /// already ([`crate::roles::normalize`]), so it meets the mint side's
+    /// spelling of the same names.
+    roles: BTreeSet<String>,
     /// Set on a restore whose network record advertises a mesh protocol version
     /// this build does not speak. Only [`VersionGate::Record`] can produce it,
     /// so it is always `None` on a fresh join.
@@ -328,6 +330,7 @@ impl NetworkRegistry {
                 let _ = config::add_pending_join(config::PendingJoinEntry {
                     network_key: network_key.to_string(),
                     name: name.map(|s| s.to_string()),
+                    roles: opts.roles.clone(),
                 });
                 // Closed network: queued for live approval. Retry in the
                 // background on a backoff until `ray accept` admits us.
@@ -353,6 +356,19 @@ impl NetworkRegistry {
                                 return;
                             }
                             Ok(TryJoin::Pending) => continue,
+                            // A refusal the coordinator marked final: asking
+                            // again cannot change it, so stop and drop the
+                            // persisted request instead of looping forever on a
+                            // backoff that nothing ever surfaces.
+                            Err(e) if e.downcast_ref::<JoinRefused>().is_some() => {
+                                let _ = config::remove_pending_join(&nk);
+                                tracing::error!(
+                                    net = %nk,
+                                    error = %e,
+                                    "coordinator refused the join; giving up"
+                                );
+                                return;
+                            }
                             Err(e) => {
                                 tracing::warn!(net = %nk, error = %e, "join retry failed");
                             }
@@ -387,6 +403,12 @@ impl NetworkRegistry {
             auto_accept_files,
             roles,
         } = opts;
+        // Canonicalize before asking. The mint side stores what
+        // `roles::normalize` produced, and the coordinator compares by exact set
+        // difference, so `--role Sentry` against a key minted `--role Sentry`
+        // would otherwise be refused a role the key does carry. A name that is
+        // not a role at all fails here, on the machine that typed it.
+        let roles = crate::roles::normalize(&roles).context("invalid --role")?;
         let net_pubkey: EndpointId = network_key.parse().context("invalid network key")?;
 
         if let Some(a) = alias
@@ -636,6 +658,16 @@ impl NetworkRegistry {
                     abort_join_tasks(&cancel, tasks);
                     return Ok(None);
                 }
+                // A refusal the coordinator marked final rests on the
+                // credential and the signed roster, both of which every
+                // coordinator shares, so the next one answers the same. Return
+                // it as-is: trying on would replace it in `last_err` with
+                // whatever the last coordinator said, and the caller's retry
+                // loop needs this exact error to know to stop.
+                Err(e) if e.downcast_ref::<JoinRefused>().is_some() => {
+                    abort_join_tasks(&cancel, tasks);
+                    return Err(e);
+                }
                 Err(e) => {
                     tracing::warn!(coordinator = %coordinator_id.fmt_short(), error = %e, "coordinator denied or unreachable, trying next");
                     abort_join_tasks(&cancel, tasks);
@@ -644,10 +676,13 @@ impl NetworkRegistry {
             }
         }
 
-        anyhow::bail!(
-            "no coordinator admitted the join (tried {}): {last_err:#}",
+        // `context`, not a formatted `bail!`: interpolating `{last_err:#}` into a
+        // fresh error reads the same but flattens the chain, and callers
+        // downcast through it.
+        Err(last_err.context(format!(
+            "no coordinator admitted the join (tried {})",
             order.len()
-        )
+        )))
     }
 
     /// Reconnect/restore dial: the coordinator speaks first, so pick the single
@@ -1294,6 +1329,38 @@ impl NetworkRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The pending-join retry loop tells "ask again" from "the answer is no" by
+    /// downcasting, and every layer between the handshake and the loop has to
+    /// keep the error reachable. This once did not hold: `dial_fresh_join`
+    /// ended in a `bail!` that interpolated `{last_err:#}` into a fresh error,
+    /// which reads identically and flattens the chain, so the loop saw an
+    /// opaque string and reasked on a backoff forever.
+    #[test]
+    fn a_final_refusal_survives_the_context_layers() {
+        let refused: anyhow::Error = JoinRefused {
+            reason: "this key does not grant validator; it grants sentry".to_string(),
+        }
+        .into();
+        let wrapped = refused
+            .context("no coordinator admitted the join (tried 2)")
+            .context("join network");
+        assert!(wrapped.downcast_ref::<JoinRefused>().is_some());
+        // And the flattened rendering is unchanged, so nothing reads differently.
+        let msg = format!("{wrapped:#}");
+        assert!(msg.contains("no coordinator admitted the join"), "{msg}");
+        assert!(msg.contains("it grants sentry"), "{msg}");
+    }
+
+    /// The other half: a transient denial stays retryable, so a coordinator
+    /// hiccup does not tear down a join that would succeed a moment later.
+    #[test]
+    fn a_retryable_denial_is_not_a_final_refusal() {
+        let err =
+            anyhow::anyhow!("join denied: direct coordinator grant is temporarily unavailable")
+                .context("no coordinator admitted the join (tried 1)");
+        assert!(err.downcast_ref::<JoinRefused>().is_none());
+    }
 
     /// A restore of a network we already belong to must not be undone by the
     /// version gate. The roster blob is not ALPN-gated, so the network still

--- a/src/daemon/mesh/create_join.rs
+++ b/src/daemon/mesh/create_join.rs
@@ -15,6 +15,30 @@ const DIAL_TIMEOUT: Duration = Duration::from_secs(10);
 /// Borrowed bundle of the per-join inputs threaded through the dial + finalize
 /// phases of `join_network_inner`, so each phase takes one argument instead of a
 /// dozen. The references point at locals that live for the whole join.
+/// The knobs one join carries: who we say we are, what credential we present,
+/// and what we consent to once inside. Grouped so the call sites name each
+/// value rather than lining up seven positionals, several of them bare `bool`s
+/// that would swap silently.
+#[derive(Debug, Clone, Default)]
+pub struct JoinOptions {
+    /// Name to claim. Authoritative only if the credential binds one.
+    pub hostname: Option<String>,
+    /// Single-use invite secret or reusable key to present at admission.
+    pub invite: Option<Vec<u8>>,
+    /// Coordinator to dial first (the invite minter), when known.
+    pub coordinator: Option<EndpointId>,
+    /// Auto-install coordinator-suggested firewall rules on this network
+    /// (`--auto-accept-firewall`); persisted so it survives restarts.
+    pub auto_accept_firewall: bool,
+    /// Seed for per-network auto-accept of file offers from own devices
+    /// (`--auto-accept-files`); persisted, config wins on reconnect/restore.
+    pub auto_accept_files: bool,
+    /// Roles to ask for (`ray join --role sentry`). Narrows what the credential
+    /// grants and can never widen it, so an empty list (the usual case) takes
+    /// whatever the credential carries.
+    pub roles: Vec<String>,
+}
+
 struct JoinContext<'a> {
     display_name: &'a str,
     my_hostname: &'a str,
@@ -32,6 +56,8 @@ struct JoinContext<'a> {
     invite_lock: Arc<AsyncMutex<()>>,
     /// Pinned coordinator to dial first (the invite minter), if known.
     coordinator: Option<EndpointId>,
+    /// Roles this join asks for, forwarded in the `JoinRequest`.
+    roles: Vec<String>,
     /// Set on a restore whose network record advertises a mesh protocol version
     /// this build does not speak. Only [`VersionGate::Record`] can produce it,
     /// so it is always `None` on a fresh join.
@@ -270,56 +296,27 @@ impl Daemon {
     /// Part of the embedding API (used by `ray-mobile` and future embedders):
     /// join an existing network by key (optionally with an invite/coordinator).
     /// Thin delegate to the network registry, which owns the join path.
-    #[allow(clippy::too_many_arguments)]
     pub async fn join_network(
         self: &Arc<Self>,
         network_key: &str,
         name: Option<&str>,
-        hostname: Option<String>,
-        invite: Option<Vec<u8>>,
-        coordinator: Option<EndpointId>,
-        auto_accept_firewall: bool,
-        auto_accept_files: bool,
+        opts: JoinOptions,
     ) -> IpcMessage {
-        self.registry
-            .join_network(
-                network_key,
-                name,
-                hostname,
-                invite,
-                coordinator,
-                auto_accept_firewall,
-                auto_accept_files,
-            )
-            .await
+        self.registry.join_network(network_key, name, opts).await
     }
 }
 
 impl NetworkRegistry {
     /// Join an existing network by key (optionally with an invite/coordinator).
-    #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, hostname), fields(net = name.unwrap_or(network_key)))]
+    #[tracing::instrument(skip(self, opts), fields(net = name.unwrap_or(network_key)))]
     pub async fn join_network(
         self: &Arc<Self>,
         network_key: &str,
         name: Option<&str>,
-        hostname: Option<String>,
-        invite: Option<Vec<u8>>,
-        coordinator: Option<EndpointId>,
-        auto_accept_firewall: bool,
-        auto_accept_files: bool,
+        opts: JoinOptions,
     ) -> IpcMessage {
         match self
-            .join_network_inner(
-                network_key,
-                name,
-                hostname.clone(),
-                invite.clone(),
-                coordinator,
-                auto_accept_firewall,
-                auto_accept_files,
-                true,
-            )
+            .join_network_inner(network_key, name, opts.clone(), true)
             .await
         {
             Ok(TryJoin::Joined(resp)) => {
@@ -337,6 +334,7 @@ impl NetworkRegistry {
                 let me = Arc::clone(self);
                 let nk = network_key.to_string();
                 let nm = name.map(|s| s.to_string());
+                let retry_opts = opts;
                 tokio::spawn(async move {
                     let mut backoff = BACKOFF_INITIAL;
                     loop {
@@ -346,16 +344,7 @@ impl NetworkRegistry {
                         }
                         backoff = (backoff * 2).min(BACKOFF_MAX);
                         match me
-                            .join_network_inner(
-                                &nk,
-                                nm.as_deref(),
-                                hostname.clone(),
-                                invite.clone(),
-                                coordinator,
-                                auto_accept_firewall,
-                                auto_accept_files,
-                                true,
-                            )
+                            .join_network_inner(&nk, nm.as_deref(), retry_opts.clone(), true)
                             .await
                         {
                             Ok(TryJoin::Joined(_)) => {
@@ -384,20 +373,20 @@ impl NetworkRegistry {
         self: &Arc<Self>,
         network_key: &str,
         alias: Option<&str>,
-        hostname: Option<String>,
-        invite: Option<Vec<u8>>,
-        coordinator: Option<EndpointId>,
-        // Auto-install coordinator-suggested firewall rules on this network
-        // (`--auto-accept-firewall`); persisted so it survives restarts.
-        auto_accept_firewall: bool,
-        // Seed for per-network auto-accept of file offers from own devices
-        // (`--auto-accept-files`); persisted, config wins on reconnect/restore.
-        auto_accept_files: bool,
+        opts: JoinOptions,
         // True for a fresh join (we send a JoinRequest first); false when
         // restoring a network we're already a member of (legacy handshake where
         // the coordinator speaks first).
         initial: bool,
     ) -> Result<TryJoin> {
+        let JoinOptions {
+            hostname,
+            invite,
+            coordinator,
+            auto_accept_firewall,
+            auto_accept_files,
+            roles,
+        } = opts;
         let net_pubkey: EndpointId = network_key.parse().context("invalid network key")?;
 
         if let Some(a) = alias
@@ -496,6 +485,7 @@ impl NetworkRegistry {
             auto_accept_files,
             invite_lock: invite_lock.clone(),
             coordinator,
+            roles,
             mismatch,
         };
 
@@ -844,6 +834,7 @@ impl NetworkRegistry {
                 group_blob: data.clone(),
                 auto_accept_firewall: ctx.auto_accept_firewall,
                 auto_accept_files: ctx.auto_accept_files,
+                requested_roles: ctx.roles.clone(),
                 initial,
             },
             cancel.clone(),
@@ -1396,6 +1387,7 @@ mod tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         };
         let roster = vec![member(me), member(other)];
 

--- a/src/daemon/mesh/create_join.rs
+++ b/src/daemon/mesh/create_join.rs
@@ -380,6 +380,15 @@ impl NetworkRegistry {
                         .to_string(),
                 }
             }
+            // Same answer as in the retry loop above, for the caller that never
+            // reaches it: the coordinator refused for good, so drop the persisted
+            // request instead of leaving it to be re-asked once per daemon
+            // restart (`connect`'s resume) with nothing ever surfacing it.
+            Err(e) if e.downcast_ref::<JoinRefused>().is_some() => {
+                let _ = config::remove_pending_join(network_key);
+                tracing::error!(net = %network_key, error = %e, "coordinator refused the join; giving up");
+                ipc_err(format!("{e:#}"))
+            }
             Err(e) => ipc_err(format!("{e:#}")),
         }
     }
@@ -612,6 +621,11 @@ impl NetworkRegistry {
         }
 
         let mut last_err = anyhow::anyhow!("no coordinators tried");
+        // The first final refusal, kept aside so the loop can carry on without
+        // `last_err` overwriting it: the caller's retry loop downcasts for it to
+        // know to stop, and whatever the last coordinator happened to say would
+        // hide it.
+        let mut refused: Option<anyhow::Error> = None;
         for coordinator_id in &order {
             let cancel = self.shutdown_token.child_token();
             // Reconnect + cleanup are daemon-wide now (the connection supervisor),
@@ -658,15 +672,18 @@ impl NetworkRegistry {
                     abort_join_tasks(&cancel, tasks);
                     return Ok(None);
                 }
-                // A refusal the coordinator marked final rests on the
-                // credential and the signed roster, both of which every
-                // coordinator shares, so the next one answers the same. Return
-                // it as-is: trying on would replace it in `last_err` with
-                // whatever the last coordinator said, and the caller's retry
-                // loop needs this exact error to know to stop.
+                // A refusal the coordinator marked final answers for that
+                // coordinator, not for the network. Most of what it rests on is
+                // shared (the signed roster, a reusable key inside it), but a
+                // single-use invite lives in a per-coordinator ledger fed by
+                // gossip, so one that has not arrived yet, or predates a field
+                // the minter added, makes this coordinator refuse a code the
+                // minter would honor. Keep the refusal and try the rest; it is
+                // returned only if nobody admits us.
                 Err(e) if e.downcast_ref::<JoinRefused>().is_some() => {
+                    tracing::warn!(coordinator = %coordinator_id.fmt_short(), error = %e, "coordinator refused the join, trying next");
                     abort_join_tasks(&cancel, tasks);
-                    return Err(e);
+                    refused.get_or_insert(e);
                 }
                 Err(e) => {
                     tracing::warn!(coordinator = %coordinator_id.fmt_short(), error = %e, "coordinator denied or unreachable, trying next");
@@ -676,10 +693,14 @@ impl NetworkRegistry {
             }
         }
 
-        // `context`, not a formatted `bail!`: interpolating `{last_err:#}` into a
+        // A final refusal outranks whatever the last coordinator said: it is the
+        // one answer the caller's retry loop can act on, and a transient failure
+        // from a later dial would only send it back to a backoff that never ends.
+        //
+        // `context`, not a formatted `bail!`: interpolating `{err:#}` into a
         // fresh error reads the same but flattens the chain, and callers
         // downcast through it.
-        Err(last_err.context(format!(
+        Err(refused.unwrap_or(last_err).context(format!(
             "no coordinator admitted the join (tried {})",
             order.len()
         )))

--- a/src/daemon/mesh/diagnostics.rs
+++ b/src/daemon/mesh/diagnostics.rs
@@ -154,6 +154,7 @@ impl Daemon {
                 Ok(s) => s,
                 Err(_) => {
                     return NetworkStatus {
+                        my_roles: BTreeSet::new(),
                         name: h.name.clone(),
                         role,
                         my_ipv6: derive_ipv6(&my_id),
@@ -215,6 +216,7 @@ impl Daemon {
                     ipv6: derive_ipv6(&m.identity),
                     hostname,
                     user_identity,
+                    roles: m.roles.clone(),
                     is_own_device: user_id == own_user,
                     // Only meaningful for a peer with no live connection: a dial hit
                     // the mesh-version ALPN gate. A connected peer is same-version by
@@ -257,6 +259,11 @@ impl Daemon {
                     .unwrap_or_else(|| m.identity.fmt_short().to_string()),
                 None => stored,
             });
+        let my_roles = members
+            .iter()
+            .find(|m| m.identity == self.transport.identity.local_identity())
+            .map(|m| m.roles.clone())
+            .unwrap_or_default();
         NetworkStatus {
             name: h.name.clone(),
             role,
@@ -265,6 +272,7 @@ impl Daemon {
             network_key: Some(h.network_key.to_string()),
             member_count,
             peers,
+            my_roles,
             pending_suggestions,
             pending_requests,
             aliases,
@@ -991,11 +999,16 @@ pub(crate) fn saved_network_status(
             // is the optimistic default for a *registered* network. Nothing on
             // this one is reachable at all until the restore lands.
             state: PeerState::Offline,
+            // Roles live only in the signed blob; this projection is the lossy
+            // config cache, so it has none to show until the restore lands.
+            roles: BTreeSet::new(),
             exit_node: false,
             exit_in_use: false,
         })
         .collect();
     NetworkStatus {
+        // Roles come from the signed blob, which this projection does not have.
+        my_roles: BTreeSet::new(),
         name: net.name.clone(),
         role,
         my_ipv6: derive_ipv6(&my_id),

--- a/src/daemon/mesh/exit_node.rs
+++ b/src/daemon/mesh/exit_node.rs
@@ -873,6 +873,7 @@ mod tests {
             last_seen: None,
             exit_node,
             exit_families,
+            roles: Default::default(),
         }
     }
 

--- a/src/daemon/mesh/files.rs
+++ b/src/daemon/mesh/files.rs
@@ -150,11 +150,10 @@ impl Daemon {
                             .join_network(
                                 &net_key,
                                 Some(&net_name),
-                                None,
-                                None,
-                                Some(endpoint_id),
-                                false,
-                                false,
+                                JoinOptions {
+                                    coordinator: Some(endpoint_id),
+                                    ..Default::default()
+                                },
                             )
                             .await
                         {

--- a/src/daemon/mesh/invite.rs
+++ b/src/daemon/mesh/invite.rs
@@ -11,10 +11,11 @@ impl Daemon {
         network: &str,
         expires_secs: u64,
         hostname: Option<String>,
+        roles: Vec<String>,
         reusable: bool,
     ) -> IpcMessage {
         self.registry
-            .invite_create(network, expires_secs, hostname, reusable)
+            .invite_create(network, expires_secs, hostname, roles, reusable)
             .await
     }
 
@@ -22,8 +23,15 @@ impl Daemon {
         self.registry.list_requests(network)
     }
 
-    pub async fn accept_request(&self, network: &str, id_prefix: &str) -> IpcMessage {
-        self.registry.accept_request(network, id_prefix).await
+    pub async fn accept_request(
+        &self,
+        network: &str,
+        id_prefix: &str,
+        roles: Vec<String>,
+    ) -> IpcMessage {
+        self.registry
+            .accept_request(network, id_prefix, roles)
+            .await
     }
 
     pub fn deny_request(&self, network: &str, id_prefix: &str) -> IpcMessage {
@@ -38,21 +46,33 @@ impl NetworkRegistry {
         network: &str,
         expires_secs: u64,
         hostname: Option<String>,
+        roles: Vec<String>,
         reusable: bool,
     ) -> IpcMessage {
+        // Validated here, on the authority side: the daemon assigns roles, so it
+        // is the daemon that decides what a role may look like.
+        let roles = match crate::roles::normalize(&roles) {
+            Ok(roles) => roles,
+            Err(e) => return ipc_err(format!("{e:#}")),
+        };
         if reusable {
             return self
-                .reusable_key_create(network, expires_secs, hostname)
+                .reusable_key_create(network, expires_secs, hostname, roles)
                 .await;
         }
         let (net_pubkey, lock) = match self.coordinator_handle(network) {
             Ok(v) => v,
             Err(e) => return e,
         };
+        // Kept for the reply: the grant consumes the set below.
+        let roles_out: Vec<String> = roles.iter().cloned().collect();
         let minted = {
             let _guard = lock.lock().await;
             match crate::invite::InviteStore::load(network) {
-                Ok(mut store) => store.mint(Duration::from_secs(expires_secs), hostname),
+                Ok(mut store) => store.mint(
+                    Duration::from_secs(expires_secs),
+                    crate::invite::Grant { hostname, roles },
+                ),
                 Err(e) => Err(e),
             }
         };
@@ -100,6 +120,7 @@ impl NetworkRegistry {
                     code,
                     id,
                     expires_secs,
+                    roles: roles_out,
                 }
             }
             Err(e) => ipc_err(format!("failed to mint invite: {e:#}")),
@@ -109,17 +130,24 @@ impl NetworkRegistry {
     /// Mint a reusable join key: insert its hash into the signed blob and
     /// republish, so any network-key holder can admit. Authority is holding the
     /// network secret key (like firewall suggestions), not the `is_coordinator`
-    /// flag. A reusable key cannot bind an authoritative hostname.
+    /// flag.
+    ///
+    /// A reusable key cannot bind an authoritative hostname but **can** bind
+    /// roles, and the asymmetry is the point: a hostname is unique per node, so
+    /// a key admitting many machines cannot assign one, while a role is
+    /// deliberately shared by a whole class. That is what lets a single key sit
+    /// in a Terraform user-data block and seat an autoscaling group as sentries.
     pub(crate) async fn reusable_key_create(
         &self,
         network: &str,
         expires_secs: u64,
         hostname: Option<String>,
+        roles: BTreeSet<String>,
     ) -> IpcMessage {
         if hostname.is_some() {
             return ipc_err(
                 "a reusable key cannot bind a hostname (a multi-use key admits many \
-                          machines); drop --hostname or omit --reusable"
+                          machines); drop --hostname, or use --role to tag them all"
                     .to_string(),
             );
         }
@@ -143,8 +171,9 @@ impl NetworkRegistry {
             );
         }
         let secret = crate::invite::generate_secret();
+        let roles_out: Vec<String> = roles.iter().cloned().collect();
         let (hash, key) =
-            crate::membership::ReusableKey::from_secret(&secret, now_secs(), expires_secs);
+            crate::membership::ReusableKey::from_secret(&secret, now_secs(), expires_secs, roles);
         let id = key.id.clone();
         {
             let mut s = state.write().unwrap();
@@ -157,6 +186,7 @@ impl NetworkRegistry {
             code,
             id,
             expires_secs,
+            roles: roles_out,
         }
     }
 
@@ -289,10 +319,21 @@ impl NetworkRegistry {
         IpcMessage::PendingRequests { requests }
     }
 
-    pub async fn accept_request(&self, network: &str, id_prefix: &str) -> IpcMessage {
+    pub async fn accept_request(
+        &self,
+        network: &str,
+        id_prefix: &str,
+        roles: Vec<String>,
+    ) -> IpcMessage {
         if let Err(e) = self.coordinator_handle(network) {
             return e;
         }
+        // A live approval has no credential to read roles off, so the operator
+        // supplies them: `ray accept <peer> --role sentry`.
+        let roles = match crate::roles::normalize(&roles) {
+            Ok(roles) => roles,
+            Err(e) => return ipc_err(format!("{e:#}")),
+        };
         // Find and remove the pending request matching the short id prefix.
         let pending = {
             let Some(handle) = self.networks.get(network) else {
@@ -325,6 +366,7 @@ impl NetworkRegistry {
                 hostname: pj.hostname.clone(),
                 user_identity: user_id,
                 device_cert: pj.device_cert.clone(),
+                roles: roles.clone(),
             });
             s.refresh_snapshot();
             net_pubkey
@@ -338,6 +380,7 @@ impl NetworkRegistry {
                 identity,
                 hostname: pj.hostname.clone(),
                 device_cert: pj.device_cert.clone(),
+                roles,
             },
         )
         .await;

--- a/src/daemon/mesh/invite.rs
+++ b/src/daemon/mesh/invite.rs
@@ -64,8 +64,8 @@ impl NetworkRegistry {
             Ok(v) => v,
             Err(e) => return e,
         };
-        // Kept for the reply: the grant consumes the set below.
-        let roles_out: Vec<String> = roles.iter().cloned().collect();
+        // Kept for the reply and the gossip below: the grant consumes the set.
+        let minted_roles = roles.clone();
         let minted = {
             let _guard = lock.lock().await;
             match crate::invite::InviteStore::load(network) {
@@ -112,6 +112,7 @@ impl NetworkRegistry {
                             id: id.clone(),
                             secret_hash: secret_hash.into_bytes(),
                             expires,
+                            roles: minted_roles.clone(),
                         },
                     )
                     .await;
@@ -120,7 +121,7 @@ impl NetworkRegistry {
                     code,
                     id,
                     expires_secs,
-                    roles: roles_out,
+                    roles: minted_roles.into_iter().collect(),
                 }
             }
             Err(e) => ipc_err(format!("failed to mint invite: {e:#}")),
@@ -335,8 +336,15 @@ impl NetworkRegistry {
             Ok(roles) => roles,
             Err(e) => return ipc_err(format!("{e:#}")),
         };
-        // Find and remove the pending request matching the short id prefix.
-        let pending = {
+        // Find the pending request matching the short id prefix, and take it only
+        // if this accept grants every role it asked for. The peer's `--role` is a
+        // request and this approval is the grant, so accepting without those roles
+        // leaves the peer refused for good: its next attempt takes the approved
+        // branch, `roles::grant` fails there, and the denial is final. Removing the
+        // entry first would delete the request the operator has to re-accept along
+        // with it, leaving no way back but a manual `ray join` on the peer itself,
+        // so refuse while the request is still queued and the peer still retrying.
+        let taken = {
             let Some(handle) = self.networks.get(network) else {
                 return ipc_err(format!("network '{network}' not active"));
             };
@@ -349,9 +357,32 @@ impl NetworkRegistry {
                         || k.to_string().starts_with(id_prefix)
                 })
                 .copied();
-            found.and_then(|id| s.pending.remove(&id).map(|pj| (id, pj)))
+            match found {
+                Some(id) => {
+                    let unmet: Vec<String> = s
+                        .pending
+                        .get(&id)
+                        .map(|pj| pj.requested_roles.difference(&granted).cloned().collect())
+                        .unwrap_or_default();
+                    match unmet.as_slice() {
+                        [] => s.pending.remove(&id).map(|pj| (id, pj)),
+                        _ => {
+                            return ipc_err(format!(
+                                "{short} asked for {unmet}, which this accept does not grant; \
+                                 it would be refused for good. Accept it with `ray requests \
+                                 {network} accept {short} --role {flags}`, or turn it away with \
+                                 `ray requests {network} deny {short}`",
+                                short = id.fmt_short(),
+                                unmet = unmet.join(", "),
+                                flags = unmet.join(" --role "),
+                            ));
+                        }
+                    }
+                }
+                None => None,
+            }
         };
-        let Some((identity, pj)) = pending else {
+        let Some((identity, pj)) = taken else {
             return ipc_err(format!("no pending request matching '{id_prefix}'"));
         };
 
@@ -385,27 +416,9 @@ impl NetworkRegistry {
             },
         )
         .await;
-        // The peer's own `--role` is a request, not a grant: this approval is
-        // the grant, so accepting without `--role` confers nothing and the
-        // peer's next attempt is refused for good. Say which roles went ungranted
-        // instead of leaving the operator to work it out from a retry that stops.
-        let unmet: Vec<&str> = pj
-            .requested_roles
-            .difference(&granted)
-            .map(String::as_str)
-            .collect();
-        let message = if unmet.is_empty() {
-            format!("accepted {} — they'll join shortly", identity.fmt_short())
-        } else {
-            format!(
-                "accepted {short} without {unmet}, which it asked for; it will be refused \
-                 until you accept it with `ray requests accept {short} --role {flags}`",
-                short = identity.fmt_short(),
-                unmet = unmet.join(", "),
-                flags = unmet.join(" --role "),
-            )
-        };
-        IpcMessage::Ok { message }
+        IpcMessage::Ok {
+            message: format!("accepted {}, they'll join shortly", identity.fmt_short()),
+        }
     }
 
     pub fn deny_request(&self, network: &str, id_prefix: &str) -> IpcMessage {

--- a/src/daemon/mesh/invite.rs
+++ b/src/daemon/mesh/invite.rs
@@ -314,6 +314,7 @@ impl NetworkRegistry {
                 short_id: id.fmt_short().to_string(),
                 hostname: pj.hostname.clone(),
                 waiting_secs: pj.requested_at.elapsed().as_secs(),
+                requested_roles: pj.requested_roles.iter().cloned().collect(),
             })
             .collect();
         IpcMessage::PendingRequests { requests }
@@ -330,7 +331,7 @@ impl NetworkRegistry {
         }
         // A live approval has no credential to read roles off, so the operator
         // supplies them: `ray accept <peer> --role sentry`.
-        let roles = match crate::roles::normalize(&roles) {
+        let granted = match crate::roles::normalize(&roles) {
             Ok(roles) => roles,
             Err(e) => return ipc_err(format!("{e:#}")),
         };
@@ -366,7 +367,7 @@ impl NetworkRegistry {
                 hostname: pj.hostname.clone(),
                 user_identity: user_id,
                 device_cert: pj.device_cert.clone(),
-                roles: roles.clone(),
+                roles: granted.clone(),
             });
             s.refresh_snapshot();
             net_pubkey
@@ -380,13 +381,31 @@ impl NetworkRegistry {
                 identity,
                 hostname: pj.hostname.clone(),
                 device_cert: pj.device_cert.clone(),
-                roles,
+                roles: granted.clone(),
             },
         )
         .await;
-        IpcMessage::Ok {
-            message: format!("accepted {} — they'll join shortly", identity.fmt_short()),
-        }
+        // The peer's own `--role` is a request, not a grant: this approval is
+        // the grant, so accepting without `--role` confers nothing and the
+        // peer's next attempt is refused for good. Say which roles went ungranted
+        // instead of leaving the operator to work it out from a retry that stops.
+        let unmet: Vec<&str> = pj
+            .requested_roles
+            .difference(&granted)
+            .map(String::as_str)
+            .collect();
+        let message = if unmet.is_empty() {
+            format!("accepted {} — they'll join shortly", identity.fmt_short())
+        } else {
+            format!(
+                "accepted {short} without {unmet}, which it asked for; it will be refused \
+                 until you accept it with `ray requests accept {short} --role {flags}`",
+                short = identity.fmt_short(),
+                unmet = unmet.join(", "),
+                flags = unmet.join(" --role "),
+            )
+        };
+        IpcMessage::Ok { message }
     }
 
     pub fn deny_request(&self, network: &str, id_prefix: &str) -> IpcMessage {

--- a/src/daemon/mesh/join.rs
+++ b/src/daemon/mesh/join.rs
@@ -115,6 +115,9 @@ pub(crate) struct JoinParams {
     /// (`--auto-accept-files`). Persisted config wins on reconnect/restore; this
     /// is only the first-join seed.
     pub(crate) auto_accept_files: bool,
+    /// Roles this join asks for. Forwarded in the `JoinRequest` and granted only
+    /// where the presented credential already permits them.
+    pub(crate) requested_roles: Vec<String>,
     /// Fresh join (send `JoinRequest` first) vs reconnect/restore (coordinator
     /// speaks first).
     pub(crate) initial: bool,
@@ -158,6 +161,7 @@ pub(crate) async fn join_mesh_shared(
         group_blob,
         auto_accept_firewall,
         auto_accept_files,
+        requested_roles,
         initial,
     } = params;
     let my_identity = identity.local_identity();
@@ -175,6 +179,7 @@ pub(crate) async fn join_mesh_shared(
             invite_secret,
             &my_hostname,
             &device_cert,
+            &requested_roles,
             &group_blob,
         )
         .await?
@@ -544,6 +549,7 @@ async fn perform_join_handshake(
     invite_secret: Option<Vec<u8>>,
     my_hostname: &Option<String>,
     device_cert: &Option<control::DeviceCert>,
+    requested_roles: &[String],
     fallback_blob: &crate::membership::GroupBlob,
 ) -> Result<HandshakeOutcome> {
     if initial {
@@ -558,6 +564,7 @@ async fn perform_join_handshake(
                 invite_secret,
                 hostname: my_hostname.clone(),
                 device_cert: device_cert.clone(),
+                roles: requested_roles.iter().cloned().collect(),
             },
         )
         .await
@@ -775,6 +782,7 @@ mod persist_config_tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         }
     }
 

--- a/src/daemon/mesh/join.rs
+++ b/src/daemon/mesh/join.rs
@@ -22,6 +22,28 @@ pub(crate) enum JoinResult {
     Pending,
 }
 
+/// A refusal the joiner cannot retry its way out of: the coordinator answered
+/// `JoinDenied` with `retryable: false`, which today means a `--role` neither
+/// the presented credential nor the operator's approval carries.
+///
+/// Carried as a concrete error so it survives the `context` layers between the
+/// handshake and the pending-join retry loop, which downcasts for it. Without
+/// that the loop cannot tell "the coordinator is busy, ask again" from "the
+/// answer is no", and reasks on a backoff forever while the CLI has long since
+/// printed "waiting for coordinator approval".
+#[derive(Debug)]
+pub(crate) struct JoinRefused {
+    pub(crate) reason: String,
+}
+
+impl std::fmt::Display for JoinRefused {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "join denied: {}", self.reason)
+    }
+}
+
+impl std::error::Error for JoinRefused {}
+
 /// Outcome of one `join_network_inner` attempt. The reply is boxed because
 /// `IpcMessage` is far larger than the `Pending` case, and this enum is returned
 /// through the whole join/retry path.
@@ -117,7 +139,7 @@ pub(crate) struct JoinParams {
     pub(crate) auto_accept_files: bool,
     /// Roles this join asks for. Forwarded in the `JoinRequest` and granted only
     /// where the presented credential already permits them.
-    pub(crate) requested_roles: Vec<String>,
+    pub(crate) requested_roles: BTreeSet<String>,
     /// Fresh join (send `JoinRequest` first) vs reconnect/restore (coordinator
     /// speaks first).
     pub(crate) initial: bool,
@@ -549,7 +571,7 @@ async fn perform_join_handshake(
     invite_secret: Option<Vec<u8>>,
     my_hostname: &Option<String>,
     device_cert: &Option<control::DeviceCert>,
-    requested_roles: &[String],
+    requested_roles: &BTreeSet<String>,
     fallback_blob: &crate::membership::GroupBlob,
 ) -> Result<HandshakeOutcome> {
     if initial {
@@ -564,7 +586,7 @@ async fn perform_join_handshake(
                 invite_secret,
                 hostname: my_hostname.clone(),
                 device_cert: device_cert.clone(),
-                roles: requested_roles.iter().cloned().collect(),
+                roles: requested_roles.clone(),
             },
         )
         .await
@@ -603,7 +625,12 @@ async fn perform_join_handshake(
                 tracing::info!(network = %network_name, "join pending operator approval");
                 Ok(HandshakeOutcome::Pending)
             }
-            ControlMsg::JoinDenied { reason } => anyhow::bail!("join denied: {reason}"),
+            ControlMsg::JoinDenied { reason, retryable } => {
+                if retryable {
+                    anyhow::bail!("join denied: {reason}");
+                }
+                Err(JoinRefused { reason }.into())
+            }
             other => anyhow::bail!("expected Welcome or JoinPending, got {other:?}"),
         }
     } else {

--- a/src/daemon/mesh/mod.rs
+++ b/src/daemon/mesh/mod.rs
@@ -34,6 +34,7 @@ mod select;
 // `pub(crate) use mesh::*`).
 pub(crate) use accept::*;
 pub(crate) use coordinator::*;
+pub use create_join::JoinOptions;
 // Device-side unpair wipe + cert-refresh helpers, reached by both control readers.
 pub(crate) use files::{is_unpaired_by, resolve_download_target, store_refreshed_cert};
 pub(crate) use join::*;

--- a/src/daemon/mesh/reconverge.rs
+++ b/src/daemon/mesh/reconverge.rs
@@ -54,9 +54,36 @@ pub(crate) fn apply_suggested_firewall(
         .iter()
         .filter_map(|m| m.hostname.as_deref().map(|h| (h, m.identity)))
         .collect();
-    let resolve = |h: &str| map.get(h).copied();
-    let rules =
-        firewall::materialize_suggestions(network_name, &my_hostname, &suggestions, &resolve);
+    let by_hostname = |h: &str| map.get(h).copied();
+    // Every member holding a role. Sorted by identity because the roster is a
+    // HashMap: without this the rule order a node installs would shuffle between
+    // recomputes, and `ray firewall show` would look like it kept changing.
+    let by_role = |role: &str| -> Vec<EndpointId> {
+        let mut holders: Vec<EndpointId> = members
+            .iter()
+            .filter(|m| m.roles.iter().any(|r| r == role))
+            .map(|m| m.identity)
+            .collect();
+        holders.sort_by_key(|id| id.to_string());
+        holders
+    };
+    // Our own roles come from the roster too, for the same reason the hostname
+    // does: it is the signed record, not what this node asked for at join time.
+    let my_roles = members
+        .iter()
+        .find(|m| m.identity == my_identity)
+        .map(|m| m.roles.clone())
+        .unwrap_or_default();
+    let rules = firewall::materialize_suggestions(
+        network_name,
+        &suggestions,
+        &firewall::SubjectResolver {
+            hostname: &my_hostname,
+            roles: &my_roles,
+            by_hostname: &by_hostname,
+            by_role: &by_role,
+        },
+    );
 
     // Auto-install only if this node opted into `--auto-accept-firewall` for the
     // network; otherwise queue the materialized rules for `ray firewall accept`.
@@ -911,6 +938,7 @@ mod self_nullified_tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         }
     }
 

--- a/src/daemon/mesh/runtime.rs
+++ b/src/daemon/mesh/runtime.rs
@@ -902,10 +902,16 @@ impl NetworkRegistry {
             let me = Arc::clone(self);
             let key = pending.network_key.clone();
             let name = pending.name.clone();
+            // Resume the request the user actually made. Roles are policy: a
+            // node that came back asking for nothing could be seated without the
+            // class it was provisioned for, and the rules keyed on that role
+            // would never reach it.
+            let opts = JoinOptions {
+                roles: pending.roles.clone(),
+                ..JoinOptions::default()
+            };
             tokio::spawn(async move {
-                let _ = me
-                    .join_network(&key, name.as_deref(), JoinOptions::default())
-                    .await;
+                let _ = me.join_network(&key, name.as_deref(), opts).await;
             });
         }
 

--- a/src/daemon/mesh/runtime.rs
+++ b/src/daemon/mesh/runtime.rs
@@ -911,7 +911,13 @@ impl NetworkRegistry {
                 ..JoinOptions::default()
             };
             tokio::spawn(async move {
-                let _ = me.join_network(&key, name.as_deref(), opts).await;
+                // Nobody is holding an IPC stream for this one, so the reply has
+                // nowhere to go but the log.
+                if let IpcMessage::Error { message } =
+                    me.join_network(&key, name.as_deref(), opts).await
+                {
+                    tracing::warn!(net = %key, error = %message, "resumed join request failed");
+                }
             });
         }
 

--- a/src/daemon/mesh/runtime.rs
+++ b/src/daemon/mesh/runtime.rs
@@ -81,6 +81,9 @@ fn materialize_coordinator_roster(
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            // Roles are assigned to joiners by a coordinator; the coordinator
+            // seating itself has none to assign.
+            roles: BTreeSet::new(),
         }),
     }
     RestoredRoster {
@@ -561,11 +564,14 @@ impl NetworkRegistry {
                 .join_network_inner(
                     &net_pubkey,
                     Some(&name),
-                    persisted_hostname.clone(),
-                    None,
-                    None,
-                    auto_accept_firewall,
-                    auto_accept_files,
+                    JoinOptions {
+                        hostname: persisted_hostname.clone(),
+                        auto_accept_firewall,
+                        auto_accept_files,
+                        // A restore is already a member; its roles are in the
+                        // roster, so there is nothing to ask for.
+                        ..Default::default()
+                    },
                     false,
                 )
                 .await
@@ -898,7 +904,7 @@ impl NetworkRegistry {
             let name = pending.name.clone();
             tokio::spawn(async move {
                 let _ = me
-                    .join_network(&key, name.as_deref(), None, None, None, false, false)
+                    .join_network(&key, name.as_deref(), JoinOptions::default())
                     .await;
             });
         }
@@ -1724,6 +1730,7 @@ mod coordinator_restore_tests {
             last_seen: Some(42),
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         }
     }
 
@@ -1787,12 +1794,14 @@ mod coordinator_restore_tests {
         let me = id(1);
         let approved_id = id(2);
         let nullified = id(3);
-        let (key_hash, key) = crate::membership::ReusableKey::from_secret(b"key", 10, 20);
+        let (key_hash, key) =
+            crate::membership::ReusableKey::from_secret(b"key", 10, 20, Default::default());
         let approved = ApprovedEntry {
             identity: approved_id,
             hostname: Some("waiting".to_string()),
             user_identity: None,
             device_cert: None,
+            roles: Default::default(),
         };
         let mut source = blob(vec![member(me, true)]);
         source.approved.push(approved.clone());

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -515,6 +515,11 @@ pub(crate) struct NetworkState {
 pub(crate) struct PendingJoin {
     pub(crate) hostname: Option<String>,
     pub(crate) device_cert: Option<control::DeviceCert>,
+    /// Roles the joiner asked for. A request, never a grant: `ray requests`
+    /// shows it so the operator can decide, and only `ray requests accept
+    /// --role` actually confers anything. Kept because without it the operator
+    /// cannot see why an otherwise-accepted peer keeps being refused.
+    pub(crate) requested_roles: BTreeSet<String>,
     pub(crate) requested_at: Instant,
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -213,6 +213,7 @@ mod mesh;
 // by bare name, as before the split.
 pub(crate) use mesh::*;
 // `run_daemon` (the `ray daemon` entry point) stays public for the binary.
+pub use mesh::JoinOptions;
 pub use mesh::run_daemon;
 // `build_headless` is the embedder (mobile) construction entry point.
 pub use mesh::build_headless;
@@ -1264,15 +1265,19 @@ impl Daemon {
                 coordinator,
                 auto_accept_firewall,
                 auto_accept_files,
+                roles,
             } => {
                 self.join_network(
                     &network_key,
                     name.as_deref(),
-                    hostname,
-                    invite,
-                    coordinator,
-                    auto_accept_firewall,
-                    auto_accept_files,
+                    JoinOptions {
+                        hostname,
+                        invite,
+                        coordinator,
+                        auto_accept_firewall,
+                        auto_accept_files,
+                        roles,
+                    },
                 )
                 .await
             }
@@ -1418,9 +1423,10 @@ impl Daemon {
                 expires_secs,
                 hostname,
                 reusable,
+                roles,
             } => {
                 self.registry
-                    .invite_create(&network, expires_secs, hostname, reusable)
+                    .invite_create(&network, expires_secs, hostname, roles, reusable)
                     .await
             }
             IpcMessage::InviteList { network } => self.registry.invite_list(&network).await,
@@ -1428,8 +1434,8 @@ impl Daemon {
                 self.registry.invite_revoke(&network, &id).await
             }
             IpcMessage::Requests { network } => self.registry.list_requests(&network),
-            IpcMessage::AcceptRequest { network, id } => {
-                self.registry.accept_request(&network, &id).await
+            IpcMessage::AcceptRequest { network, id, roles } => {
+                self.registry.accept_request(&network, &id, roles).await
             }
             IpcMessage::DenyRequest { network, id } => self.registry.deny_request(&network, &id),
             IpcMessage::AdminAdd { network, identity } => {
@@ -2610,6 +2616,7 @@ mod absent_member_tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         }
     }
 
@@ -2781,6 +2788,7 @@ mod accept_handler_tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         }
     }
 
@@ -2808,6 +2816,7 @@ mod accept_handler_tests {
                 hostname: None,
                 user_identity: None,
                 device_cert: None,
+                roles: Default::default(),
             });
         }
         assert!(h.knows_sender(peer));
@@ -3008,6 +3017,7 @@ mod accept_handler_tests {
                     last_seen: None,
                     exit_node: false,
                     exit_families: ExitFamilies::Unknown,
+                    roles: Default::default(),
                 });
             }
             registry.networks.insert(
@@ -3118,6 +3128,7 @@ mod accept_handler_tests {
                 last_seen: None,
                 exit_node: false,
                 exit_families: ExitFamilies::Unknown,
+                roles: Default::default(),
             });
         }
         registry.networks.insert(
@@ -3265,6 +3276,7 @@ mod accept_handler_tests {
                     last_seen: None,
                     exit_node: false,
                     exit_families: ExitFamilies::Unknown,
+                    roles: Default::default(),
                 },
                 Member {
                     identity: member_id,
@@ -3275,6 +3287,7 @@ mod accept_handler_tests {
                     last_seen: None,
                     exit_node: false,
                     exit_families: ExitFamilies::Unknown,
+                    roles: Default::default(),
                 },
             ]
         };
@@ -3500,6 +3513,7 @@ mod coordinator_dial_order_tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         };
         let members = vec![mk(a, true), mk(b, true), mk(c, false), mk(me, true)];
         // minter = b: b first, then the other coordinator a, never c (not coord), never me.
@@ -3518,6 +3532,7 @@ mod coordinator_dial_order_tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         };
 
         // No coordinators in the roster ⇒ empty order (caller bails).
@@ -3578,6 +3593,7 @@ mod coordinator_dial_order_tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         };
         let members = vec![mk(a, true), mk(b, false), mk(c, true)];
         let me = a;
@@ -3597,6 +3613,7 @@ mod coordinator_dial_order_tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         };
         // Only members are us (coordinator) and a plain member: nobody to gossip to.
         let members = vec![mk(me, true), mk(test_id(2), false)];

--- a/src/daemon/network_registry.rs
+++ b/src/daemon/network_registry.rs
@@ -699,6 +699,8 @@ impl NetworkRegistry {
             // `Unknown` until the data plane probes the uplink: an offer we have
             // not verified is not a claim to publish.
             exit_families: ExitFamilies::Unknown,
+            // See the coordinator's own entry in `runtime::restore_roster`.
+            roles: BTreeSet::new(),
         });
 
         let mut approved = ApprovedList::new();
@@ -708,6 +710,9 @@ impl NetworkRegistry {
                 hostname: peer_hostname,
                 user_identity: None,
                 device_cert: None,
+                // A `ray connect` link is a symmetric 2-peer network with no
+                // policy to select on, so the requester gets no roles.
+                roles: BTreeSet::new(),
             });
         }
 

--- a/src/firewall.rs
+++ b/src/firewall.rs
@@ -58,6 +58,7 @@
 //! Explicit rules always win (first-match). Established return traffic only
 //! bypasses the *default* action, never an explicit rule.
 
+use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -69,6 +70,7 @@ use arc_swap::ArcSwap;
 use iroh::EndpointId;
 use ray_proto::SuggestedFirewall;
 use ray_proto::ipc::FirewallRuleView;
+use ray_proto::policy::{self, ROLE_PREFIX};
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
@@ -925,13 +927,32 @@ pub fn parse_spec_token(tok: &str) -> Result<(Protocol, Option<PortRange>)> {
     }
 }
 
+/// How [`materialize_suggestions`] turns the names in a suggestion into peers.
+///
+/// Every field is derived from the same signed `GroupBlob` the suggestions came
+/// from, so a rule and the roster it resolves against cannot disagree.
+pub struct SubjectResolver<'a> {
+    /// This node's hostname, from the roster rather than its join-time claim.
+    pub hostname: &'a str,
+    /// Roles this node holds. Matched against a `role:` subject key, so one
+    /// published rule covers every node the coordinator gave that role.
+    pub roles: &'a BTreeSet<String>,
+    /// Hostname to identity, for a peer key naming one machine.
+    pub by_hostname: &'a dyn Fn(&str) -> Option<EndpointId>,
+    /// Role to every member currently holding it, for a `role:` peer key. This
+    /// is what makes scaling out free: a new holder shows up here on the next
+    /// blob update and its rule materializes with no `ray apply` re-run.
+    pub by_role: &'a dyn Fn(&str) -> Vec<EndpointId>,
+}
+
 /// Build the concrete local firewall rules a node enforces for network `net`,
 /// from `suggestions` targeting `my_hostname`. Two subjects apply to a node: its
-/// own hostname and the wildcard `*` subject (which targets every node, e.g.
-/// "everyone opens 6969"). Peer hostnames are resolved to identities via
-/// `resolve` (the blob's member list); unresolved peers are skipped, their rules
-/// materialize once they join. The `*` peer key means *any peer* and bypasses
-/// resolution. Every rule is inbound, network-scoped to `net`, and tagged
+/// own hostname, every `role:` it holds, and the wildcard `*` subject (which
+/// targets every node, e.g. "everyone opens 6969"). Peer names are resolved to
+/// identities via `r` (built from the blob's member list); unresolved peers are
+/// skipped, their rules materialize once they join. The `*` peer key means *any
+/// peer* and bypasses resolution, and a `role:` peer expands to every member
+/// holding that role. Every rule is inbound, network-scoped to `net`, and tagged
 /// `origin: Network(net)`. Suggestions are purely additive: each token yields
 /// exactly one rule (allow or deny) and nothing is synthesized: the node's own
 /// `default_inbound` (Deny by default) already covers anything an allow-list
@@ -940,44 +961,56 @@ pub fn parse_spec_token(tok: &str) -> Result<(Protocol, Option<PortRange>)> {
 /// value yields one rule per token.
 pub fn materialize_suggestions(
     net: &str,
-    my_hostname: &str,
     suggestions: &SuggestedFirewall,
-    resolve: &dyn Fn(&str) -> Option<EndpointId>,
+    r: &SubjectResolver,
 ) -> Vec<FirewallRule> {
     let mut rules = Vec::new();
-    // The wildcard `*` subject applies to every node, alongside its own subject
-    // (deduped so a node literally named "*" isn't counted twice).
-    let mut keys = vec!["*"];
-    if my_hostname != "*" {
-        keys.push(my_hostname);
+    // The wildcard `*` subject applies to every node, alongside its own hostname
+    // (deduped so a node literally named "*" isn't counted twice) and every role
+    // it holds. A node wearing two roles takes the union of both.
+    let mut keys = vec!["*".to_string()];
+    if r.hostname != "*" {
+        keys.push(r.hostname.to_string());
     }
-    let applicable: Vec<_> = keys.iter().filter_map(|k| suggestions.get(*k)).collect();
+    keys.extend(r.roles.iter().map(|role| format!("{ROLE_PREFIX}{role}")));
+    let applicable: Vec<_> = keys.iter().filter_map(|k| suggestions.get(k)).collect();
     if applicable.is_empty() {
         return rules;
     }
     for host in &applicable {
         for (action, list) in [(Action::Allow, &host.allows), (Action::Deny, &host.denies)] {
             for (peer, ports) in list {
-                // `*` ⇒ any peer (no resolution); otherwise resolve the hostname.
-                let filter = if peer == "*" {
-                    PeerFilter::Any
+                // One peer key can name several peers: `*` is any of them, a
+                // role is every member currently holding it, a hostname is one.
+                // A role naming nobody yet emits nothing and materializes on the
+                // blob update that seats its first holder, exactly as an
+                // unresolved hostname does.
+                let filters: Vec<PeerFilter> = if peer == "*" {
+                    vec![PeerFilter::Any]
+                } else if let Some(role) = policy::role_of(peer) {
+                    (r.by_role)(role)
+                        .into_iter()
+                        .map(PeerFilter::Identity)
+                        .collect()
                 } else {
-                    match resolve(peer) {
-                        Some(id) => PeerFilter::Identity(id),
+                    match (r.by_hostname)(peer) {
+                        Some(id) => vec![PeerFilter::Identity(id)],
                         None => continue,
                     }
                 };
                 for tok in ports.split(',').map(str::trim).filter(|s| !s.is_empty()) {
                     match parse_spec_token(tok) {
-                        Ok((proto, port)) => rules.push(FirewallRule {
-                            direction: Direction::In,
-                            action,
-                            protocol: proto,
-                            port,
-                            peer: filter.clone(),
-                            network: Some(net.to_string()),
-                            origin: RuleOrigin::Network(net.to_string()),
-                        }),
+                        Ok((proto, port)) => {
+                            rules.extend(filters.iter().map(|filter| FirewallRule {
+                                direction: Direction::In,
+                                action,
+                                protocol: proto,
+                                port: port.clone(),
+                                peer: filter.clone(),
+                                network: Some(net.to_string()),
+                                origin: RuleOrigin::Network(net.to_string()),
+                            }))
+                        }
                         Err(e) => tracing::warn!(
                             token = %tok, network = %net, error = %e,
                             "skipping invalid firewall spec token"
@@ -1040,6 +1073,26 @@ pub fn rule_views(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// No roles on this node and no role holders anywhere: the shape every
+    /// hostname-keyed case wants, so those tests keep reading as they did.
+    static NO_ROLES: BTreeSet<String> = BTreeSet::new();
+
+    fn no_holders(_: &str) -> Vec<EndpointId> {
+        Vec::new()
+    }
+
+    fn host_resolver<'a>(
+        hostname: &'a str,
+        by_hostname: &'a dyn Fn(&str) -> Option<EndpointId>,
+    ) -> SubjectResolver<'a> {
+        SubjectResolver {
+            hostname,
+            roles: &NO_ROLES,
+            by_hostname,
+            by_role: &no_holders,
+        }
+    }
 
     fn test_id(seed: u8) -> EndpointId {
         let mut key_bytes = [0u8; 32];
@@ -2431,6 +2484,145 @@ mod tests {
         map
     }
 
+    /// A `role:` subject applies to a node holding that role, and its rules
+    /// resolve exactly as a hostname-keyed subject's would.
+    #[test]
+    fn materialize_matches_a_role_subject_this_node_holds() {
+        let peer = test_id(2);
+        let by_hostname = |h: &str| (h == "peer").then_some(peer);
+        let my_roles: BTreeSet<String> = ["sentry".to_string()].into();
+        let suggestions = suggest("role:sentry", &[("peer", "tcp:4000")]);
+        let rules = materialize_suggestions(
+            "prod",
+            &suggestions,
+            &SubjectResolver {
+                hostname: "sentry-07",
+                roles: &my_roles,
+                by_hostname: &by_hostname,
+                by_role: &no_holders,
+            },
+        );
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].peer, PeerFilter::Identity(peer));
+        assert_eq!(rules[0].port.as_ref().unwrap().start, 4000);
+    }
+
+    /// The other half: a node that does not hold the role installs nothing, so
+    /// one published rule cannot leak to the rest of the network.
+    #[test]
+    fn materialize_ignores_a_role_subject_this_node_lacks() {
+        let peer = test_id(2);
+        let by_hostname = |h: &str| (h == "peer").then_some(peer);
+        let my_roles: BTreeSet<String> = ["nonvalid".to_string()].into();
+        let suggestions = suggest("role:sentry", &[("peer", "tcp:4000")]);
+        let rules = materialize_suggestions(
+            "prod",
+            &suggestions,
+            &SubjectResolver {
+                hostname: "box",
+                roles: &my_roles,
+                by_hostname: &by_hostname,
+                by_role: &no_holders,
+            },
+        );
+        assert!(rules.is_empty());
+    }
+
+    /// A `role:` peer expands to every member holding it: one rule each, so
+    /// twenty sentries are twenty identities and no wildcard.
+    #[test]
+    fn materialize_expands_a_role_peer_to_every_holder() {
+        let a = test_id(2);
+        let b = test_id(3);
+        let by_hostname = |_: &str| None;
+        let by_role = |role: &str| {
+            if role == "sentry" {
+                vec![a, b]
+            } else {
+                Vec::new()
+            }
+        };
+        let suggestions = suggest("me", &[("role:sentry", "tcp:4000")]);
+        let rules = materialize_suggestions(
+            "prod",
+            &suggestions,
+            &SubjectResolver {
+                hostname: "me",
+                roles: &NO_ROLES,
+                by_hostname: &by_hostname,
+                by_role: &by_role,
+            },
+        );
+        assert_eq!(rules.len(), 2);
+        let mut peers: Vec<PeerFilter> = rules.iter().map(|r| r.peer.clone()).collect();
+        peers.sort_by_key(|p| format!("{p:?}"));
+        let mut want = vec![PeerFilter::Identity(a), PeerFilter::Identity(b)];
+        want.sort_by_key(|p| format!("{p:?}"));
+        assert_eq!(peers, want);
+        // Never a blanket "any peer": an empty role must not read as `*`.
+        assert!(!rules.iter().any(|r| r.peer == PeerFilter::Any));
+    }
+
+    /// The property the whole design rests on: a role nobody holds yet emits
+    /// nothing, and the same published suggestion starts emitting once a member
+    /// turns up, with no re-apply in between.
+    #[test]
+    fn a_role_peer_with_no_holders_materializes_later() {
+        let by_hostname = |_: &str| None;
+        let suggestions = suggest("me", &[("role:sentry", "tcp:4000")]);
+        let empty =
+            materialize_suggestions("prod", &suggestions, &host_resolver("me", &by_hostname));
+        assert!(empty.is_empty(), "no holders yet, so no rules");
+
+        // Same suggestions, one member later.
+        let joined = test_id(9);
+        let by_role = |role: &str| {
+            if role == "sentry" {
+                vec![joined]
+            } else {
+                Vec::new()
+            }
+        };
+        let now = materialize_suggestions(
+            "prod",
+            &suggestions,
+            &SubjectResolver {
+                hostname: "me",
+                roles: &NO_ROLES,
+                by_hostname: &by_hostname,
+                by_role: &by_role,
+            },
+        );
+        assert_eq!(now.len(), 1);
+        assert_eq!(now[0].peer, PeerFilter::Identity(joined));
+    }
+
+    /// A node wearing two roles takes the union of both subjects, alongside its
+    /// hostname and `*`.
+    #[test]
+    fn materialize_unions_every_role_a_node_holds() {
+        let peer = test_id(2);
+        let by_hostname = |h: &str| (h == "peer").then_some(peer);
+        let my_roles: BTreeSet<String> = ["eu".to_string(), "sentry".to_string()].into();
+        let mut suggestions = suggest("role:sentry", &[("peer", "tcp:4000")]);
+        suggestions.extend(suggest("role:eu", &[("peer", "tcp:8080")]));
+        let rules = materialize_suggestions(
+            "prod",
+            &suggestions,
+            &SubjectResolver {
+                hostname: "box",
+                roles: &my_roles,
+                by_hostname: &by_hostname,
+                by_role: &no_holders,
+            },
+        );
+        let ports: BTreeSet<u16> = rules
+            .iter()
+            .map(|r| r.port.as_ref().unwrap().start)
+            .collect();
+        assert_eq!(ports, [4000, 8080].into());
+    }
+
     #[test]
     fn materialize_resolves_peer_hostnames_and_expands_comma_ports() {
         let me = test_id(1);
@@ -2441,7 +2633,7 @@ mod tests {
             _ => None,
         };
         let suggestions = suggest("me", &[("peer", "tcp:9000,tcp:8123")]);
-        let rules = materialize_suggestions("prod", "me", &suggestions, &resolve);
+        let rules = materialize_suggestions("prod", &suggestions, &host_resolver("me", &resolve));
         // Two allow rules (one per port), all inbound, network-scoped, origin prod.
         let allows: Vec<_> = rules.iter().filter(|r| r.action == Action::Allow).collect();
         assert_eq!(allows.len(), 2);
@@ -2472,7 +2664,7 @@ mod tests {
         // An allow-list yields exactly its allow rules, no synthesized catch-all
         // deny. The node's own `default_inbound` already drops the rest.
         let suggestions = suggest("me", &[("peer", "tcp:9000")]);
-        let rules = materialize_suggestions("prod", "me", &suggestions, &resolve);
+        let rules = materialize_suggestions("prod", &suggestions, &host_resolver("me", &resolve));
         assert_eq!(rules.len(), 1, "only the suggested allow rule");
         assert_eq!(rules[0].action, Action::Allow);
         assert_eq!(rules[0].peer, PeerFilter::Identity(peer));
@@ -2499,7 +2691,7 @@ mod tests {
         };
         let mut suggestions = SuggestedFirewall::new();
         suggestions.insert("me".to_string(), entry);
-        let rules = materialize_suggestions("prod", "me", &suggestions, &resolve);
+        let rules = materialize_suggestions("prod", &suggestions, &host_resolver("me", &resolve));
         // One deny rule for eve, no catch-all deny.
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].action, Action::Deny);
@@ -2517,7 +2709,7 @@ mod tests {
         // Subject present but no allows and no default ⇒ no catch-all deny.
         let mut suggestions = SuggestedFirewall::new();
         suggestions.insert("me".to_string(), HostSuggestions::default());
-        let rules = materialize_suggestions("prod", "me", &suggestions, &resolve);
+        let rules = materialize_suggestions("prod", &suggestions, &host_resolver("me", &resolve));
         assert!(rules.is_empty(), "expected no rules for an open subject");
     }
 
@@ -2526,7 +2718,7 @@ mod tests {
         // No resolver ever returns an identity for "ghost".
         let resolve = |_: &str| None;
         let suggestions = suggest("me", &[("ghost", "tcp:9000")]);
-        let rules = materialize_suggestions("prod", "me", &suggestions, &resolve);
+        let rules = materialize_suggestions("prod", &suggestions, &host_resolver("me", &resolve));
         // The allow rule is dropped (peer not joined) and nothing is synthesized,
         // so no rules materialize at all.
         assert!(rules.is_empty());
@@ -2541,7 +2733,7 @@ mod tests {
         };
         // Suggestions target a different subject.
         let suggestions = suggest("other", &[("me", "tcp:9000")]);
-        let rules = materialize_suggestions("prod", "me", &suggestions, &resolve);
+        let rules = materialize_suggestions("prod", &suggestions, &host_resolver("me", &resolve));
         assert!(rules.is_empty());
     }
 
@@ -2556,7 +2748,7 @@ mod tests {
         };
         // One peer, mixed protocols in a single comma-list.
         let suggestions = suggest("me", &[("peer", "icmp,tcp:*,udp:53,any")]);
-        let rules = materialize_suggestions("prod", "me", &suggestions, &resolve);
+        let rules = materialize_suggestions("prod", &suggestions, &host_resolver("me", &resolve));
         let allows: Vec<_> = rules.iter().filter(|r| r.action == Action::Allow).collect();
         // icmp + tcp:* + udp:53 + any = 4 rules.
         assert_eq!(allows.len(), 4);
@@ -2587,7 +2779,7 @@ mod tests {
         entry.allows.insert("*".to_string(), "tcp:6969".to_string());
         suggestions.insert("*".to_string(), entry);
         // "me" has no own subject, only the wildcard.
-        let rules = materialize_suggestions("prod", "me", &suggestions, &resolve);
+        let rules = materialize_suggestions("prod", &suggestions, &host_resolver("me", &resolve));
         let allow = rules
             .iter()
             .find(|r| r.action == Action::Allow)
@@ -2605,7 +2797,7 @@ mod tests {
         // A `*` peer key opens the port to anyone, without resolving a hostname.
         let resolve = |_: &str| None; // resolves nothing
         let suggestions = suggest("me", &[("*", "udp:53")]);
-        let rules = materialize_suggestions("prod", "me", &suggestions, &resolve);
+        let rules = materialize_suggestions("prod", &suggestions, &host_resolver("me", &resolve));
         let allow = rules
             .iter()
             .find(|r| r.action == Action::Allow)
@@ -2629,7 +2821,7 @@ mod tests {
         let mut wild = HostSuggestions::default();
         wild.allows.insert("*".to_string(), "tcp:6969".to_string());
         suggestions.insert("*".to_string(), wild);
-        let rules = materialize_suggestions("prod", "me", &suggestions, &resolve);
+        let rules = materialize_suggestions("prod", &suggestions, &host_resolver("me", &resolve));
         let allows: Vec<_> = rules.iter().filter(|r| r.action == Action::Allow).collect();
         assert_eq!(allows.len(), 2, "own subject + wildcard subject");
         assert!(

--- a/src/invite.rs
+++ b/src/invite.rs
@@ -12,6 +12,7 @@
 //! secret, looks it up in the ledger, and burns it. Codes minted before the
 //! checksum existed still decode.
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -50,6 +51,23 @@ pub struct Invite {
     /// networks). `None` = the joiner's `--hostname` claim is used as before.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hostname: Option<String>,
+    /// Roles the coordinator assigns on redemption. Unlike [`Self::hostname`]
+    /// there is no "the joiner's claim stands" fallback: a role is only ever
+    /// what the credential grants.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub roles: BTreeSet<String>,
+}
+
+/// What redeeming a credential grants the joiner. Everything here is the
+/// coordinator's assignment, never the joiner's claim, which is what lets a
+/// firewall rule key on it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Grant {
+    /// Hostname to assign authoritatively. `None` leaves the joiner's own
+    /// `--hostname` claim standing (and subject to collision-rename).
+    pub hostname: Option<String>,
+    /// Roles to assign, already validated at mint time.
+    pub roles: BTreeSet<String>,
 }
 
 /// On-disk container (so the toml file has a stable `[[invites]]` shape).
@@ -221,13 +239,9 @@ impl InviteStore {
 
     /// Mint a new invite valid for `ttl`, persist it, and return `(secret, id)`.
     /// The raw secret is returned only here so it can be encoded into the code.
-    /// `hostname` (trusted networks) is assigned authoritatively on redemption,
-    /// so the holder joins with `ray join <code>` and no `--hostname`.
-    pub fn mint(
-        &mut self,
-        ttl: Duration,
-        hostname: Option<String>,
-    ) -> Result<([u8; SECRET_LEN], String)> {
+    /// `grant` is what redemption assigns: a hostname (trusted networks, so the
+    /// holder joins with `ray join <code>` and no `--hostname`) and any roles.
+    pub fn mint(&mut self, ttl: Duration, grant: Grant) -> Result<([u8; SECRET_LEN], String)> {
         let secret = generate_secret();
         let secret_hash = hash_secret(&secret);
         let id = secret_hash[..8].to_string();
@@ -239,16 +253,17 @@ impl InviteStore {
             created,
             expires,
             status: InviteStatus::Pending,
-            hostname,
+            hostname: grant.hostname,
+            roles: grant.roles,
         });
         self.save()?;
         Ok((secret, id))
     }
 
     /// Verify a presented secret and burn it (single-use). Errors if the secret is
-    /// unknown, already used, revoked, or expired. Returns the invite's intended
-    /// hostname (trusted networks) so the coordinator can assign it.
-    pub fn redeem(&mut self, secret: &[u8], by: EndpointId) -> Result<Option<String>> {
+    /// unknown, already used, revoked, or expired. Returns what the invite
+    /// grants (hostname, roles) so the coordinator can assign it.
+    pub fn redeem(&mut self, secret: &[u8], by: EndpointId) -> Result<Grant> {
         let hash = hash_secret(secret);
         let now = now_secs();
         let invite = self
@@ -264,10 +279,13 @@ impl InviteStore {
         if now >= invite.expires {
             bail!("invite expired");
         }
-        let hostname = invite.hostname.clone();
+        let grant = Grant {
+            hostname: invite.hostname.clone(),
+            roles: invite.roles.clone(),
+        };
         invite.status = InviteStatus::Redeemed { by, at: now };
         self.save()?;
-        Ok(hostname)
+        Ok(grant)
     }
 
     /// Un-burn an invite: revert a `Redeemed` record back to `Pending`. Used when
@@ -324,6 +342,7 @@ impl InviteStore {
             expires,
             status: InviteStatus::Pending,
             hostname: None,
+            roles: BTreeSet::new(),
         });
         self.save()
     }
@@ -468,7 +487,9 @@ mod tests {
     #[test]
     fn mint_then_redeem_succeeds() {
         let (mut store, _dir) = temp_store();
-        let (secret, id) = store.mint(Duration::from_secs(3600), None).unwrap();
+        let (secret, id) = store
+            .mint(Duration::from_secs(3600), Grant::default())
+            .unwrap();
         assert_eq!(id.len(), 8);
         store.redeem(&secret, test_id(9)).unwrap();
         // Status is now redeemed.
@@ -481,7 +502,9 @@ mod tests {
     #[test]
     fn redeem_is_single_use() {
         let (mut store, _dir) = temp_store();
-        let (secret, _id) = store.mint(Duration::from_secs(3600), None).unwrap();
+        let (secret, _id) = store
+            .mint(Duration::from_secs(3600), Grant::default())
+            .unwrap();
         store.redeem(&secret, test_id(9)).unwrap();
         let err = store.redeem(&secret, test_id(10)).unwrap_err();
         assert!(err.to_string().contains("already used"));
@@ -491,7 +514,9 @@ mod tests {
     fn redeem_rejects_expired() {
         let (mut store, _dir) = temp_store();
         // ttl=0 → expires == created == now, so now >= expires immediately.
-        let (secret, _id) = store.mint(Duration::from_secs(0), None).unwrap();
+        let (secret, _id) = store
+            .mint(Duration::from_secs(0), Grant::default())
+            .unwrap();
         let err = store.redeem(&secret, test_id(9)).unwrap_err();
         assert!(err.to_string().contains("expired"));
     }
@@ -499,7 +524,9 @@ mod tests {
     #[test]
     fn redeem_rejects_wrong_secret() {
         let (mut store, _dir) = temp_store();
-        store.mint(Duration::from_secs(3600), None).unwrap();
+        store
+            .mint(Duration::from_secs(3600), Grant::default())
+            .unwrap();
         let err = store.redeem(&generate_secret(), test_id(9)).unwrap_err();
         assert!(err.to_string().contains("invalid invite"));
     }
@@ -507,7 +534,9 @@ mod tests {
     #[test]
     fn revoke_then_redeem_fails() {
         let (mut store, _dir) = temp_store();
-        let (secret, id) = store.mint(Duration::from_secs(3600), None).unwrap();
+        let (secret, id) = store
+            .mint(Duration::from_secs(3600), Grant::default())
+            .unwrap();
         store.revoke(&id).unwrap();
         let err = store.redeem(&secret, test_id(9)).unwrap_err();
         assert!(err.to_string().contains("revoked"));
@@ -516,7 +545,9 @@ mod tests {
     #[test]
     fn cannot_revoke_used_invite() {
         let (mut store, _dir) = temp_store();
-        let (secret, id) = store.mint(Duration::from_secs(3600), None).unwrap();
+        let (secret, id) = store
+            .mint(Duration::from_secs(3600), Grant::default())
+            .unwrap();
         store.redeem(&secret, test_id(9)).unwrap();
         assert!(store.revoke(&id).is_err());
     }
@@ -528,7 +559,9 @@ mod tests {
         let secret;
         {
             let mut store = InviteStore::with_path(&path);
-            let (s, _id) = store.mint(Duration::from_secs(3600), None).unwrap();
+            let (s, _id) = store
+                .mint(Duration::from_secs(3600), Grant::default())
+                .unwrap();
             secret = s;
         }
         // Reload from disk and redeem.
@@ -539,7 +572,9 @@ mod tests {
     #[test]
     fn list_reports_expired_lazily() {
         let (mut store, _dir) = temp_store();
-        store.mint(Duration::from_secs(0), None).unwrap();
+        store
+            .mint(Duration::from_secs(0), Grant::default())
+            .unwrap();
         let view = store.list();
         assert_eq!(view[0].status, "expired");
         // Stored status remains Pending (not mutated).
@@ -550,19 +585,47 @@ mod tests {
     fn mint_with_hostname_returns_it_on_redeem() {
         let (mut store, _dir) = temp_store();
         let (secret, _id) = store
-            .mint(Duration::from_secs(3600), Some("ty2-clic01".to_string()))
+            .mint(
+                Duration::from_secs(3600),
+                Grant {
+                    hostname: Some("ty2-clic01".to_string()),
+                    roles: BTreeSet::new(),
+                },
+            )
             .unwrap();
-        let hostname = store.redeem(&secret, test_id(9)).unwrap();
-        assert_eq!(hostname.as_deref(), Some("ty2-clic01"));
+        let grant = store.redeem(&secret, test_id(9)).unwrap();
+        assert_eq!(grant.hostname.as_deref(), Some("ty2-clic01"));
         // The bound hostname is visible in the list.
         let view = store.list();
         assert_eq!(view[0].hostname.as_deref(), Some("ty2-clic01"));
     }
 
+    /// A single-use invite can carry roles too, so `--hostname sentry-01
+    /// --role sentry` seats a named node with its policy class in one code.
+    #[test]
+    fn mint_with_roles_returns_them_on_redeem() {
+        let (mut store, _dir) = temp_store();
+        let roles: BTreeSet<String> = ["sentry".to_string()].into();
+        let (secret, _id) = store
+            .mint(
+                Duration::from_secs(3600),
+                Grant {
+                    hostname: None,
+                    roles: roles.clone(),
+                },
+            )
+            .unwrap();
+        let grant = store.redeem(&secret, test_id(9)).unwrap();
+        assert_eq!(grant.roles, roles);
+        assert!(grant.hostname.is_none());
+    }
+
     #[test]
     fn restore_reinstates_a_burned_invite() {
         let (mut store, _dir) = temp_store();
-        let (secret, _id) = store.mint(Duration::from_secs(3600), None).unwrap();
+        let (secret, _id) = store
+            .mint(Duration::from_secs(3600), Grant::default())
+            .unwrap();
         store.redeem(&secret, test_id(9)).unwrap();
         // After restore the invite is pending again and redeemable once more.
         store.restore(&secret).unwrap();
@@ -574,7 +637,9 @@ mod tests {
     #[test]
     fn restore_is_noop_for_unknown_or_pending() {
         let (mut store, _dir) = temp_store();
-        let (secret, _id) = store.mint(Duration::from_secs(3600), None).unwrap();
+        let (secret, _id) = store
+            .mint(Duration::from_secs(3600), Grant::default())
+            .unwrap();
         // Pending stays pending; an unknown secret is ignored.
         store.restore(&secret).unwrap();
         store.restore(&generate_secret()).unwrap();
@@ -588,7 +653,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("net.toml");
         let mut store = InviteStore::with_path(&path);
-        store.mint(Duration::from_secs(3600), None).unwrap();
+        store
+            .mint(Duration::from_secs(3600), Grant::default())
+            .unwrap();
         let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600);
     }
@@ -596,9 +663,12 @@ mod tests {
     #[test]
     fn mint_without_hostname_returns_none_on_redeem() {
         let (mut store, _dir) = temp_store();
-        let (secret, _id) = store.mint(Duration::from_secs(3600), None).unwrap();
-        let hostname = store.redeem(&secret, test_id(9)).unwrap();
-        assert!(hostname.is_none());
+        let (secret, _id) = store
+            .mint(Duration::from_secs(3600), Grant::default())
+            .unwrap();
+        let grant = store.redeem(&secret, test_id(9)).unwrap();
+        assert!(grant.hostname.is_none());
+        assert!(grant.roles.is_empty());
     }
 
     #[test]
@@ -616,7 +686,7 @@ mod tests {
         // A shared entry is redeemable by this (non-minting) coordinator
         // (hostname is None since record_shared has no hostname binding):
         let by = test_id(5);
-        assert!(store.redeem(&secret, by).unwrap().is_none());
+        assert!(store.redeem(&secret, by).unwrap().hostname.is_none());
         // Burning an already-redeemed hash is a no-op (returns false):
         assert!(!store.burn_by_hash(&hash).unwrap());
     }

--- a/src/invite.rs
+++ b/src/invite.rs
@@ -331,7 +331,18 @@ impl InviteStore {
     /// The `secret_hash` is the full hex blake3 of the secret (same format as
     /// `mint` stores internally). This lets a co-coordinator redeem an invite it
     /// did not mint, when the originating coordinator shares the hash out-of-band.
-    pub fn record_shared(&mut self, id: String, secret_hash: String, expires: u64) -> Result<()> {
+    ///
+    /// `roles` is what the minter bound to the code, so redeeming here grants the
+    /// same thing it would have there. `hostname` has no counterpart: it is not
+    /// gossiped, so an authoritative name still only binds on the coordinator
+    /// that minted the invite.
+    pub fn record_shared(
+        &mut self,
+        id: String,
+        secret_hash: String,
+        expires: u64,
+        roles: BTreeSet<String>,
+    ) -> Result<()> {
         if self.invites.iter().any(|i| i.id == id) {
             return Ok(());
         }
@@ -342,7 +353,7 @@ impl InviteStore {
             expires,
             status: InviteStatus::Pending,
             hostname: None,
-            roles: BTreeSet::new(),
+            roles,
         });
         self.save()
     }
@@ -680,13 +691,17 @@ mod tests {
         // secret_hash is a hex String in the real code.
         let hash = blake3::hash(&secret).to_hex().to_string();
 
+        let roles: BTreeSet<String> = ["sentry".to_string()].into();
         store
-            .record_shared("abcd1234".into(), hash.clone(), u64::MAX)
+            .record_shared("abcd1234".into(), hash.clone(), u64::MAX, roles.clone())
             .unwrap();
-        // A shared entry is redeemable by this (non-minting) coordinator
-        // (hostname is None since record_shared has no hostname binding):
+        // A shared entry is redeemable by this (non-minting) coordinator, and
+        // grants the roles the minter bound to it. The hostname is None: that
+        // half of the binding is not gossiped.
         let by = test_id(5);
-        assert!(store.redeem(&secret, by).unwrap().hostname.is_none());
+        let grant = store.redeem(&secret, by).unwrap();
+        assert!(grant.hostname.is_none());
+        assert_eq!(grant.roles, roles);
         // Burning an already-redeemed hash is a no-op (returns false):
         assert!(!store.burn_by_hash(&hash).unwrap());
     }
@@ -698,7 +713,7 @@ mod tests {
         let secret = generate_secret();
         let hash = blake3::hash(&secret).to_hex().to_string();
         store
-            .record_shared("id00".into(), hash.clone(), u64::MAX)
+            .record_shared("id00".into(), hash.clone(), u64::MAX, BTreeSet::new())
             .unwrap();
         assert!(store.burn_by_hash(&hash).unwrap()); // first burn changes state
         assert!(store.redeem(&secret, test_id(9)).is_err()); // now unusable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ pub mod onepassword;
 pub mod peers;
 pub mod ratelimit;
 pub mod reject;
+pub mod roles;
 pub mod shutdown;
 #[cfg(feature = "desktop")]
 #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,7 @@ fn json_requested(command: &Command) -> bool {
         | Command::Pair { json, .. }
         | Command::Identityof { json, .. }
         | Command::Alias { json, .. }
+        | Command::Apply { json, .. }
         | Command::Config { json, .. } => *json,
         _ => false,
     }
@@ -126,6 +127,11 @@ pub(crate) enum Command {
         /// it, suggestions queue for `ray firewall accept`.
         #[arg(long)]
         auto_accept_firewall: bool,
+        /// Ask for a role the invite grants (repeatable). Only ever narrows what
+        /// the code already carries; asking for one it does not grant refuses
+        /// the join. Omit it to take everything the code carries.
+        #[arg(long = "role")]
+        roles: Vec<String>,
         /// Opt out of auto-accepting file transfers from your own paired devices
         /// on this network. By default own-device offers are accepted without a
         /// manual `ray files accept` (only offers whose sender is one of your own
@@ -288,6 +294,10 @@ pub(crate) enum Command {
         /// Short id of the pending peer (from `ray requests`)
         #[arg(add = complete::join_requests())]
         id: String,
+        /// Role to assign on approval (repeatable). A live approval has no code
+        /// to read roles off, so name them here.
+        #[arg(long = "role")]
+        roles: Vec<String>,
     },
     /// The old spelling of `ray requests <network> deny <id>`.
     #[command(hide = true)]
@@ -438,6 +448,11 @@ pub(crate) enum Command {
         /// Print an example spec file and exit.
         #[arg(long, conflicts_with_all = ["spec", "prune", "dry_run", "invite_missing"])]
         example: bool,
+        /// Emit machine-readable JSON instead of styled text. What a provisioner
+        /// reads: the networks touched, role coverage, the missing hosts and any
+        /// invite codes minted for them.
+        #[arg(long, global = true)]
+        json: bool,
     },
     /// Change your hostname on a network
     Hostname {
@@ -604,6 +619,12 @@ pub(crate) enum InviteAction {
         /// `ray invite <net> revoke <id>`.
         #[arg(long)]
         reusable: bool,
+        /// Role to assign every node redeeming this code (repeatable). Firewall
+        /// rules target `role:<name>`, so one reusable key seats a whole
+        /// autoscaling group with the right policy. Unlike --hostname this is
+        /// allowed on a reusable key.
+        #[arg(long = "role")]
+        roles: Vec<String>,
         /// Also render the invite as a scannable QR code (off by default, it
         /// takes up a lot of terminal space).
         #[arg(long)]
@@ -707,6 +728,10 @@ pub(crate) enum RequestsAction {
         /// Short id of the pending peer (from `ray requests <network>`)
         #[arg(add = complete::join_requests())]
         id: String,
+        /// Role to assign on approval (repeatable). A live approval has no code
+        /// to read roles off, so name them here.
+        #[arg(long = "role")]
+        roles: Vec<String>,
     },
     /// Reject a peer waiting for approval
     Deny {
@@ -1405,14 +1430,18 @@ async fn run() -> Result<()> {
             tor,
             auto_accept_firewall,
             no_auto_accept_files,
+            roles,
         } => {
             ipc_join(
                 &network_key,
                 name.as_deref(),
-                hostname,
-                tor,
-                auto_accept_firewall,
-                !no_auto_accept_files,
+                JoinArgs {
+                    hostname,
+                    tor,
+                    auto_accept_firewall,
+                    auto_accept_files: !no_auto_accept_files,
+                    roles,
+                },
             )
             .await
         }
@@ -1454,10 +1483,12 @@ async fn run() -> Result<()> {
             json: _,
         } => match action {
             None => ipc_requests(&network).await,
-            Some(RequestsAction::Accept { id }) => ipc_accept_request(&network, &id).await,
+            Some(RequestsAction::Accept { id, roles }) => {
+                ipc_accept_request(&network, &id, roles).await
+            }
             Some(RequestsAction::Deny { id }) => ipc_deny_request(&network, &id).await,
         },
-        Command::Accept { network, id } => ipc_accept_request(&network, &id).await,
+        Command::Accept { network, id, roles } => ipc_accept_request(&network, &id, roles).await,
         Command::Deny { network, id } => ipc_deny_request(&network, &id).await,
         // An action is a request-queue verb, a bare contact id dials that peer,
         // and with neither, show the queue, the same as `ray connections` did.
@@ -1499,6 +1530,7 @@ async fn run() -> Result<()> {
             dry_run,
             invite_missing,
             example,
+            json: _,
         } => ipc_apply(spec, prune, dry_run, invite_missing, example).await,
         Command::Hostname { network, name } => ipc_set_hostname(&network, &name).await,
         Command::Identityof {

--- a/src/membership.rs
+++ b/src/membership.rs
@@ -168,6 +168,20 @@ pub struct Member {
     /// family's traffic and have nowhere to send it. Without this that failure is
     /// a silent black hole, since nothing else on the roster says which families a
     /// gateway can egress. See [`ExitFamilies`] for why it is three-valued.
+    #[serde(default)]
+    pub exit_families: ExitFamilies,
+    /// Roles the coordinator assigned this member, the selector a suggested
+    /// firewall rule uses when it targets a class of nodes (`role:sentry`)
+    /// rather than one machine. Empty for a member admitted without any.
+    ///
+    /// Assigned from the redeemed join key, never from anything the joiner says
+    /// about itself (see [`crate::roles`]), so unlike [`Self::hostname`] on an
+    /// unbound invite this cannot be self-claimed. That is what lets a rule key
+    /// on it safely.
+    ///
+    /// A [`BTreeSet`] because it sorts: `canonical_group_bytes` hashes this, so
+    /// two coordinators assigning the same roles in different orders must
+    /// produce the same blob.
     ///
     /// **Last on purpose.** The wire is positional, so a field's declaration order
     /// *is* the wire format: appending is what makes an older build's shorter array
@@ -176,7 +190,7 @@ pub struct Member {
     /// only when the two happen to differ in type and decodes clean and wrong when
     /// they do not.
     #[serde(default)]
-    pub exit_families: ExitFamilies,
+    pub roles: BTreeSet<String>,
 }
 
 impl Member {
@@ -284,6 +298,11 @@ pub struct ApprovedEntry {
     pub user_identity: Option<EndpointId>,
     #[serde(default)]
     pub device_cert: Option<DeviceCert>,
+    /// Roles to assign when this peer connects, so an approval made before the
+    /// peer arrives carries the same authority a redeemed key would. Appended
+    /// last for the reason spelled out on [`Member::roles`].
+    #[serde(default)]
+    pub roles: BTreeSet<String>,
 }
 
 /// Pre-approved peers that the coordinator has broadcast but that haven't
@@ -312,6 +331,13 @@ impl ApprovedList {
 
     pub fn is_approved(&self, identity: &EndpointId) -> bool {
         self.entries.contains_key(identity)
+    }
+
+    /// The approval recorded for `identity`, if any. Admission reads the roles
+    /// off it so a peer approved before it connected is seated with the same
+    /// authority a redeemed key would have given it.
+    pub fn get(&self, identity: &EndpointId) -> Option<&ApprovedEntry> {
+        self.entries.get(identity)
     }
 
     pub fn remove(&mut self, identity: &EndpointId) -> Option<ApprovedEntry> {
@@ -402,6 +428,15 @@ pub struct ReusableKey {
     pub expires: u64,
     /// Set by `ray invite revoke`; a revoked key admits no one.
     pub revoked: bool,
+    /// Roles this key grants. Every node redeeming it is assigned these (or the
+    /// subset it asks for with `ray join --role`), which is what lets one key in
+    /// a Terraform user-data block admit a whole autoscaling group as sentries.
+    ///
+    /// A reusable key may bind roles even though it may not bind a hostname: a
+    /// hostname is unique per node and a role is deliberately not, so a shared
+    /// key can carry one and not the other. Appended last, see [`Member::roles`].
+    #[serde(default)]
+    pub roles: BTreeSet<String>,
 }
 
 /// The single authoritative blob for a network, published by the coordinator.
@@ -438,7 +473,14 @@ impl ReusableKey {
     /// Build a reusable key from a freshly generated secret. Returns the map key
     /// (hex `blake3(secret)`) and the entry. `created`/`ttl_secs` are Unix seconds;
     /// the raw secret is the caller's to encode into the join code and discard.
-    pub fn from_secret(secret: &[u8], created: u64, ttl_secs: u64) -> (String, ReusableKey) {
+    /// `roles` is what every node redeeming this key is assigned; already
+    /// validated and canonicalized by [`crate::roles::normalize`].
+    pub fn from_secret(
+        secret: &[u8],
+        created: u64,
+        ttl_secs: u64,
+        roles: BTreeSet<String>,
+    ) -> (String, ReusableKey) {
         let hash = blake3::hash(secret).to_hex().to_string();
         let id = hash[..8].to_string();
         (
@@ -448,6 +490,7 @@ impl ReusableKey {
                 created,
                 expires: created.saturating_add(ttl_secs),
                 revoked: false,
+                roles,
             },
         )
     }
@@ -650,6 +693,21 @@ mod tests {
         }
     }
 
+    /// A plain roster entry, for tests that only care about one field.
+    fn test_member(n: u8) -> Member {
+        Member {
+            identity: test_id(n),
+            is_coordinator: false,
+            hostname: None,
+            user_identity: None,
+            device_cert: None,
+            last_seen: None,
+            exit_node: false,
+            exit_families: ExitFamilies::Unknown,
+            roles: BTreeSet::new(),
+        }
+    }
+
     #[test]
     fn test_derive_ipv6_different_identities_differ() {
         let a = derive_ipv6(&test_id(1));
@@ -684,6 +742,7 @@ mod tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         };
         list.add(member.clone());
         assert!(list.is_member(&id));
@@ -703,6 +762,7 @@ mod tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         });
         list.add(Member {
             identity: id,
@@ -713,6 +773,7 @@ mod tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         });
         assert!(list.get(&id).unwrap().is_coordinator);
     }
@@ -730,6 +791,7 @@ mod tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         });
         let removed = list.remove(&id);
         assert!(removed.is_some());
@@ -749,6 +811,7 @@ mod tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         });
         list.add(Member {
             identity: test_id(2),
@@ -759,6 +822,7 @@ mod tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         });
         assert_eq!(list.all().len(), 2);
     }
@@ -772,6 +836,7 @@ mod tests {
             hostname: None,
             user_identity: None,
             device_cert: None,
+            roles: Default::default(),
         };
         list.approve(entry);
         assert!(list.is_approved(&id));
@@ -787,12 +852,14 @@ mod tests {
             hostname: None,
             user_identity: None,
             device_cert: None,
+            roles: Default::default(),
         });
         approved.approve(ApprovedEntry {
             identity: id,
             hostname: None,
             user_identity: None,
             device_cert: None,
+            roles: Default::default(),
         });
         assert_eq!(approved.all().len(), 1);
     }
@@ -806,6 +873,7 @@ mod tests {
             hostname: None,
             user_identity: None,
             device_cert: None,
+            roles: Default::default(),
         });
         let removed = approved.remove(&id);
         assert!(removed.is_some());
@@ -820,12 +888,14 @@ mod tests {
                 hostname: None,
                 user_identity: None,
                 device_cert: None,
+                roles: Default::default(),
             },
             ApprovedEntry {
                 identity: test_id(2),
                 hostname: None,
                 user_identity: None,
                 device_cert: None,
+                roles: Default::default(),
             },
         ];
         let list = ApprovedList::from_entries(entries);
@@ -849,6 +919,7 @@ mod tests {
                 last_seen: None,
                 exit_node: false,
                 exit_families: ExitFamilies::Unknown,
+                roles: Default::default(),
             });
         }
         list
@@ -869,6 +940,7 @@ mod tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         });
 
         // Mesh IPv6 literal -> the member's device id.
@@ -966,6 +1038,7 @@ mod tests {
             hostname: None,
             user_identity: None,
             device_cert: None,
+            roles: Default::default(),
         });
 
         let bytes = canonical_group_bytes(
@@ -1057,6 +1130,7 @@ mod tests {
             last_seen: Some(12345),
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         });
         let approved = ApprovedList::new();
         let sf = ray_proto::SuggestedFirewall::default();
@@ -1096,6 +1170,7 @@ mod tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         });
         let approved = ApprovedList::new();
         let sf = ray_proto::SuggestedFirewall::default();
@@ -1332,6 +1407,7 @@ mod tests {
                     1 => ExitFamilies::Dual,
                     _ => ExitFamilies::Unknown,
                 },
+                roles: Default::default(),
             });
             released.push(ReleasedMember {
                 identity: id,
@@ -1502,6 +1578,7 @@ mod tests {
             last_seen: None,
             exit_node: true,
             exit_families: ExitFamilies::Dual,
+            roles: Default::default(),
         })
         .unwrap();
 
@@ -1564,6 +1641,7 @@ mod tests {
                 created: 0,
                 expires,
                 revoked,
+                roles: Default::default(),
             },
         )
     }
@@ -1655,10 +1733,61 @@ mod tests {
         assert!(blob.nullifiers.is_empty());
     }
 
+    /// Roles ride the signed blob, so they must survive the array encoding the
+    /// hash is taken over.
+    #[test]
+    fn member_roles_survive_the_blob_round_trip() {
+        let roles: BTreeSet<String> = ["eu".to_string(), "sentry".to_string()].into();
+        let mut member = test_member(1);
+        member.roles = roles.clone();
+        let mut members = MemberList::new();
+        members.add(member);
+        let bytes = canonical_group_bytes(
+            &members,
+            &ApprovedList::new(),
+            &SuggestedFirewall::new(),
+            None,
+            &BTreeMap::new(),
+            &BTreeSet::new(),
+        );
+        let decoded: GroupBlob = rmp_serde::from_slice(&bytes).expect("decode blob");
+        assert_eq!(decoded.members[0].roles, roles);
+    }
+
+    /// The hash has to be independent of the order roles were assigned in, or
+    /// two coordinators with the same intent would fight over the blob.
+    #[test]
+    fn role_order_does_not_change_the_blob_hash() {
+        let bytes_for = |names: [&str; 2]| {
+            let mut member = test_member(1);
+            member.roles = names.iter().map(|s| s.to_string()).collect();
+            let mut members = MemberList::new();
+            members.add(member);
+            canonical_group_bytes(
+                &members,
+                &ApprovedList::new(),
+                &SuggestedFirewall::new(),
+                None,
+                &BTreeMap::new(),
+                &BTreeSet::new(),
+            )
+        };
+        assert_eq!(bytes_for(["sentry", "eu"]), bytes_for(["eu", "sentry"]));
+    }
+
+    /// A reusable key carries the roles it grants; that is what lets one code in
+    /// a user-data block seat a whole group.
+    #[test]
+    fn a_reusable_key_carries_its_roles() {
+        let roles: BTreeSet<String> = ["sentry".to_string()].into();
+        let (_hash, key) = ReusableKey::from_secret(&[7u8; 16], 0, 100, roles.clone());
+        assert_eq!(key.roles, roles);
+    }
+
     #[test]
     fn reusable_key_from_secret_sets_id_and_expiry() {
         let secret = [5u8; 16];
-        let (hash, key) = ReusableKey::from_secret(&secret, 100, 50);
+        let (hash, key) = ReusableKey::from_secret(&secret, 100, 50, Default::default());
         assert_eq!(hash, blake3::hash(&secret).to_hex().to_string());
         assert_eq!(key.id, hash[..8]);
         assert_eq!(key.created, 100);
@@ -1669,7 +1798,7 @@ mod tests {
     #[test]
     fn revoke_reusable_by_full_id_and_prefix() {
         let secret = [6u8; 16];
-        let (hash, key) = ReusableKey::from_secret(&secret, 0, 100);
+        let (hash, key) = ReusableKey::from_secret(&secret, 0, 100, Default::default());
         let mut keys = BTreeMap::new();
         keys.insert(hash.clone(), key.clone());
         // Full id.
@@ -1694,6 +1823,7 @@ mod tests {
                 created: 0,
                 expires: 100,
                 revoked: false,
+                roles: Default::default(),
             },
         );
         keys.insert(
@@ -1703,6 +1833,7 @@ mod tests {
                 created: 0,
                 expires: 100,
                 revoked: false,
+                roles: Default::default(),
             },
         );
         assert!(
@@ -1752,6 +1883,7 @@ mod tests {
             last_seen: None,
             exit_node: false,
             exit_families: ExitFamilies::Unknown,
+            roles: Default::default(),
         });
         mark_coordinator(&mut list, &id);
         assert!(list.get(&id).unwrap().is_coordinator);

--- a/src/roles.rs
+++ b/src/roles.rs
@@ -1,0 +1,245 @@
+//! Coordinator-assigned roles: the label a firewall rule targets when it means
+//! a *class* of nodes rather than one machine.
+//!
+//! A hostname names exactly one node, so a suggested-firewall subject keyed by
+//! hostname can never say "every sentry". Enumerating the class instead (a
+//! `groups:` list in a `ray apply` spec) is expanded on the admin's machine
+//! before publishing, so a node that joins later is not covered until someone
+//! re-runs `ray apply`.
+//!
+//! A role fixes both. It rides the *reusable* join key, so one key minted with
+//! `create --role sentry` admits a whole autoscaling group, and it is stored on the
+//! member in the signed blob, so [`crate::firewall::materialize_suggestions`]
+//! resolves it on every node at every blob update. Scaling the fleet needs no
+//! re-apply.
+//!
+//! **A role is never a self-claim.** The coordinator takes it from the redeemed
+//! key, exactly as it takes an authoritative hostname from an invite binding;
+//! `ray join --role` only *requests* a subset of what the key already permits.
+//! That is what makes a role-keyed rule safe in a way a rule keyed on a
+//! self-chosen hostname is not: an unbound invite takes the joiner's own
+//! `--hostname` at face value (see [`crate::invite::Invite::hostname`]).
+
+use std::collections::BTreeSet;
+
+use anyhow::{Result, bail};
+
+/// Most roles one key or member may carry. The coordinator assigns them, so
+/// this bounds how much a single mint can add to the signed blob.
+pub const MAX_ROLES: usize = 8;
+
+/// Longest role name. Long enough for `nonvalidating-sentry`, short enough that
+/// [`MAX_ROLES`] of them stay negligible on the wire.
+pub const MAX_ROLE_LEN: usize = 32;
+
+/// Check one role name: 1..=[`MAX_ROLE_LEN`] chars of `[a-z0-9-]`, starting
+/// alphanumeric.
+///
+/// Lowercase-only is not cosmetic. The `config` crate lowercases every key it
+/// parses, so a spec written as `role:Sentry` arrives as `role:sentry`; if a
+/// role could be minted with capitals it would silently never match its own
+/// rule. [`normalize`] lowercases first so both sides meet in the same case.
+///
+/// `:` is rejected along with everything else outside the set, which is what
+/// stops a role named `role:sentry` from nesting the
+/// [`ray_proto::policy::ROLE_PREFIX`] inside itself.
+pub fn validate_role(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("a role name cannot be empty");
+    }
+    if name.len() > MAX_ROLE_LEN {
+        bail!(
+            "role '{name}' is {} chars; the limit is {MAX_ROLE_LEN}",
+            name.len()
+        );
+    }
+    if !name.starts_with(|c: char| c.is_ascii_lowercase() || c.is_ascii_digit()) {
+        bail!("role '{name}' must start with a lowercase letter or digit");
+    }
+    if let Some(bad) = name
+        .chars()
+        .find(|c| !(c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '-'))
+    {
+        bail!("role '{name}' contains '{bad}'; use lowercase letters, digits and '-'");
+    }
+    Ok(())
+}
+
+/// Lowercase, validate and dedupe a list of role names into the canonical set
+/// stored on a key or member. A [`BTreeSet`] sorts, which keeps
+/// `canonical_group_bytes` canonical: two mints listing the same roles in
+/// different orders hash to the same blob.
+pub fn normalize(names: &[String]) -> Result<BTreeSet<String>> {
+    let mut out = BTreeSet::new();
+    for raw in names {
+        let name = raw.trim().to_ascii_lowercase();
+        validate_role(&name)?;
+        out.insert(name);
+    }
+    if out.len() > MAX_ROLES {
+        bail!("{} roles given; the limit is {MAX_ROLES}", out.len());
+    }
+    Ok(out)
+}
+
+/// Narrow the roles a redeemed credential permits to the subset the joiner
+/// asked for.
+///
+/// An empty request means "everything the key carries", which is the common
+/// case: Terraform bakes one `--role sentry` key into user-data and the
+/// instances run a bare `ray join <code>`. A request naming anything the key
+/// does not permit is an **error**, not a silent trim: a provisioner that asks
+/// for `validator` on a sentry key has a bug, and seating it quietly as a
+/// sentry would hide that until someone wondered why the firewall never opened.
+pub fn grant(
+    permitted: &BTreeSet<String>,
+    requested: &BTreeSet<String>,
+) -> Result<BTreeSet<String>> {
+    if requested.is_empty() {
+        return Ok(permitted.clone());
+    }
+    let outside: Vec<&str> = requested
+        .difference(permitted)
+        .map(String::as_str)
+        .collect();
+    if !outside.is_empty() {
+        bail!(
+            "this key does not grant {}; it grants {}",
+            outside.join(", "),
+            render(permitted)
+        );
+    }
+    Ok(requested.clone())
+}
+
+/// Render a role set for a human: `sentry, eu` (empty reads as `-`).
+pub fn render(roles: &BTreeSet<String>) -> String {
+    if roles.is_empty() {
+        return "-".to_string();
+    }
+    roles.iter().cloned().collect::<Vec<_>>().join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_names_validate() {
+        for ok in ["sentry", "validator", "non-validating", "s3", "a"] {
+            assert!(validate_role(ok).is_ok(), "{ok} should validate");
+        }
+    }
+
+    #[test]
+    fn bad_names_are_rejected() {
+        for bad in ["", "-lead", "Sentry", "role:sentry", "a b", "sen_try", "é"] {
+            assert!(validate_role(bad).is_err(), "{bad:?} should not validate");
+        }
+    }
+
+    #[test]
+    fn a_name_at_the_limit_passes_and_one_over_fails() {
+        let at = "a".repeat(MAX_ROLE_LEN);
+        let over = "a".repeat(MAX_ROLE_LEN + 1);
+        assert!(validate_role(&at).is_ok());
+        assert!(validate_role(&over).is_err());
+    }
+
+    /// The spec side is lowercased by the `config` crate, so the mint side has
+    /// to meet it there or a `--role Sentry` key would never match its rule.
+    #[test]
+    fn normalize_lowercases_trims_and_dedupes() {
+        let got = normalize(&[
+            "Sentry".to_string(),
+            " sentry ".to_string(),
+            "EU".to_string(),
+        ])
+        .unwrap();
+        assert_eq!(
+            got,
+            ["eu".to_string(), "sentry".to_string()]
+                .into_iter()
+                .collect::<BTreeSet<_>>()
+        );
+    }
+
+    /// Ordering must not reach the blob: the set sorts, so two mints listing the
+    /// same roles differently produce identical canonical bytes.
+    #[test]
+    fn normalize_is_order_independent() {
+        let a = normalize(&["sentry".to_string(), "eu".to_string()]).unwrap();
+        let b = normalize(&["eu".to_string(), "sentry".to_string()]).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn too_many_roles_is_rejected() {
+        let many: Vec<String> = (0..=MAX_ROLES).map(|i| format!("r{i}")).collect();
+        assert!(normalize(&many).is_err());
+        let just_enough: Vec<String> = (0..MAX_ROLES).map(|i| format!("r{i}")).collect();
+        assert!(normalize(&just_enough).is_ok());
+    }
+
+    /// Dedupe happens before the count check, so a repeated role is not a way to
+    /// trip the limit.
+    #[test]
+    fn duplicates_do_not_count_towards_the_limit() {
+        let dupes: Vec<String> = std::iter::repeat_n("sentry".to_string(), MAX_ROLES + 4).collect();
+        assert_eq!(normalize(&dupes).unwrap().len(), 1);
+    }
+
+    fn set(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// The Terraform shape: one key, a bare `ray join`, every instance seated
+    /// with everything the key carries.
+    #[test]
+    fn an_empty_request_takes_the_whole_key() {
+        let permitted = set(&["sentry", "eu"]);
+        assert_eq!(grant(&permitted, &BTreeSet::new()).unwrap(), permitted);
+    }
+
+    #[test]
+    fn a_subset_request_narrows_the_grant() {
+        let permitted = set(&["sentry", "eu"]);
+        assert_eq!(
+            grant(&permitted, &set(&["sentry"])).unwrap(),
+            set(&["sentry"])
+        );
+    }
+
+    /// The property the whole design rests on: asking for a role the key does
+    /// not carry fails the join instead of granting it.
+    #[test]
+    fn a_role_outside_the_key_is_refused() {
+        let err = grant(&set(&["sentry"]), &set(&["validator"])).unwrap_err();
+        assert!(err.to_string().contains("validator"), "{err}");
+    }
+
+    /// Refused as a whole, not trimmed to the permitted part: a half-granted
+    /// join would look like it worked.
+    #[test]
+    fn a_partly_permitted_request_is_refused_entirely() {
+        assert!(grant(&set(&["sentry"]), &set(&["sentry", "validator"])).is_err());
+    }
+
+    /// A key with no roles grants none, and cannot be talked into any.
+    #[test]
+    fn a_key_without_roles_grants_nothing() {
+        assert!(
+            grant(&BTreeSet::new(), &BTreeSet::new())
+                .unwrap()
+                .is_empty()
+        );
+        assert!(grant(&BTreeSet::new(), &set(&["sentry"])).is_err());
+    }
+
+    #[test]
+    fn render_reads_as_a_list() {
+        assert_eq!(render(&BTreeSet::new()), "-");
+        let roles: BTreeSet<String> = ["sentry".to_string(), "eu".to_string()].into();
+        assert_eq!(render(&roles), "eu, sentry");
+    }
+}

--- a/src/roles.rs
+++ b/src/roles.rs
@@ -35,10 +35,13 @@ pub const MAX_ROLE_LEN: usize = 32;
 /// Check one role name: 1..=[`MAX_ROLE_LEN`] chars of `[a-z0-9-]`, starting
 /// alphanumeric.
 ///
-/// Lowercase-only is not cosmetic. The `config` crate lowercases every key it
-/// parses, so a spec written as `role:Sentry` arrives as `role:sentry`; if a
-/// role could be minted with capitals it would silently never match its own
-/// rule. [`normalize`] lowercases first so both sides meet in the same case.
+/// Lowercase-only is not cosmetic. A `role:` selector in a `ray apply` spec is
+/// compared byte for byte against these names, and the `config` crate preserves
+/// the case its keys were written in, so nothing folds the two sides together on
+/// its own: a role minted with capitals would silently never match its own rule.
+/// [`normalize`] lowercases what the CLI hands in, and `apply::validate_names`
+/// rejects a spec key that is not already canonical, so both sides meet in the
+/// same case.
 ///
 /// `:` is rejected along with everything else outside the set, which is what
 /// stops a role named `role:sentry` from nesting the
@@ -80,6 +83,18 @@ pub fn normalize(names: &[String]) -> Result<BTreeSet<String>> {
         bail!("{} roles given; the limit is {MAX_ROLES}", out.len());
     }
     Ok(out)
+}
+
+/// Canonicalize a role set that arrived over the wire.
+///
+/// The joiner normalizes what it asks for before sending, but an older or
+/// hand-rolled client need not have, and [`grant`] compares by exact set
+/// difference: an un-normalized `Sentry` reads as outside a key that grants
+/// `sentry` and fails the join for no reason the operator can see. A name that
+/// is still not a role after trimming and lowercasing is an error, so a
+/// malformed request is refused rather than quietly dropped.
+pub fn canonicalize(roles: &BTreeSet<String>) -> Result<BTreeSet<String>> {
+    normalize(&roles.iter().cloned().collect::<Vec<_>>())
 }
 
 /// Narrow the roles a redeemed credential permits to the subset the joiner
@@ -146,8 +161,10 @@ mod tests {
         assert!(validate_role(&over).is_err());
     }
 
-    /// The spec side is lowercased by the `config` crate, so the mint side has
-    /// to meet it there or a `--role Sentry` key would never match its rule.
+    /// The mint side takes free-form CLI input, so it canonicalizes; the spec
+    /// side is validated to be canonical already (`apply::validate_role_key`).
+    /// Both land on the same name or a `--role Sentry` key would never match
+    /// its rule.
     #[test]
     fn normalize_lowercases_trims_and_dedupes() {
         let got = normalize(&[
@@ -234,6 +251,21 @@ mod tests {
                 .is_empty()
         );
         assert!(grant(&BTreeSet::new(), &set(&["sentry"])).is_err());
+    }
+
+    /// The join path's half of the case rule: a key minted `--role Sentry` is
+    /// stored as `sentry`, so a request spelled `Sentry` has to land there too
+    /// or `grant` refuses a role the key actually carries.
+    #[test]
+    fn canonicalize_matches_what_the_mint_stored() {
+        let permitted = normalize(&["Sentry".to_string()]).unwrap();
+        let requested = canonicalize(&set(&["Sentry"])).unwrap();
+        assert_eq!(grant(&permitted, &requested).unwrap(), set(&["sentry"]));
+    }
+
+    #[test]
+    fn canonicalize_rejects_a_name_that_is_not_a_role() {
+        assert!(canonicalize(&set(&["not a role"])).is_err());
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -78,7 +78,7 @@ pub const RAYFISH_LISTEN_PORT: u16 = 41383;
 /// Compact gave that up. Bump for anything that changes a struct's shape, and
 /// for anything an old peer would *misinterpret* (removed or repurposed fields
 /// and variants, changed semantics of existing ones).
-pub const MESH_PROTOCOL_VERSION: u32 = 5;
+pub const MESH_PROTOCOL_VERSION: u32 = 6;
 
 /// Capability bits a peer advertises in its `MeshHello.features`. These are
 /// negotiated *inside* the single mesh ALPN, so adding one needs no version bump:

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -9,6 +9,7 @@
 #   firewall      3-peer suggested-firewall + rule matrix (tests/e2e/firewall)
 #   closed-net    3-peer admission + lifecycle commands (tests/e2e/closed-net)
 #   apply         3-peer declarative `ray apply` deploy       (tests/e2e/apply)
+#   roles         3-peer coordinator-assigned roles           (tests/e2e/roles)
 #   dns           2-peer Magic DNS resolution + resolv.conf takeover (tests/e2e/dns)
 #   ssh           2-peer mesh SSH (`ray firewall ssh`) allow/deny matrix (tests/e2e/ssh)
 #   v4bridge      2-peer IPv4-only listener bridge over the mesh (tests/e2e/v4bridge)
@@ -48,7 +49,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # variable would silently drop back to digitalocean halfway through.
 export E2E_BACKEND="${E2E_BACKEND:-digitalocean}"
 
-usage(){ sed -n '2,36p' "$0" | sed 's/^#\( \|$\)//'; exit "${1:-0}"; }
+usage(){ sed -n '2,37p' "$0" | sed 's/^#\( \|$\)//'; exit "${1:-0}"; }
 
 # Scenarios the docker backend cannot run faithfully (see tests/e2e/README.md).
 DOCKER_UNSUPPORTED=(exit-node reliability bench)
@@ -78,6 +79,9 @@ scenario_meta(){
                  LABELS=(srv-a srv-b srv-c) ;;
     apply)       DIR="$ROOT/tests/e2e/apply"
                  NAMES=(rayfish-apply-a rayfish-apply-b rayfish-apply-c)
+                 LABELS=(srv-a srv-b srv-c) ;;
+    roles)       DIR="$ROOT/tests/e2e/roles"
+                 NAMES=(rayfish-roles-a rayfish-roles-b rayfish-roles-c)
                  LABELS=(srv-a srv-b srv-c) ;;
     dns)         DIR="$ROOT/tests/e2e/dns"
                  NAMES=(rayfish-dns-a rayfish-dns-b)
@@ -118,7 +122,7 @@ case "$scenario" in -h|--help|help|"") usage 0 ;; esac
 # dispatcher per scenario (provision-if-needed + run, then teardown). Prints a
 # pass/fail summary and exits non-zero if any scenario failed.
 if [[ "$scenario" == all ]]; then
-  all_scenarios=(device-cert connect firewall closed-net apply dns ssh v4bridge reliability restore-offline unpair churn exit-node)
+  all_scenarios=(device-cert connect firewall closed-net apply roles dns ssh v4bridge reliability restore-offline unpair churn exit-node)
   passed=(); failed=(); skipped=()
   hint="check 'doctl compute droplet list'"
   [[ "$E2E_BACKEND" == "docker" ]] && hint="check 'docker ps -a'"

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -18,6 +18,7 @@ DigitalOcean droplets (the default) and local Docker containers
 | [`firewall/`](firewall) | 3 | The coordinator suggested-firewall pipeline (`suggest` → `pending`/`accept`, `auto-accept`, additive whitelist vs blacklist) and the per-packet rule matrix (UDP, port ranges, same-selector replace, `--network` scoping) over a real TUN. |
 | [`closed-net/`](closed-net) | 3 | Closed-net admission + lifecycle commands: live approval (`requests`/`accept`/`deny`), co-coordinator (`admin add`) gatekeeper resilience with a reusable key, `ray hostname` + magic-DNS, `ray leave`/`nuke`, and a `ray apply` smoke. |
 | [`apply/`](apply) | 3 | Declarative `ray apply` deploy end to end: create-if-absent + membership-gap diff, `--invite-missing`, `ray identityof`, alias/group expansion (`--dry-run`), real suggestion publish + data-plane enforcement, and `--prune`. |
+| [`roles/`](roles) | 3 | Coordinator-assigned roles: one reusable `--role` key seats two nodes, a `role:` subject/peer resolves against the signed roster, a third node joining later is covered with **no** second `ray apply`, and a `--role` outside the key's grant refuses the join. |
 | [`dns/`](dns) | 2 | Magic DNS resolution over a real TUN: `<host>.<net>.ray` resolves via the system resolver, drives reachability, no host `:53` bind, non-`.ray` passthrough, and `ray down` revert. |
 | [`ssh/`](ssh) | 2 | Mesh SSH (`ray firewall ssh`): the allow/deny matrix over the TUN, so an SSH grant is a firewall rule and not a separate door. |
 | [`v4bridge/`](v4bridge) | 2 | A service listening on `0.0.0.0` answers over the IPv6-only mesh: the payload path by IP and by `.ray` name, the firewall still upstream of the bridge, loopback-only services declined, no bind/unbind flap across rescans, the setting + data-plane lifetime, and a new listener picked up from a kernel event rather than a timer (droplets only, see the scenario README). |
@@ -36,7 +37,7 @@ tests/e2e.sh <scenario> teardown    # destroy the instances (manual)
 ```
 
 where `<scenario>` is `device-cert`, `connect`, `firewall`, `closed-net`,
-`apply`, `dns`, `ssh`, `reliability`, `restore-offline`, `unpair`, `churn`,
+`apply`, `roles`, `dns`, `ssh`, `reliability`, `restore-offline`, `unpair`, `churn`,
 `exit-node`, `all`, or `bench` (run `tests/e2e.sh` with no scenario for usage). The per-scenario run steps live in `<dir>/run.sh`
 (still runnable directly once `.servers` exists); the fleet definitions and the
 provision/teardown/assert bodies are shared in [`../lib/`](../lib).

--- a/tests/e2e/apply/run.sh
+++ b/tests/e2e/apply/run.sh
@@ -75,9 +75,9 @@ echo "$APPLY1" | grep -qi 'creating closed network' \
 has_net "$A" "$NET" && pass "'$NET' now present on srv-a" || fail "'$NET' missing on srv-a after apply"
 echo "$APPLY1" | grep -qi 'Missing hosts' \
   && pass "apply reported a membership gap" || fail "no membership gap reported"
-echo "$APPLY1" | grep -q "ray invite $NET --hostname srv-b" \
+echo "$APPLY1" | grep -q "ray invite $NET create --hostname srv-b" \
   && pass "gap lists an invite command for srv-b" || fail "srv-b not in the gap"
-echo "$APPLY1" | grep -q "ray invite $NET --hostname srv-c" \
+echo "$APPLY1" | grep -q "ray invite $NET create --hostname srv-c" \
   && pass "gap lists an invite command for srv-c" || fail "srv-c not in the gap"
 # apply never joins — the members must not have the network yet.
 ! has_net "$B" "$NET" && ! has_net "$C" "$NET" \

--- a/tests/e2e/roles/README.md
+++ b/tests/e2e/roles/README.md
@@ -1,0 +1,43 @@
+# roles
+
+Three hosts. Proves the one thing a hostname-keyed rule cannot do: cover a class
+of nodes whose size changes.
+
+| Host | Part |
+|------|------|
+| `srv-a` | coordinator, `ray apply` driver, the validator the rule protects |
+| `srv-b` | sentry, joined with a reusable `--role sentry` key |
+| `srv-c` | sentry, joined with the **same** key |
+
+A hostname names one machine, and a reusable key refuses to bind one precisely
+because it admits many. A role is shared by a class on purpose, so it can ride
+that key: one code in a machine image or Terraform user-data seats the whole
+group.
+
+What each step asserts:
+
+1. A `role:` spec publishes against an empty network. The role is reported as
+   covering nobody rather than as a host that failed to turn up, and it never
+   appears in the `--invite-missing` gap: there is no single machine to bind an
+   invite to.
+2. `--hostname` is still refused on a reusable key; `--role` is not. Both
+   members redeem the same code and land under distinct names.
+3. The roster carries the role. The coordinator wrote it from the redeemed key,
+   so it is not something either node claimed about itself.
+4. **The scale-out property.** The suggestion published in step 1 named no
+   members. Two rules exist now, one per sentry, and nothing was applied in
+   between: each node re-resolved `role:sentry` against the roster when it
+   changed.
+5. The resolved allow opens tcp:4000 over the TUN, and an un-listed port stays
+   shut, so this is a real rule and not a display artefact.
+6. `ray join --role validator` on a sentry key is refused, and says why. A role
+   request can only ever narrow what the credential grants.
+7. Re-joining with the granted role puts the rule count back, again with no
+   apply.
+
+Run it:
+
+```bash
+tests/e2e.sh roles                    # droplets
+E2E_BACKEND=docker tests/e2e.sh roles # local containers
+```

--- a/tests/e2e/roles/run.sh
+++ b/tests/e2e/roles/run.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Coordinator-assigned roles e2e test orchestrator.
+#
+# Topology:
+#   srv-a  coordinator + apply driver (closed network `hyperliquid`)
+#   srv-b  sentry  (joined with the reusable --role sentry key)
+#   srv-c  sentry  (joined with the SAME key, to prove one key seats a group)
+#
+# The point of roles is that a rule names a class of nodes, not one machine, so
+# what this proves is the scale-out property a hostname cannot give:
+#   - a reusable key may bind roles where it may not bind a hostname
+#   - two nodes redeem the *same* code and are both seated as sentries
+#   - a `role:` subject/peer resolves against the signed roster on each node
+#   - a third sentry joining later is covered with NO second `ray apply`
+#   - `--role` outside what the key grants refuses the join
+#   - the resolved allow actually opens the port over the TUN
+#
+# Reads tests/e2e/roles/.servers (written by provision). Does NOT modify infra.
+# Re-runnable (resets rayfish state each run unless KEEP_STATE=1).
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/../../.." && pwd)"
+SERVERS="$DIR/.servers"
+# shellcheck source=../../lib/common.sh
+source "$ROOT/tests/lib/common.sh"
+
+[[ -f "$SERVERS" ]] || { echo "No $SERVERS — run provision first"; exit 1; }
+
+A="$(server_ip "$SERVERS" srv-a || true)"
+B="$(server_ip "$SERVERS" srv-b || true)"
+C="$(server_ip "$SERVERS" srv-c || true)"
+[[ -n "$A" && -n "$B" && -n "$C" ]] || { echo "missing srv-a/b/c in $SERVERS"; exit 1; }
+
+NET=hyperliquid
+
+# roles_of <ip> <hostname> : the roles the roster shows for a peer, comma-joined.
+roles_of(){
+  on "$1" 'ray status --json' 2>/dev/null | jq -r --arg h "$2" --arg n "$NET" \
+    '[ .networks[]? | select(.name == $n) | .peers[]? | select(.hostname == $h)
+       | .roles[]? ] | sort | join(",")'
+}
+
+# sugg_tcp_allow <ip> <port> : installed suggested-by-$NET inbound tcp ALLOW
+# rules for <port>. One per resolved peer, so this counts role expansion.
+sugg_tcp_allow(){
+  on "$1" 'ray firewall show --json' 2>/dev/null | jq -r --arg p "$2" --arg n "$NET" \
+    '[ .rules[]? | select((.suggested_by // "") == $n and .action == "allow"
+        and (.protocol | ascii_downcase) == "tcp" and .port == $p) ] | length'
+}
+
+# ---------------------------------------------------------------------------
+step "0. wait for SSH + deploy on all hosts"
+wait_all_ssh "$A" "$B" "$C"
+seed_known_hosts "$A" "$B" "$C"
+reset_state "$A" "$B" "$C"
+deploy_all "$ROOT" "$A" "$B" "$C"
+# srv-a drives apply and is named as a literal subject, so pin its hostname.
+# srv-b/srv-c deliberately do NOT get a pinned name: a reusable key cannot bind
+# one, which is the whole reason policy keys on the role instead.
+on "$A" 'ray up --hostname srv-a' >/dev/null 2>&1 || true
+for h in "$B" "$C"; do on "$h" 'ray up' >/dev/null 2>&1 || true; done
+wait_daemons "$A" "$B" "$C"
+
+# ---------------------------------------------------------------------------
+step "1. apply publishes a role-keyed spec against an empty network"
+# srv-a is the validator; every sentry may reach tcp:4000 on it. No sentry has
+# joined yet, so this must publish cleanly and report the role as covering
+# nobody rather than treating `role:sentry` as a host that failed to turn up.
+on "$A" "printf 'networks:\n  $NET:\n    srv-a:\n      allows:\n        \"role:sentry\": \"tcp:4000\"\n' > /tmp/roles.yaml"
+APPLY1="$(on "$A" "ray apply /tmp/roles.yaml" 2>&1 | strip)"
+echo "$APPLY1" | sed 's/^/   a| /'
+echo "$APPLY1" | grep -qi 'creating closed network' \
+  && pass "apply created the closed network" || fail "apply did not create '$NET'"
+echo "$APPLY1" | grep -q 'role:sentry' \
+  && pass "apply reported the role it targets" || fail "role:sentry not reported"
+echo "$APPLY1" | grep -qi 'no members yet' \
+  && pass "role with no holders is called out" || fail "empty role not flagged"
+# A role is not a host, so it must never appear as a gap to mint an invite for.
+! echo "$APPLY1" | grep -q 'ray invite .* --hostname role:' \
+  && pass "role is not reported as a missing host" || fail "role leaked into the host gap"
+on "$A" "ray firewall auto-accept $NET on" >/dev/null 2>&1 || true
+
+# ---------------------------------------------------------------------------
+step "2. one reusable key carries a role and seats two nodes"
+# --hostname is refused on a reusable key; --role is not. That asymmetry is what
+# lets a single code sit in user-data and cover a whole group.
+HOSTBIND="$(on "$A" "ray invite $NET create --reusable --hostname sentry-01" 2>&1 | strip)"
+# Assert on the message, not just a non-zero exit: a mistyped flag also fails,
+# and would pass this check while testing nothing. clap rejects the pair before
+# the daemon sees it, which is the refusal arriving one layer earlier.
+echo "$HOSTBIND" | grep -qiE "cannot be used with|cannot bind a hostname" \
+  && pass "a reusable key still refuses --hostname" \
+  || fail "expected the hostname refusal, got: $HOSTBIND"
+MINT="$(on "$A" "ray invite $NET create --reusable --role sentry --json" 2>&1 | strip | tail -1)"
+echo "$MINT" | sed 's/^/   a| /'
+KEY="$(echo "$MINT" | jq -r '.code')"
+[[ -n "$KEY" && "$KEY" != null ]] \
+  && pass "minted a reusable sentry key" || { fail "could not mint/parse the role key"; summary; }
+[[ "$(echo "$MINT" | jq -r '.roles | join(",")')" == "sentry" ]] \
+  && pass "--json echoes the role the key grants" || fail "minted key did not report its role"
+
+# The same code on both hosts. This is the line a provisioner bakes into an image.
+on "$B" "ray join $KEY --auto-accept-firewall" 2>&1 | strip | sed 's/^/   b| /'
+on "$C" "ray join $KEY --auto-accept-firewall" 2>&1 | strip | sed 's/^/   c| /'
+B_HOST="$(on "$B" 'ray status --json' | jq -r --arg n "$NET" '.networks[]?|select(.name==$n)|.my_hostname')"
+C_HOST="$(on "$C" 'ray status --json' | jq -r --arg n "$NET" '.networks[]?|select(.name==$n)|.my_hostname')"
+[[ -n "$B_HOST" && -n "$C_HOST" && "$B_HOST" != "$C_HOST" ]] \
+  && pass "both nodes joined on one code, under distinct names ($B_HOST, $C_HOST)" \
+  || fail "the shared key did not seat two distinct members"
+
+# ---------------------------------------------------------------------------
+step "3. the roster carries the role the coordinator assigned"
+if retry_until 60 "[[ \"\$(roles_of '$A' '$B_HOST')\" == sentry ]]"; then
+  pass "srv-b is a sentry in the signed roster"
+else
+  fail "srv-b roles = '$(roles_of "$A" "$B_HOST")', expected sentry"
+fi
+if retry_until 60 "[[ \"\$(roles_of '$A' '$C_HOST')\" == sentry ]]"; then
+  pass "srv-c is a sentry in the signed roster"
+else
+  fail "srv-c roles = '$(roles_of "$A" "$C_HOST")', expected sentry"
+fi
+
+# ---------------------------------------------------------------------------
+step "4. the role peer resolved to BOTH sentries with no re-apply"
+# The suggestion published in step 1 named no members. Nothing has been applied
+# since; the rules appear because the roster changed underneath it.
+if retry_until 90 "[[ \"\$(sugg_tcp_allow '$A' 4000)\" -eq 2 ]]"; then
+  pass "role:sentry materialized one rule per sentry, no second apply"
+else
+  fail "expected 2 suggested tcp:4000 allows on srv-a (got $(sugg_tcp_allow "$A" 4000))"
+fi
+
+# ---------------------------------------------------------------------------
+step "5. the resolved allow actually opens the port over the TUN"
+A_VPN="$(peer_ip "$B" srv-a "$NET")"
+[[ -n "$A_VPN" ]] && pass "srv-b sees srv-a at $A_VPN" || { fail "srv-b cannot see srv-a"; summary; }
+start_tcp_listener "$A" 4000
+start_tcp_listener "$A" 8080   # not in the spec: default-deny covers it
+fw_allows "$B" "$A_VPN" 4000 "a sentry reaches the role-allowed tcp:4000"
+fw_denies "$B" "$A_VPN" 8080 "a sentry is still blocked on un-allowed tcp:8080"
+stop_tcp_listener "$A" 4000
+stop_tcp_listener "$A" 8080
+
+# ---------------------------------------------------------------------------
+step "6. asking for a role the key does not grant refuses the join"
+# srv-c leaves and comes back asking to be a validator on a sentry key.
+on "$C" "ray leave $NET" >/dev/null 2>&1 || true
+retry_until 30 "! has_net '$C' '$NET'" >/dev/null 2>&1 || true
+OUT="$(on "$C" "ray join $KEY --role validator" 2>&1 | strip)"
+echo "$OUT" | sed 's/^/   c| /'
+if has_net "$C" "$NET"; then
+  fail "a join asking for an ungranted role was admitted anyway"
+else
+  pass "join refused for a role the key does not grant"
+fi
+echo "$OUT" | grep -qi 'role' \
+  && pass "the refusal says it was about the role" || fail "refusal did not mention the role"
+
+# ---------------------------------------------------------------------------
+step "7. re-joining with the granted role works, and re-covers the rule"
+on "$C" "ray join $KEY --role sentry --auto-accept-firewall" 2>&1 | strip | sed 's/^/   c| /'
+if retry_until 90 "[[ \"\$(sugg_tcp_allow '$A' 4000)\" -eq 2 ]]"; then
+  pass "the returning sentry is covered again with no apply"
+else
+  fail "expected 2 suggested tcp:4000 allows after re-join (got $(sugg_tcp_allow "$A" 4000))"
+fi
+
+# ---------------------------------------------------------------------------
+summary

--- a/tests/encoding_properties.rs
+++ b/tests/encoding_properties.rs
@@ -165,7 +165,8 @@ fn control_msg_strategy() -> impl Strategy<Value = ControlMsg> {
     prop_oneof![
         Just(ControlMsg::MemberSync),
         Just(ControlMsg::JoinPending),
-        ".{0,40}".prop_map(|reason| ControlMsg::JoinDenied { reason }),
+        (".{0,40}", any::<bool>())
+            .prop_map(|(reason, retryable)| ControlMsg::JoinDenied { reason, retryable }),
         prop::collection::vec(any::<u8>(), 0..64)
             .prop_map(|packet| ControlMsg::SignedRecord { packet }),
         (

--- a/tests/encoding_properties.rs
+++ b/tests/encoding_properties.rs
@@ -176,6 +176,7 @@ fn control_msg_strategy() -> impl Strategy<Value = ControlMsg> {
                 invite_secret,
                 hostname,
                 device_cert: None,
+                roles: Default::default(),
             }),
     ]
 }

--- a/tests/membership_properties.rs
+++ b/tests/membership_properties.rs
@@ -37,6 +37,7 @@ fn member(identity: EndpointId) -> Member {
         last_seen: None,
         exit_node: false,
         exit_families: ExitFamilies::Unknown,
+        roles: Default::default(),
     }
 }
 


### PR DESCRIPTION
## Why

A `ray apply` firewall subject or peer is a hostname, and a hostname names one
machine. Covering a group of them means listing every member by hand:

```yaml
groups: {sentry: [sentry1, sentry2, sentry3]}
```

That list is expanded on the admin's machine at apply time, so a node that joins
later gets nothing until someone re-runs `ray apply`. For a fleet whose size
changes, the spec has to change with it.

## What

A subject or peer can now be a **role**:

```yaml
networks:
  hyperliquid:
    "role:validator":
      allows: {"role:sentry": "tcp:4000-4004"}
```

The role is assigned by the coordinator from the join code and resolved on each
node against the signed roster, so the spec stops changing when the fleet does.

```bash
ray invite hyperliquid create --reusable --role sentry --json
ray join <code> --auto-accept-firewall     # identical on every instance
```

`--role` is allowed on a reusable key where `--hostname` is not, and the
asymmetry is the point: a hostname is unique per node, a role is shared by a
class of them on purpose. That is what lets one code sit in a machine image or
in cloud-init user-data and cover an autoscaling group.

`ray join --role <name>` asks for a subset of what the code grants. Asking for
one it does not grant refuses the join rather than trimming it, so a rule keyed
on a role rests on nothing the joiner asserts. Rules keyed on a *hostname* do
not have that property: an invite that binds no hostname takes the joiner's
`--hostname` at face value.

Also here:

- `ray requests <net> accept <id> --role <name>` for live approvals, which have
  no code to read roles from.
- `ray status` shows the roles a peer holds.
- `--json` on `ray apply` and `ray invite`: the networks touched, role coverage,
  the hosts a spec expects that have not joined, and any codes minted for them.
  `changed` in the apply payload is what an Ansible `changed_when` wants.

## Breaking: mesh ALPN 5 -> 6

`Member` gains a `roles` field. Per `.claude/rules/wire-protocol.md` the roster
blob rides an unversioned ALPN, so a widened `Member` is not an additive change
and `MESH_PROTOCOL_VERSION` bumps in the same commit. An un-upgraded peer fails
ALPN negotiation cleanly instead of misdecoding the roster, so the network
splits visibly on upgrade rather than quietly.

## Fixes found on the way

All three are pre-existing and independent of roles.

- **A coordinator never re-resolved suggested rules when its own roster
  changed.** Members reconverge from the published record, but the coordinator
  *is* that record's source, so the poller's hash check short-circuits. A peer
  named in a rule before it joined was therefore never picked up there. This
  contradicted the documented lazy-materialization promise and affected
  hostname peers too, not only roles.
- **`ray apply --invite-missing` minted invites on the wrong network.** The
  expected-host diff was computed over the whole spec but reported once per
  network, so a host belonging to one network read as missing from every other.
- **The invite command apply printed could not be pasted.** It rendered
  `ray invite <net> --hostname <h>`; those flags belong to the `create`
  subcommand.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
  `cargo test --workspace`: clean, 886 tests.
- New `tests/e2e/roles` scenario, 3 hosts on the docker backend, 17 assertions.
  It covers the property the change exists for: two nodes join on one code, a
  third joins later, and the validator's rule set grows with no second apply.
  It also asserts the allow actually opens tcp:4000 over the TUN while an
  unlisted port stays shut, and that a join asking for an ungranted role is
  refused with a message naming the role.
- The pre-existing `apply` scenario still passes; its assertions were updated
  for the `create` fix above.

The e2e caught the coordinator bug: step 4 expected 2 rules and found 0.
