### PR TITLE
feat(cli): add `ray files reject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`ray files reject <id>`.** Turn down an incoming file offer instead of
+  leaving it sitting in the queue. The offer is dropped without being fetched;
+  the sender is not told, so it is the same as never picking it up. The
+  Android app has had a Reject button on the offer notification for a while,
+  and the CLI now matches it.
+
 - **Windows on ARM64.** Releases and nightlies now publish
   `ray-windows-aarch64.exe`, so Snapdragon and other ARM laptops get a native
   binary instead of running the x86_64 one under emulation. CI builds the

--- a/ray-proto/src/ipc.rs
+++ b/ray-proto/src/ipc.rs
@@ -262,6 +262,12 @@ pub enum IpcMessage {
         id: u64,
         output: Option<String>,
     },
+    /// Decline a pending inbound offer (`ray files reject <id>`). Local only:
+    /// the entry leaves the queue and nothing is sent to the sender, so their
+    /// offer is left unpulled exactly as if it had been ignored.
+    RejectFile {
+        id: u64,
+    },
     StartPairing,
     PairWithDevice {
         endpoint_id: EndpointId,

--- a/src/cli/complete.rs
+++ b/src/cli/complete.rs
@@ -193,7 +193,7 @@ pub(crate) fn invite_ids() -> ArgValueCompleter {
     })
 }
 
-/// Incoming transfers awaiting a decision, for `ray files accept <id>`.
+/// Incoming transfers awaiting a decision, for `ray files accept|reject <id>`.
 pub(crate) fn incoming_files() -> ArgValueCompleter {
     ArgValueCompleter::new(|current: &OsStr| {
         let (files, _) = file_queues();
@@ -1051,7 +1051,7 @@ mod tests {
     /// is not something the model records.
     #[test]
     fn every_id_read_off_a_listing_has_a_completer() {
-        let expected: [(&[&str], &str); 9] = [
+        let expected: [(&[&str], &str); 10] = [
             (&["requests", "accept"], "id"),
             (&["requests", "deny"], "id"),
             (&["accept"], "id"),
@@ -1059,6 +1059,7 @@ mod tests {
             (&["connect", "approve"], "id"),
             (&["invite", "revoke"], "id"),
             (&["files", "accept"], "id"),
+            (&["files", "reject"], "id"),
             (&["files", "cancel"], "id"),
             (&["firewall", "remove"], "index"),
         ];

--- a/src/cli/files.rs
+++ b/src/cli/files.rs
@@ -332,6 +332,18 @@ pub(crate) async fn ipc_files(action: Option<FilesAction>) -> Result<()> {
                 other => fail_unexpected(&other),
             }
         }
+        Some(FilesAction::Reject { id }) => {
+            // No spinner, unlike `Accept`: nothing is fetched, the daemon just
+            // drops the entry and answers.
+            ipc::send(&mut stream, ipc::IpcMessage::RejectFile { id }).await?;
+            match ipc::recv(&mut stream).await? {
+                ipc::IpcMessage::Ok { message } => {
+                    println!("  {} {}", style::check(), style::value(&message));
+                }
+                ipc::IpcMessage::Error { message } => fail_with("error", &message),
+                other => fail_unexpected(&other),
+            }
+        }
         Some(FilesAction::Cancel { id }) => {
             ipc::send(&mut stream, ipc::IpcMessage::CancelSend { id }).await?;
             match ipc::recv(&mut stream).await? {

--- a/src/daemon/file_service.rs
+++ b/src/daemon/file_service.rs
@@ -166,6 +166,14 @@ pub(crate) fn evict_oldest_file(pending: &mut Vec<PendingFile>, cap: usize) -> O
     Some(dropped.id)
 }
 
+/// Take the queued offer with `id` out of `pending`, if it is still there.
+/// Shared by accept and reject: both consume the entry, and neither may leave
+/// it behind for the other to act on a second time.
+pub(crate) fn take_pending(pending: &mut Vec<PendingFile>, id: u64) -> Option<PendingFile> {
+    let i = pending.iter().position(|f| f.id == id)?;
+    Some(pending.remove(i))
+}
+
 /// How long an open pairing session stays open.
 ///
 /// Nothing else closes it. A wrong secret deliberately does not (that was the bug
@@ -402,9 +410,8 @@ impl FileService {
         let _ = peer_cred;
         let pending_file = {
             let mut pending = self.pending_files.lock().unwrap();
-            let idx = pending.iter().position(|f| f.id == id);
-            match idx {
-                Some(i) => pending.remove(i),
+            match take_pending(&mut pending, id) {
+                Some(f) => f,
                 None => {
                     return ipc_err(format!("no pending file with id {id}"));
                 }
@@ -954,13 +961,10 @@ impl FileService {
     /// blob. In-memory only, mirroring how `accept_file` consumes the entry.
     pub(crate) fn reject_file(&self, id: u64) -> IpcMessage {
         let mut pending = self.pending_files.lock().unwrap();
-        match pending.iter().position(|f| f.id == id) {
-            Some(i) => {
-                pending.remove(i);
-                IpcMessage::Ok {
-                    message: format!("declined file {id}"),
-                }
-            }
+        match take_pending(&mut pending, id) {
+            Some(f) => IpcMessage::Ok {
+                message: format!("declined {} from {}", f.filename, f.from.fmt_short()),
+            },
             None => ipc_err(format!("no pending file with id {id}")),
         }
     }
@@ -1151,6 +1155,39 @@ mod tests {
     use super::*;
     use iroh_blobs::Hash;
     use std::time::Instant;
+
+    fn pending(id: u64) -> PendingFile {
+        PendingFile {
+            id,
+            from: SecretKey::from([id as u8; 32]).public(),
+            filename: format!("file{id}.bin"),
+            size: 1,
+            mime_type: "application/octet-stream".to_string(),
+            blob_hash: blake3::hash(b"payload"),
+        }
+    }
+
+    /// `ray files accept` and `ray files reject` both consume the offer, so a
+    /// second command on the same id must find nothing left to act on.
+    #[test]
+    fn taking_a_pending_offer_removes_only_that_one() {
+        let mut queue = vec![pending(1), pending(2), pending(3)];
+
+        let taken = take_pending(&mut queue, 2).expect("id 2 is queued");
+        assert_eq!(taken.id, 2);
+        assert_eq!(
+            queue.iter().map(|f| f.id).collect::<Vec<_>>(),
+            vec![1, 3],
+            "the other offers stay queued, in order"
+        );
+
+        assert!(
+            take_pending(&mut queue, 2).is_none(),
+            "an id already taken is gone, not taken twice"
+        );
+        assert!(take_pending(&mut queue, 99).is_none());
+        assert_eq!(queue.len(), 2, "a miss leaves the queue untouched");
+    }
 
     /// Pins the outbox persistence format: `EndpointId` and `blake3::Hash`
     /// must survive a JSON round trip (the file is reloaded across daemon

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1391,6 +1391,7 @@ impl Daemon {
             IpcMessage::AcceptFile { id, output } => {
                 self.files.accept_file(id, output, peer_cred).await
             }
+            IpcMessage::RejectFile { id } => self.files.reject_file(id),
             IpcMessage::StartPairing => self.start_pairing(),
             IpcMessage::PairWithDevice {
                 endpoint_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1065,6 +1065,15 @@ pub(crate) enum FilesAction {
         #[arg(long, short, value_hint = clap::ValueHint::DirPath)]
         output: Option<String>,
     },
+    /// Decline a pending file transfer
+    ///
+    /// Drops the offer from the queue without fetching it. The sender is not
+    /// told: their offer is simply never pulled.
+    Reject {
+        /// Transfer ID (from 'ray files')
+        #[arg(add = complete::incoming_files())]
+        id: u64,
+    },
     /// Cancel a queued send that hasn't reached its peer yet
     Cancel {
         /// Queued-send ID (from 'ray files')


### PR DESCRIPTION
An incoming file offer could be accepted or ignored, and nothing else. The
Android app has had a Reject action on the offer notification for a while;
this gives the CLI the same thing.

```
$ ray files
  id  from      size    file
  4   a1b2c3d4  2.1 MB  holiday.zip   ray files accept 4

$ ray files reject 4
  ✓ declined holiday.zip from a1b2c3d4
```

The daemon side already existed: `FileService::reject_file` was there for
the `ray-mobile` FFI. What is new is the `RejectFile` IPC variant, the
daemon arm, and the subcommand. IPC is one of the two `to_vec_named`
callers, so the added variant needs no ALPN bump.

Rejecting is local. The entry leaves the pending queue and nothing goes to
the sender, so their outbox entry stays `Offered` and their send tag holds
the blob, exactly as when an offer is never picked up. Telling the sender
would be a new message on `FILES_ALPN` and a version bump, which is worth
doing on its own if it is worth doing.

`accept_file` and `reject_file` both looked the offer up by index and
removed it, so that moves into `take_pending`, which is testable without
standing up a `FileService`.

Authorization is unchanged: `RejectFile` is not in the read allowlist in
`check_authorized`, so it needs root or the operator uid, like accept.

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and
`cargo test -p rayfish -p ray-proto` (853 passed) are clean.
